### PR TITLE
packet_filter bug workaround: Disable JIT on generated code.

### DIFF
--- a/src/apps/packet_filter/packet_filter.lua
+++ b/src/apps/packet_filter/packet_filter.lua
@@ -337,8 +337,10 @@ local function generateConformFunctionString(rules)
    local T = make_code_concatter()
    T"local ffi = require(\"ffi\")"
    T"local bit = require(\"bit\")"
+   T"local jit = require(\"jit\")"
    T"return function(buffer, size)"
    T:indent()
+   T"jit.off(true,true)"
 
    for i = 1, #rules do
       if rules[i].ethertype == "ipv4" then
@@ -423,6 +425,8 @@ function PacketFilter:push ()
 end
 
 function selftest ()
+   -- Temporarily disabled:
+   --   Packet filter selftest is failing in.
    -- enable verbose logging for selftest
    verbose = true
    buffer.preallocate(10000)


### PR DESCRIPTION
Theory is that JIT of packet filter rules is triggering a LuaJIT bug,
possibly related to:

  http://www.freelists.org/post/luajit/0LL-nil
