### PR TITLE
Tweaked the PDF output a bit ...

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -50,7 +50,7 @@ obj/jit_vmprof.o: extra/vmprof.c
 	gcc -Wl,-E -O2 -I ../deps/luajit/src -c -Wall -Werror -o $@ $<
 
 $(MDOBJS): doc/obj/%.md : %
-	sed -E -e 's/^/    /g' -e 's/^    --- ?//g' < $< > $@
+	awk '/^ *[^-]{3}/ {if (last~/^ *---/) printf("\n")} {print} {last=$$0}' < $< | sed -E -e 's/^/    /g' -e 's/^    --- ?//g' > $@
 
 book: doc/snabbswitch.pdf doc/snabbswitch.html doc/snabbswitch.epub
 
@@ -58,7 +58,7 @@ doc/snabbswitch.md: $(MDOBJS)
 	(cd doc; ./genbook.sh) > $@
 
 doc/snabbswitch.pdf: doc/snabbswitch.md
-	pandoc -V documentclass:book -S --toc --chapters -o $@ $<
+	pandoc --template=doc/template.latex --latex-engine=lualatex -V fontsize=10pt -V monofont=inconsolata -V monoscale=.80 -V verbatimspacing=.85 -V mainfont=droidsans -V sansfont=droidsans -V documentclass:book -V geometry:margin=1.5in -S --toc --chapters  -o $@ $<
 
 doc/snabbswitch.html doc/snabbswitch.epub: doc/snabbswitch.md
 	pandoc -S --toc --chapters -o $@ $<

