### PR TITLE
Added Intel 82571 support to Snabb Switch

### DIFF
--- a/src/pci.lua
+++ b/src/pci.lua
@@ -19,7 +19,8 @@ function suitable_devices ()
 end
 
 function is_suitable (info)
-   return info.vendor == "0x8086" and info.device == "0x10d3" and
+   return info.vendor == "0x8086" and 
+      (info.device == "0x10d3" or info.device == "0x105e") and
       (info.interface == nil or info.status == 'down')
 end
 


### PR DESCRIPTION
Luke,

Here is the low-tech integration using if statements. Let me know if it looks okay or if you want changes. I tested the same codebase on both sets of hardware successfully.

Thanks,
Pete

Here are the key changes required:
- PCI device ID: I had to change so a suitable device would be found.
- PHY reads/writes: PHY reads and writes are synchronized by using the
  PHY locking functions.
- PHY reset procedure: The procedure to reset the 82571 card is
  vastly different than the 82574 due to the synchronization issues
  associated with the multi-port card.
- PHY status differences: The 82571 PHY status register varies
  slightly from the 82574. For example, the copper link status is not
  available in bit 3 like it is on the 82574. This resulted in a
  couple of changes in the way stats are printed.
- PHY locking code: The 82571 uses different registers to obtain a
  PHY lock from firmware. In addition, I had to implement software
  locking (SWSM.SMBI) to synchronize access between drivers. Recall
  that this is a multi-port card, so it is possible that one port
  could be bound to snabbswitch and the other bound to the OS. The
  locking methods take an options parameter that allows one to
  request the type of lock desired (software, firmware, or both). By
  default, both locks are acquired and released. However, during the
  PHY reset process, there were steps that had to be executed in
  between the acquisition of software and firmware locks, which is
  why I refactored the code in this manner.
