### PR TITLE
More PDF enhancements

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -58,7 +58,7 @@ doc/snabbswitch.md: $(MDOBJS)
 	(cd doc; ./genbook.sh) > $@
 
 doc/snabbswitch.pdf: doc/snabbswitch.md
-	pandoc --template=doc/template.latex --latex-engine=lualatex -V fontsize=10pt -V monofont=droidsansmono -V monoscale=.70 -V verbatimspacing=.85 -V mainfont=droidserif -V sansfont=droidsans -V documentclass:book -V geometry:margin=1.5in -S --toc --chapters  -o $@ $<
+	pandoc --template=doc/template.latex --latex-engine=lualatex -V fontsize=10pt -V monofont=droidsansmono -V monoscale=.70 -V verbatimspacing=.85 -V mainfont=droidserif -V sansfont=droidsans -V documentclass:book -V geometry:top=1.0in -V geometry:bottom=0.75in -S --toc --chapters  -o $@ $<
 
 doc/snabbswitch.html doc/snabbswitch.epub: doc/snabbswitch.md
 	pandoc -S --toc --chapters -o $@ $<

--- a/src/doc/template.latex
+++ b/src/doc/template.latex
@@ -1,4 +1,4 @@
-\documentclass[$if(fontsize)$$fontsize$,$endif$$if(lang)$$lang$,$endif$]{$documentclass$}
+\documentclass[oneside,$if(fontsize)$$fontsize$,$endif$$if(lang)$$lang$,$endif$]{$documentclass$}
 \usepackage[T1]{fontenc}
 \usepackage{lmodern}
 % Use sans for sections, serif for main
@@ -7,8 +7,25 @@
 % Nicer chapter headings
 \usepackage{titlesec,color}
 \definecolor{gray75}{gray}{0.75}
+\definecolor{gray30}{gray}{0.30}
 \newcommand{\hsp}{\hspace{20pt}}
-\titleformat{\chapter}[hang]{\Huge\sffamily}{\thechapter\hsp\textcolor{gray75}{|}\hsp}{0pt}{\Huge\sffamily}
+\titleformat{\chapter}[hang]{\Huge\sffamily}{\textcolor{gray30}{\thechapter}\hsp\textcolor{gray75}{|}\hsp}{0pt}{\Huge\sffamily\textcolor{gray30}}
+% Make nice title
+\usepackage{titling}
+\renewcommand{\maketitlehooka}{\sffamily}
+\pretitle{\begin{center}\Huge}
+\posttitle{\par\end{center}\vskip 0.5em}
+% Make nicer headers
+\usepackage{fancyhdr}
+\pagestyle{fancy}
+\renewcommand{\chaptermark}[1]{\markboth{#1}{}}
+\renewcommand{\headrulewidth}{0pt}
+\renewcommand{\footrulewidth}{0pt}
+\lhead{\nouppercase{\textcolor{gray30}{\leftmark}\ {\bfseries\textcolor{gray75}|} \textcolor{gray30}\rightmark}}
+\rhead{\nouppercase{\textcolor{gray30}\thepage}}
+\cfoot{}
+\fancypagestyle{plain}{\fancyhf{}}
+\fancyheadoffset[R]{0.0in}
 % Smaller spacing with bullets
 \usepackage{enumitem}
 \setlist{nolistsep}
@@ -167,7 +184,9 @@ $endfor$
 $if(toc)$
 {
 \hypersetup{linkcolor=black}
+\pagestyle{plain}
 \tableofcontents
+\cleardoublepage
 }
 $endif$
 $body$


### PR DESCRIPTION
Modernized the look and feel of the standard LaTex chapter titles and headers. Also tweaked the fonts a bit as I couldn't live without a serifed body font. Right now I'm using droid serif, sans, and sans mono for consistency. Yes, these fonts are designed for on-screen reading, but that's where I do most of my PDF reading anyways (plus it seems that most people will have those fonts on their linux boxes as I don't recall installing them).

Next up: margin notes for any markdown footnotes, which might be cool.
