### PR TITLE
Added per-app LuaJIT trace dumping [draft]

### DIFF
--- a/src/core/lib.lua
+++ b/src/core/lib.lua
@@ -196,6 +196,14 @@ function malloc (type)
    return ffi.cast(ffi.typeof("$*", ffi_type), ptr)
 end
 
+-- Function that should always trigger a LuaJIT "NYI".
+-- 
+-- That is: no JIT trace should be able to span across a call to
+-- trace_barrier().
+function trace_barrier (...)
+   return {...}
+end
+
 function selftest ()
    print("selftest: lib")
    local data = "\x45\x00\x00\x73\x00\x00\x40\x00\x40\x11\xc0\xa8\x00\x01\xc0\xa8\x00\xc7"


### PR DESCRIPTION
I added experimental support for outputting a separate LuaJIT JIT-trace dump file for each app, and making sure that JIT-traces never span across multiple apps. The idea is to make it easier to optimize apps by giving the programmer a LuaJIT dump (byte code, intermediate representation, machine code) for their own code only (+ libraries they call).