--- a/src/doc/template.latex
+++ b/src/doc/template.latex
@@ -1,0 +1,188 @@
+\documentclass[$if(fontsize)$$fontsize$,$endif$$if(lang)$$lang$,$endif$]{$documentclass$}
+\usepackage[T1]{fontenc}
+\usepackage{lmodern}
+% Smaller spacing with bullets
+\usepackage{enumitem}
+\setlist{nolistsep}
+$if(verbatimspacing)$
+% Smaller line spacing with verbatim code listings
+\usepackage{setspace}
+\usepackage{etoolbox}
+\preto{\verbatim}{\edef\tempstretch{\baselinestretch}\par\setstretch{$verbatimspacing$}}
+\appto{\endverbatim}{\vspace{-\tempstretch\baselineskip}\vspace{\baselineskip}}
+$endif$
+\usepackage{amssymb,amsmath}
+\usepackage{ifxetex,ifluatex}
+\usepackage{fixltx2e} % provides \textsubscript
+% use microtype if available
+\IfFileExists{microtype.sty}{\usepackage{microtype}}{}
+\ifnum 0\ifxetex 1\fi\ifluatex 1\fi=0 % if pdftex
+  \usepackage[utf8]{inputenc}
+$if(euro)$
+  \usepackage{eurosym}
+$endif$
+\else % if luatex or xelatex
+  \usepackage{fontspec}
+  \ifxetex
+    \usepackage{xltxtra,xunicode}
+  \fi
+  \defaultfontfeatures{Mapping=tex-text,Scale=MatchLowercase}
+  \newcommand{\euro}{€}
+$if(mainfont)$
+    \setmainfont{$mainfont$}
+$endif$
+$if(sansfont)$
+    \setsansfont{$sansfont$}
+$endif$
+$if(monofont)$
+    $if(monoscale)$
+    \setmonofont[Scale=$monoscale$]{$monofont$}
+    $else$
+    \setmonofont{$monofont$}
+    $endif$
+$endif$
+$if(mathfont)$
+    \setmathfont{$mathfont$}
+$endif$
+\fi
+$if(geometry)$
+\usepackage[$for(geometry)$$geometry$$sep$,$endfor$]{geometry}
+$endif$
+$if(natbib)$
+\usepackage{natbib}
+\bibliographystyle{plainnat}
+$endif$
+$if(biblatex)$
+\usepackage{biblatex}
+$if(biblio-files)$
+\bibliography{$biblio-files$}
+$endif$
+$endif$
+$if(listings)$
+\usepackage{listings}
+$endif$
+$if(lhs)$
+\lstnewenvironment{code}{\lstset{language=Haskell,basicstyle=\small\ttfamily}}{}
+$endif$
+$if(highlighting-macros)$
+$highlighting-macros$
+$endif$
+$if(verbatim-in-note)$
+\usepackage{fancyvrb}
+$endif$
+$if(fancy-enums)$
+% Redefine labelwidth for lists; otherwise, the enumerate package will cause
+% markers to extend beyond the left margin.
+\makeatletter\AtBeginDocument{%
+  \renewcommand{\@listi}
+    {\setlength{\labelwidth}{4em}}
+}\makeatother
+\usepackage{enumerate}
+$endif$
+$if(tables)$
+\usepackage{ctable}
+\usepackage{float} % provides the H option for float placement
+$endif$
+$if(graphics)$
+\usepackage{graphicx}
+% We will generate all images so they have a width \maxwidth. This means
+% that they will get their normal width if they fit onto the page, but
+% are scaled down if they would overflow the margins.
+\makeatletter
+\def\maxwidth{\ifdim\Gin@nat@width>\linewidth\linewidth
+\else\Gin@nat@width\fi}
+\makeatother
+\let\Oldincludegraphics\includegraphics
+\renewcommand{\includegraphics}[1]{\Oldincludegraphics[width=\maxwidth]{#1}}
+$endif$
+\ifxetex
+  \usepackage[setpagesize=false, % page size defined by xetex
+              unicode=false, % unicode breaks when used with xetex
+              xetex]{hyperref}
+\else
+  \usepackage[unicode=true]{hyperref}
+\fi
+\hypersetup{breaklinks=true,
+            bookmarks=true,
+            pdfauthor={$author-meta$},
+            pdftitle={$title-meta$},
+            colorlinks=true,
+            urlcolor=$if(urlcolor)$$urlcolor$$else$blue$endif$,
+            linkcolor=$if(linkcolor)$$linkcolor$$else$magenta$endif$,
+            pdfborder={0 0 0}}
+$if(links-as-notes)$
+% Make links footnotes instead of hotlinks:
+\renewcommand{\href}[2]{#2\footnote{\url{#1}}}
+$endif$
+$if(strikeout)$
+\usepackage[normalem]{ulem}
+% avoid problems with \sout in headers with hyperref:
+\pdfstringdefDisableCommands{\renewcommand{\sout}{}}
+$endif$
+\setlength{\parindent}{0pt}
+\setlength{\parskip}{6pt plus 2pt minus 1pt}
+\setlength{\emergencystretch}{3em}  % prevent overfull lines
+$if(numbersections)$
+$else$
+\setcounter{secnumdepth}{0}
+$endif$
+$if(verbatim-in-note)$
+\VerbatimFootnotes % allows verbatim text in footnotes
+$endif$
+$if(lang)$
+\ifxetex
+  \usepackage{polyglossia}
+  \setmainlanguage{$mainlang$}
+\else
+  \usepackage[$lang$]{babel}
+\fi
+$endif$
+$for(header-includes)$
+$header-includes$
+$endfor$
+
+$if(title)$
+\title{$title$}
+$endif$
+\author{$for(author)$$author$$sep$ \and $endfor$}
+\date{$date$}
+
+\begin{document}
+$if(title)$
+\maketitle
+$endif$
+
+$for(include-before)$
+$include-before$
+
+$endfor$
+$if(toc)$
+{
+\hypersetup{linkcolor=black}
+\tableofcontents
+}
+$endif$
+$body$
+
+$if(natbib)$
+$if(biblio-files)$
+$if(biblio-title)$
+$if(book-class)$
+\renewcommand\bibname{$biblio-title$}
+$else$
+\renewcommand\refname{$biblio-title$}
+$endif$
+$endif$
+\bibliography{$biblio-files$}
+
+$endif$
+$endif$
+$if(biblatex)$
+\printbibliography$if(biblio-title)$[title=$biblio-title$]$endif$
+
+$endif$
+$for(include-after)$
+$include-after$
+
+$endfor$
+\end{document}


### PR DESCRIPTION
Give this a try Luke. I changed the latex rendering engine that pandoc uses to lualatex which allows you to change the fonts. In addition, to fix some of the other stuff, I use three other latex packages: enumitem, setspace, and etoolbox. I think the full texlive distribution included these as I didn't have to do anything in terms of installing anything. I'm also trying to get colored code listings to work as the docs suggest pandoc supports them, but it's still generating the blocks using the verbatim environment instead of the listing environment. I'll keep playing around though. 

Pete

---
- Changed the fonts (Inconsolata for mono, Droid sans for main)
- Scaled down the code listing font and line spacing to be more proportionate with main text
- Ditched extra spacing in bulleted lists
- Tweaked the margins a bit
- Fixed the merging of code with the prior comment if there was no newline
  separating (see the register object section of Luke's original PDF)

Here is a sample:
http://www.kazmier.com/~kaz/snabbswitch.pdf

I created a separate Latex template for use with pandoc that I imagine a Latex
expert could make even better. I also parameterized the scaling of the
monospace font as well as the line spacing used within code listings.
