### PR TITLE
lib.pcap.lua: replace ffi.cast() from a local string with ffi.copy()

### DIFF
--- a/src/apps/packet_filter/packet_filter.lua
+++ b/src/apps/packet_filter/packet_filter.lua
@@ -335,10 +335,8 @@ local function generateConformFunctionString(rules)
    local T = make_code_concatter()
    T"local ffi = require(\"ffi\")"
    T"local bit = require(\"bit\")"
-   T"local jit = require(\"jit\")"
    T"return function(buffer, size)"
    T:indent()
-   T"jit.off(true,true)"
 
    for i = 1, #rules do
       if rules[i].ethertype == "ipv4" then

--- a/src/lib/pcap/pcap.lua
+++ b/src/lib/pcap/pcap.lua
@@ -75,20 +75,21 @@ function records (filename)
       local packet = file:read(datalen)
       local extra = nil
       if record.incl_len == #packet + ffi.sizeof("struct pcap_record_extra") then
-	 extra = readc(file, "struct pcap_record_extra")
+         extra = readc(file, "struct pcap_record_extra")
       end
       return packet, record, extra
    end
    return pcap_records_it, true, true
 end
 
--- Read a C object of TYPE from FILE. Return a pointer to the result.
+-- Read a C object of TYPE from FILE
 function readc(file, type)
    local string = file:read(ffi.sizeof(type))
    if string == nil then return nil end
    if #string ~= ffi.sizeof(type) then
       error("short read of " .. type .. " from " .. tostring(file))
    end
-   return ffi.cast(type.."*", string)
+   local obj = ffi.new(type)
+   ffi.copy(obj, string)
+   return obj
 end
-


### PR DESCRIPTION
readc() reads a local string and casts to a pointer of a given type.  The string goes out of scope and can be collected, making the pointer invalid.  Replacing the cast with a copy makes it safer and allows the code generated by packet_filter to be JITted.
