### PR TITLE
Apply partial loop-unrolling to avoid trace aborts

### DIFF
--- a/src/apps/intel/intel10g.lua
+++ b/src/apps/intel/intel10g.lua
@@ -173,14 +173,27 @@ end
 local txdesc_flags = bits{ifcs=25, dext=29, dtyp0=20, dtyp1=21}
 local txdesc_flags_last = bits({eop=24}, txdesc_flags)
 
+local function transmit_aux (self, p, i, niovecs)
+   local iov = p.iovecs[i]
+   local flags = (i + 1 < niovecs) and txdesc_flags or txdesc_flags_last
+   self.txdesc[self.tdt].address = iov.buffer.physical + iov.offset
+   self.txdesc[self.tdt].options = bor(iov.length, flags, lshift(p.length+0ULL, 46))
+   self.txpackets[self.tdt] = packet_ref(p)
+   self.tdt = band(self.tdt + 1, num_descriptors - 1)
+end
+
 function M_sf:transmit (p)
-   for i = 0, p.niovecs - 1 do
-      local iov = p.iovecs[i]
-      local flags = (i + 1 < p.niovecs) and txdesc_flags or txdesc_flags_last
-      self.txdesc[self.tdt].address = iov.buffer.physical + iov.offset
-      self.txdesc[self.tdt].options = bor(iov.length, flags, lshift(p.length+0ULL, 46))
-      self.txpackets[self.tdt] = packet_ref(p)
-      self.tdt = band(self.tdt + 1, num_descriptors - 1)
+   local niovecs = p.niovecs
+   if niovecs > 0 then
+      transmit_aux(self, p, 0, niovecs)
+   end
+   if niovecs > 1 then
+      transmit_aux(self, p, 1, niovecs)
+   end
+   if niovecs > 2 then
+      for i = 2, niovecs - 1 do
+	 transmit_aux(self, p, i, niovecs)
+      end
    end
 end
 
@@ -189,10 +202,12 @@ function M_sf:sync_transmit ()
    self.tdh = self.r.TDH()
    C.full_memory_barrier()
    -- Release processed buffers
-   while old_tdh ~= self.tdh do
-      packet.deref(self.txpackets[old_tdh])
-      self.txpackets[old_tdh] = nil
-      old_tdh = band(old_tdh + 1, num_descriptors - 1)
+   if old_tdh ~= self.tdh then
+      while old_tdh ~= self.tdh do
+	 packet.deref(self.txpackets[old_tdh])
+	 self.txpackets[old_tdh] = nil
+	 old_tdh = band(old_tdh + 1, num_descriptors - 1)
+      end
    end
    self.r.TDT(self.tdt)
 end
@@ -205,17 +220,25 @@ end
 
 --- See datasheet section 7.1 "Inline Functions -- Receive Functionality."
 
+local function receive_aux(self, p)
+   local wb = self.rxdesc[self.rxnext].wb
+   if band(wb.xstatus_xerror, 1) == 1 then -- Descriptor Done
+      local b = self.rxbuffers[self.rxnext]
+      packet.add_iovec(p, b, wb.pkt_len)
+      self.rxnext = band(self.rxnext + 1, num_descriptors - 1)
+   end
+   return band(wb.xstatus_xerror, 2) == 2  -- End Of Packet
+end
+
 function M_sf:receive ()
    assert(self.rdh ~= self.rxnext)
    local p = packet.allocate()
-   repeat
-      local wb = self.rxdesc[self.rxnext].wb
-      if band(wb.xstatus_xerror, 1) == 1 then -- Descriptor Done
-         local b = self.rxbuffers[self.rxnext]
-         packet.add_iovec(p, b, wb.pkt_len)
-         self.rxnext = band(self.rxnext + 1, num_descriptors - 1)
+   if not receive_aux(self, p) then
+      if not receive_aux(self, p) then
+	 repeat
+	 until receive_aux(self, p)
       end
-   until band(wb.xstatus_xerror, 2) == 2  -- End Of Packet
+   end
    return p
 end
 

--- a/src/core/packet.lua
+++ b/src/core/packet.lua
@@ -199,9 +199,23 @@ function tenure (p)
 end
 
 -- Free a packet and all of its buffers.
+
+local function free_aux(p, i)
+   buffer.free(p.iovecs[i].buffer)
+end
+
 function free (p)
-   for i = 0, p.niovecs-1 do
-      buffer.free(p.iovecs[i].buffer)
+   local niovecs = p.niovecs
+   if niovecs > 0 then
+      free_aux(p, 0)
+   end
+   if niovecs > 1 then
+      free_aux(p, 1)
+   end
+   if niovecs > 2 then
+      for i = 2, p.niovecs-1 do
+	 free_aux(p, i)
+      end
    end
    p.length         = 0
    p.niovecs        = 0

--- a/src/lib/hardware/register.lua
+++ b/src/lib/hardware/register.lua
@@ -55,7 +55,7 @@ function Register:noop () end
 ---     reg()      <=> reg:read()
 ---     reg(value) <=> reg:write(value)
 function Register:__call (value)
-   if value then return self:write(value) else return self:read() end
+   if value then return (self:write(value)) else return (self:read()) end
 end
 
 --- Registers print as `$NAME:$HEXVALUE` to make debugging easy.

--- a/src/lib/protocol/header.lua
+++ b/src/lib/protocol/header.lua
@@ -144,11 +144,11 @@ end
 -- Instance methods
 
 function header:header ()
-   return self._header[0][0]
+   return (self._header[0][0])
 end
 
 function header:sizeof ()
-   return ffi.sizeof(self._header_type)
+   return (ffi.sizeof(self._header_type))
 end
 
 -- default equality method, can be overriden in the ancestors


### PR DESCRIPTION
The JIT compiler has to unroll inner loops in a trace.  It does this up to a (configurable) limit and aborts the trace if it hits that limit.

This commit tries to avoid excessive unroll operations by manually unrolling a few iterations in critical code sections like multi-buffer receive and transmit processing.  This significantly reduces trace aborts in the case of, for example, encapsulation operations that typically use two buffers per packet.  It should not have any negative impact on single-buffer packets.

This could be a middle ground between full-fledged multi-buffer packets and the somewhat radical single-buffer approach proposed by Luke some time ago.

The commit also includes a few deliberate preventions of tailcalls to avoid an effect discussed in the thread
http://www.freelists.org/post/luajit/FFI-methods-for-userdata-objects,3. This is more guesswork than well-founded analysis, though.
