### PR TITLE
[neutron-sync-agent] Disregard local history, always rebase on origin.

### DIFF
--- a/src/designs/neutron/neutron-sync-agent
+++ b/src/designs/neutron/neutron-sync-agent
@@ -33,7 +33,7 @@ while true; do
     cd $NEUTRON_DIR
     git fetch
     if ! git diff --quiet origin/master; then
-	git merge --ff origin/master
+	git pull --rebase origin master
 	echo "Generating new configuration"
 	$NEUTRON2SNABB $NEUTRON_DIR $SNABB_DIR
     fi


### PR DESCRIPTION
Use `git pull --rebase` instead of (interactive) `git merge --ff` in order to always sync with `origin` and drop possible local contradictions.
