### PR TITLE
(intel10g): Restore adapter configuration state after selftest.

### DIFF
--- a/src/intel10g.lua
+++ b/src/intel10g.lua
@@ -75,6 +75,15 @@ end
 
 function linkup () return bitset(r.LINKS(), 30) end
 
+function get_configuration_state ()
+   return { AUTOC = r.AUTOC(), HLREG0 = r.HLREG0() }
+end
+
+function restore_configuration_state (saved_state)
+   r.AUTOC(saved_state.AUTOC)
+   r.HLREG0(saved_state.HLREG0)
+end
+
 function enable_mac_loopback ()
    r.AUTOC:set(bits({ForceLinkUp=0, LMS10G=13}))
    r.HLREG0:set(bits({Loop=15}))
@@ -209,6 +218,7 @@ end
 function selftest ()
    print("intel10g")
    open()
+   local saved_state = get_configuration_state()
    enable_mac_loopback()
    test.waitfor("linkup", linkup, 20, 250000)
    local finished = lib.timer(1e9)
@@ -220,6 +230,7 @@ function selftest ()
       sync()
 --      C.usleep(1)
    until finished()
+   restore_configuration_state(saved_state)
    assert(buffers[40960]==99)
    C.usleep(1000)
    print "stats"


### PR DESCRIPTION
Before putting the interface into loopback mode for a selftest, save the parts of the configuration that we modify, and restore them after the test.

How this is done: We simply record the full AUTOC (link autoconfiguration) and HLREG0 (MAC core control 0) register contents and restore them to their original values in the end.

This notably reverts to the previous loopback mode setting (typically "no loopback"), and makes it easy to put a port into normal operation after a selftest.  Note that the Linux ixgbe driver doesn't clear loopback mode when it brings up an interface.
