### PR TITLE
Disable interrupts before and after reset.

### DIFF
--- a/src/intel.lua
+++ b/src/intel.lua
@@ -109,10 +109,10 @@ function new (pciaddress)
    end
 
    function reset ()
-      regs[IMC] = 0                       -- Disable interrupts
+      regs[IMC] = 0xffffffff                 -- Disable interrupts
       regs[CTRL] = bits({FD=0,SLU=6,RST=26}) -- Global reset
       C.usleep(10); assert( not bitset(regs[CTRL],26) )
-      regs[IMC] = 0                       -- Disable interrupts
+      regs[IMC] = 0xffffffff                 -- Disable interrupts
    end
 
    function init_pci ()


### PR DESCRIPTION
Hi Luke,

I think this pull request is better. It has only the small change I was intending, which may or may not be right, but based on what I read in the documentation, it looks like we are supposed to set IMC to 1's to disable all interrupts. Am I interpreting this correctly? 

Pete
