### PR TITLE
Looks like a small typo in one of the register address offsets.

### DIFF
--- a/src/intel.lua
+++ b/src/intel.lua
@@ -91,7 +91,7 @@ function new (pciaddress)
    local MDIC   = 0x00020 / 4 -- MDI Control Register (RW)
    local EXTCNF_CTRL = 0x00F00 / 4 -- Extended Configuration Control (RW)
    local POEMB  = 0x00F10 / 4 -- PHY OEM Bits Register (RW)
-   local ICR    = 0x00C00 / 4 -- Interrupt Cause Register (RW)
+   local ICR    = 0x000C0 / 4 -- Interrupt Cause Register (RW)
 
    local regs = ffi.cast("uint32_t *", pci.map_pci_memory(pciaddress, 0))
 


### PR DESCRIPTION
I know it's not used now, but maybe this will save someone a headache down the road.
