### PR TITLE
Intel10g: rx_buffsize config and check

### DIFF
--- a/src/apps/intel/intel_app.lua
+++ b/src/apps/intel/intel_app.lua
@@ -38,7 +38,7 @@ function Intel82599:new (args)
       return setmetatable({dev=vf:open(args)}, Intel82599)
    else
       local dev = intel10g.new_sf(args.pciaddr)
-         :open(args)
+         :open()
          :autonegotiate_sfi()
          :wait_linkup()
       if not dev then return null end
@@ -83,7 +83,6 @@ function Intel82599:pull ()
 end
 
 function Intel82599:add_receive_buffers ()
-   self.dev:set_rx_buffersize()        -- revert to default buffersize (16KB)
    if self.rx_buffer_freelist == nil then
       -- Generic buffers
       while self.dev:can_add_receive_buffer() do


### PR DESCRIPTION
This is supposed to fix #272 
-  driver: The config parameter `rx_buffsize` is used to set the receive queue buffer size (rounded down to KB increments and clipped to 16KB max)
-  driver: Before adding a buffer to the descriptor ring `rxdesc`, the size is `assert()`'ed to be big enough.
-  intel_app: Before accepting a given `rx_freelist`, each buffer in it is checked for minimum size.

I don't know if the virtio app can switch from zero-copy to non-optimized at any time, so i opted for checking the whole freelist immediately, and ignoring it if it's not acceptable.
