### PR TITLE
[SnabbBot] Make tasks fail when build fails

### DIFF
--- a/src/scripts/snabb_bot/snabb_bot.sh
+++ b/src/scripts/snabb_bot/snabb_bot.sh
@@ -68,9 +68,17 @@ for number in $("$JQ" ".[].number" "$tmpdir/pulls"); do
                 printf "\n$task" >> "$log"
 
                 # Ensure `head' is checked out and (re)built.
-                (cd "$tmpdir/repo"
+                out=$(cd "$tmpdir/repo"
                     git checkout "$head"
-                    make > /dev/null 2>&1)
+                    make 2>&1)
+
+                # If build failed, fail the task.
+                if [ "$?" != "0" ]; then
+                    echo ": build failure" >> "$log"
+                    echo "$out" >> "$log"
+                    status=failure
+                    continue
+                fi
 
                 # Run task and record results.
                 out=$( (cd "$tmpdir/repo"

--- a/src/scripts/snabb_bot/tasks/test.sh
+++ b/src/scripts/snabb_bot/tasks/test.sh
@@ -14,5 +14,7 @@ if echo "$test_out" | grep ERROR > /dev/null; then
     exit 1
 else
     echo "Tests successful."
+    echo
+    echo "$test_out"
     exit 0
 fi


### PR DESCRIPTION
SnabbBot didn't care for build failures... Also even for successul test runs in tasks/test.sh the test output will be printed.
