### PR TITLE
Ignore dirty submodules so they don't pollute the output of git status

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,8 @@
 [submodule "deps/luajit"]
 	path = deps/luajit
 	url = http://luajit.org/git/luajit-2.0.git
+        ignore = dirty
 [submodule "deps/luafilesystem"]
 	path = deps/luafilesystem
 	url = https://github.com/keplerproject/luafilesystem.git
+        ignore = dirty


### PR DESCRIPTION
I don't know about you guys, but this has been driving me bonkers. Does this affect you as well, or is it just me? I found the following resolves the behavior. Pete.
## 

The `ignore = dirty` option tells git to disregard any local changes
to the submodule directories. In the case of snabbswitch, the luajit
depenency is installed in the submodule directory itself, which yields
the following `git status` output:

```
kaz@monad:~/src/snabbswitch$ git status
# On branch ignore-dirty-submodules
# Changes not staged for commit:
#   (use "git add <file>..." to update what will be committed)
#   (use "git checkout -- <file>..." to discard changes in working directory)
#   (commit or discard the untracked or modified content in submodules)
#
#       modified:   deps/luajit (untracked content)
#
no changes added to commit (use "git add" and/or "git commit -a")
```
