### PR TITLE
Register changes

### DIFF
--- a/src/register.lua
+++ b/src/register.lua
@@ -62,12 +62,12 @@ end
 --- Metatables for the three different types of register
 local mt = {
   RO = {__index = { read=Register.read, wait=Register.wait, reset=Register.noop},
-       __call = Register.read, __tostring = Register.__tostring},
+        __call = Register.read, __tostring = Register.__tostring},
   RW = {__index = { read=Register.read, write=Register.write, wait=Register.wait,
                     set=Register.set, clr=Register.clr, reset=Register.noop},
-       __call = Register.__call, __tostring = Register.__tostring},
+        __call = Register.__call, __tostring = Register.__tostring},
   RC = {__index = { read=Register.readrc, reset=Register.reset},
-       __call = Register.readrc, __tostring = Register.__tostring},
+        __call = Register.readrc, __tostring = Register.__tostring},
 }
 
 --- Create a register `offset` bytes from `base_ptr`.


### PR DESCRIPTION
The current version creates a new metatable for every register, which is somewhat wasteful, so cleaned these up to share metatables, plus remove the runtime checks for register type in favour of different metatables with appropriate methods.

I am somewhat inclined to make registers into ffi metatypes not Lua tables, as then they would be jitted to straight memory accesses, and basically just be pointers with methods. The names would then need to move to the register collection rather than each register.
