### PR TITLE
Fixed crash in selftest when multiple PCI devices are available

### DIFF
--- a/src/intel.lua
+++ b/src/intel.lua
@@ -20,6 +20,62 @@ local bits, bitset = lib.bits, lib.bitset
 require("clib_h")
 require("snabb_h")
 
+-- FFI definitions for receive and transmit descriptors
+
+ffi.cdef[[
+         // RX descriptor written by software.
+         struct rx_desc {
+            uint64_t address;    // 64-bit address of receive buffer
+            uint64_t dd;         // low bit must be 0, otherwise reserved
+         } __attribute__((packed));
+
+         // RX writeback descriptor written by hardware.
+         struct rx_desc_wb {
+            // uint32_t rss;
+            uint16_t checksum;
+            uint16_t id;
+            uint32_t mrq;
+            uint32_t status;
+            uint16_t length;
+            uint16_t vlan;
+         } __attribute__((packed));
+
+         union rx {
+            struct rx_desc data;
+            struct rx_desc_wb wb;
+         } __attribute__((packed));
+   ]]
+
+ffi.cdef[[
+         // TX Extended Data Descriptor written by software.
+         struct tx_desc {
+            uint64_t address;
+            uint64_t options;
+         } __attribute__((packed));
+
+         struct tx_context_desc {
+            unsigned int tucse:16,
+                         tucso:8,
+                         tucss:8,
+                         ipcse:16,
+                         ipcso:8,
+                         ipcss:8,
+                         mss:16,
+                         hdrlen:8,
+                         rsv:2,
+                         sta:4,
+                         tucmd:8,
+                         dtype:4,
+                         paylen:20;
+         } __attribute__((packed));
+
+         union tx {
+            struct tx_desc data;
+            struct tx_context_desc ctx;
+         };
+   ]]
+
+
 function new (pciaddress)
 
    -- Method dictionary for Intel NIC objects.
@@ -207,30 +263,6 @@ function new (pciaddress)
 
    -- Receive functionality
 
-   ffi.cdef[[
-         // RX descriptor written by software.
-         struct rx_desc {
-            uint64_t address;    // 64-bit address of receive buffer
-            uint64_t dd;         // low bit must be 0, otherwise reserved
-         } __attribute__((packed));
-
-         // RX writeback descriptor written by hardware.
-         struct rx_desc_wb {
-            // uint32_t rss;
-            uint16_t checksum;
-            uint16_t id;
-            uint32_t mrq;
-            uint32_t status;
-            uint16_t length;
-            uint16_t vlan;
-         } __attribute__((packed));
-
-         union rx {
-            struct rx_desc data;
-            struct rx_desc_wb wb;
-         } __attribute__((packed));
-   ]]
-
    local rxnext = 0
    local rxbuffers = {}
 
@@ -314,35 +346,6 @@ function new (pciaddress)
    end
 
    -- Transmit functionality
-
-   ffi.cdef[[
-         // TX Extended Data Descriptor written by software.
-         struct tx_desc {
-            uint64_t address;
-            uint64_t options;
-         } __attribute__((packed));
-
-         struct tx_context_desc {
-            unsigned int tucse:16,
-                         tucso:8,
-                         tucss:8,
-                         ipcse:16,
-                         ipcso:8,
-                         ipcss:8,
-                         mss:16,
-                         hdrlen:8,
-                         rsv:2,
-                         sta:4,
-                         tucmd:8,
-                         dtype:4,
-                         paylen:20;
-         } __attribute__((packed));
-
-         union tx {
-            struct tx_desc data;
-            struct tx_context_desc ctx;
-         };
-   ]]
 
    function init_transmit ()
       regs[TCTL]        = 0x3103f0f8


### PR DESCRIPTION
The selftest executes for each suitable PCI device found. As part of
the test, an instance of the intel NIC is instantiated, which caused
the FFI cdefs to be executed more than once resulting in a crash due
to the attempt to redefine the cdefs.

I simply moved the cdef definitions outside of the `new` constructor method. Now I no longer get a crash when the selftest attempts to run on both ports of my NIC. Here is a successful run showing the selftest running:

