### PR TITLE
intel10g: Fix to avoid multicast traffic looping back to sender.

### DIFF
--- a/src/apps/intel/intel10g.lua
+++ b/src/apps/intel/intel10g.lua
@@ -490,7 +490,7 @@ function M_vf:init_transmit ()
    local poolnum = self.poolnum or 0
    self.r.TXDCTL:clr(bits{Enable=25})
    self:set_transmit_descriptors()
-   self.pf.r.PFVMTXSW[math.floor(poolnum/32)]:set(bits{LLE=poolnum%32})
+   self.pf.r.PFVMTXSW[math.floor(poolnum/32)]:clr(bits{LLE=poolnum%32})
    self.pf.r.PFVFTE[math.floor(poolnum/32)]:set(bits{VFTE=poolnum%32})
    self.pf.r.RTTDQSEL(poolnum)
    self.pf.r.RTTDT1C(0x2000)


### PR DESCRIPTION
If multicast traffic is returned to sender it triggers IPv6 Duplicate
Address Detection (in Linux) and prevents traffic from being sent.

Fixed by clearing the LLE (Local Loopback Enable) bit of register
PFVMTXSW (PF VM Tx Switch Loopback Enable).

Relevant note in the 82599 datasheet on page 161:

```
A VM might be set to receive it’s own traffic in case the source and
the destination are in the same pool via the PFVMTXSW.LLE.
```
