### PR TITLE
Disable interrupts by writing 1's to IMC instead of 0's

### DIFF
--- a/src/intel.lua
+++ b/src/intel.lua
@@ -109,10 +109,10 @@ function new (pciaddress)
    end
 
    function reset ()
-      regs[IMC] = 0                       -- Disable interrupts
+      regs[IMC] = 0xffffffff                 -- Disable interrupts
       regs[CTRL] = bits({FD=0,SLU=6,RST=26}) -- Global reset
       C.usleep(10); assert( not bitset(regs[CTRL],26) )
-      regs[IMC] = 0                       -- Disable interrupts
+      regs[IMC] = 0xffffffff                 -- Disable interrupts
    end
 
    function init_pci ()


### PR DESCRIPTION
Luke,

I'm still getting the hang of github, so I'm not sure how this pull will come across. The only thing I am trying to send over is a small change on the way interrupts are disabled in `intel.reset`. If I read the documentation correctly, I think we need to set all 1's to the IMC register instead of all 0's.

Can you let me know how this pull request comes over? Although 4 commits are bundled in the pull request, two of them cancel each other (one is a revert), and one is me merging your master to my master (which I'm just trying to track yours - I do my work on my development branch). 

Thanks,
Pete