```
root@world:/home/kaz# ./snabbswitch                                                                                                              
selftest: memory
Kernel HugeTLB pages (/proc/sys/vm/nr_hugepages): 12
  Allocating a 2MB HugeTLB: Got 2MB at 0x58c00000
  Allocating a 2MB HugeTLB: Got 2MB at 0x51e00000
  Allocating a 2MB HugeTLB: Got 2MB at 0x5c200000
  Allocating a 2MB HugeTLB: Got 2MB at 0x5f800000
Kernel HugeTLB pages (/proc/sys/vm/nr_hugepages): 12
HugeTLB page allocation OK.
selftest: pci
Scanning PCI devices:
pciaddr         vendor  device  iface   status
0000:00:00.0    0x8086  0x2e30  -       -
0000:00:01.0    0x8086  0x2e31  -       -
0000:00:02.0    0x8086  0x2e32  -       -
0000:00:1b.0    0x8086  0x27d8  -       -
0000:00:1c.0    0x8086  0x27d0  -       -
0000:00:1c.1    0x8086  0x27d2  -       -
0000:00:1d.0    0x8086  0x27c8  -       -
0000:00:1d.1    0x8086  0x27c9  -       -
0000:00:1d.3    0x8086  0x27cb  -       -
0000:00:1d.7    0x8086  0x27cc  -       -
0000:00:1e.0    0x8086  0x244e  -       -
0000:00:1f.0    0x8086  0x27b8  -       -
0000:00:1f.2    0x8086  0x27c0  -       -
0000:00:1f.3    0x8086  0x27da  -       -
0000:01:00.0    0x8086  0x105e  -       -
0000:01:00.1    0x8086  0x105e  -       -
0000:02:00.0    0x10ec  0x8168  eth0    up
0000:03:00.0    0x10ec  0x8168  eth1    up
Suitable devices: 
  0000:01:00.0
  0000:01:00.1selftest: intel device 0000:01:00.0
NIC transmit test
intel selftest: pciaddr=0000:01:00.0 secs=1
Waiting for linkup............. ok
Generating traffic for 1 second(s)...
Statistics for PCI device 0000:01:00.0:
                   9 PRC64      Packets Received [64 Bytes] Count
                   1 PRC255     Packets Received [128-255 Bytes] Count
                   9 PRC511     Packets Received [256-511 Bytes] Count
                   1 PRC1023    Packets Received [512-1023 Bytes] Count
                   2 PRC1522    Packets Received [1024 to Max Bytes] Count
                  22 GPRC       Good Packets Received Count
                  10 BPRC       Broadcast Packets Received Count
                  12 MPRC       Multicast Packets Received Count
           1,530,140 GPTC       Good Packets Transmitted Count
               7,320 GORCL      Good Octets Received Count
          97,929,344 GOTCL      Good Octets Transmitted Count
                  22 RNBC       Receive No Buffers Count
               7,320 TORL       Total Octets Received (Low)
          97,930,560 TOTL       Total Octets Transmitted (Low)
                  22 TPR        Total Packets Received
           1,530,168 TPT        Total Packets Transmitted
           1,530,168 PTC64      Packets Transmitted [64 Bytes] Count
NIC transmit+receive loopback test
intel selftest: pciaddr=0000:01:00.0 secs=1 receive=true loopback=true
Waiting for linkup.............. ok
Generating traffic for 1 second(s)...
Statistics for PCI device 0000:01:00.0:
             724,995 MPC        Missed Packets Count
             800,612 PRC64      Packets Received [64 Bytes] Count
             800,621 GPRC       Good Packets Received Count
           1,525,621 GPTC       Good Packets Transmitted Count
          51,240,128 GORCL      Good Octets Received Count
          97,640,000 GOTCL      Good Octets Transmitted Count
              22,839 RNBC       Receive No Buffers Count
          97,640,960 TORL       Total Octets Received (Low)
          97,641,216 TOTL       Total Octets Transmitted (Low)
           1,525,644 TPR        Total Packets Received
           1,525,646 TPT        Total Packets Transmitted
           1,525,648 PTC64      Packets Transmitted [64 Bytes] Count
selftest: intel device 0000:01:00.1
NIC transmit test
intel selftest: pciaddr=0000:01:00.1 secs=1
Waiting for linkup............. ok
Generating traffic for 1 second(s)...
Statistics for PCI device 0000:01:00.1:
                   4 PRC64      Packets Received [64 Bytes] Count
                   1 PRC127     Packets Received [65-127 Bytes] Count
                   1 PRC255     Packets Received [128-255 Bytes] Count
                   9 PRC511     Packets Received [256-511 Bytes] Count
                   2 PRC1522    Packets Received [1024 to Max Bytes] Count
                  17 GPRC       Good Packets Received Count
                   6 BPRC       Broadcast Packets Received Count
                  11 MPRC       Multicast Packets Received Count
           1,530,430 GPTC       Good Packets Transmitted Count
               6,488 GORCL      Good Octets Received Count
          97,947,776 GOTCL      Good Octets Transmitted Count
                  17 RNBC       Receive No Buffers Count
               6,488 TORL       Total Octets Received (Low)
          97,949,120 TOTL       Total Octets Transmitted (Low)
                  17 TPR        Total Packets Received
           1,530,458 TPT        Total Packets Transmitted
           1,530,460 PTC64      Packets Transmitted [64 Bytes] Count
NIC transmit+receive loopback test
intel selftest: pciaddr=0000:01:00.1 secs=1 receive=true loopback=true
Waiting for linkup.............. ok
Generating traffic for 1 second(s)...
Statistics for PCI device 0000:01:00.1:
             725,656 MPC        Missed Packets Count
             800,424 PRC64      Packets Received [64 Bytes] Count
             800,434 GPRC       Good Packets Received Count
           1,526,095 GPTC       Good Packets Transmitted Count
          51,228,160 GORCL      Good Octets Received Count
          97,670,400 GOTCL      Good Octets Transmitted Count
              22,839 RNBC       Receive No Buffers Count
          97,671,424 TORL       Total Octets Received (Low)
          97,671,680 TOTL       Total Octets Transmitted (Low)
           1,526,121 TPR        Total Packets Received
           1,526,123 TPT        Total Packets Transmitted
           1,526,125 PTC64      Packets Transmitted [64 Bytes] Count
root@world:/home/kaz# 
```
