### PR TITLE
do not hardcode pci devices

### DIFF
--- a/src/apps/intel/intel_app.lua
+++ b/src/apps/intel/intel_app.lua
@@ -142,10 +142,10 @@ function selftest ()
    end
 
    buffer.preallocate(100000)
-   sq_sq('0000:05:00.0', '0000:8a:00.0')
+   sq_sq(pcideva, pcidevb)
    engine.main({duration = 1, report={showlinks=true, showapps=false}})
 
-   mq_sq('0000:05:00.0', '0000:8a:00.0')
+   mq_sq(pcideva, pcidevb)
    engine.main({duration = 1, report={showlinks=true, showapps=false}})
 end
 


### PR DESCRIPTION
intel_app: The PCI devices were still hardcoded in the self tests.
