### PR TITLE
Fixed the dropped packet issue, head and tail were reversed in rx_pending()

### DIFF
--- a/src/intel.lua
+++ b/src/intel.lua
@@ -319,7 +319,7 @@ function new (pciaddress)
    end
 
    local function rx_pending ()
-      return ring_pending(regs[RDT], regs[RDH])
+      return ring_pending(regs[RDH], regs[RDT])
    end M.rx_pending = rx_pending
 
    local function rx_available ()


### PR DESCRIPTION
Check out the receive statistics below ...

```
NIC transmit+receive loopback test
intel selftest: pciaddr=0000:01:00.0 secs=1 receive=true loopback=true
Waiting for linkup............ ok
Generating traffic for 1 second(s)...
Statistics for PCI device 0000:01:00.0:
           1,526,023 PRC64      Packets Received [64 Bytes] Count
           1,526,030 GPRC       Good Packets Received Count
           1,526,035 GPTC       Good Packets Transmitted Count
          97,666,368 GORCL      Good Octets Received Count
          97,666,560 GOTCL      Good Octets Transmitted Count
          97,667,584 TORL       Total Octets Received (Low)
          97,667,776 TOTL       Total Octets Transmitted (Low)
           1,526,060 TPR        Total Packets Received
           1,526,062 TPT        Total Packets Transmitted
           1,526,064 PTC64      Packets Transmitted [64 Bytes] Count
```
