### PR TITLE
intel10g: Fix transmit descriptor ring wrap-around bug.

### DIFF
--- a/src/apps/intel/intel10g.lua
+++ b/src/apps/intel/intel10g.lua
@@ -221,7 +221,7 @@ end
 function M_sf:can_receive ()
    -- Fast forward past non-terminal descriptors (DD=1 EoP=0)
    while bit.band(self.rxdesc[self.rxnext].wb.xstatus_xerror, 3) == 1 do
-      self.rxnext = self.rxnext + 1
+      self.rxnext = (self.rxnext + 1) % num_descriptors
    end
    -- Got a packet if DD=1 and EoP=1
    return bit.band(self.rxdesc[self.rxnext].wb.xstatus_xerror, 3) == 3


### PR DESCRIPTION
Bug introduced in commit 76296ddc1470af1bc2f2a8c25a54bbf714d80ec7. Caught by the keen eyes of @javierguerragiraldez.
