### PR TITLE
Fix virtio/net_device receive to support iovec.offset>0

### DIFF
--- a/src/core/clib.h
+++ b/src/core/clib.h
@@ -19,6 +19,9 @@ void *memset(void *s, int c, size_t n);
 // memcmp(3)
 int memcmp(const void *s1, const void *s2, int n);
 
+// memmove(3)
+void *memmove(void *dest, const void *src, int n);
+
 // strncpy(3) - copy a string
 char *strncpy(char *dest, const char *src, size_t n);
 

--- a/src/lib/virtio/net_device.lua
+++ b/src/lib/virtio/net_device.lua
@@ -225,6 +225,12 @@ function VirtioNetDevice:vm_buffer (iovec)
          -- no more buffers, stop the loop
          should_continue = false
       end
+   else
+      if iovec.offset ~= 0 then
+         -- Virtio requires the offset to be 0. Move the memory to make it so.
+         C.memmove(b.pointer, b.pointer + iovec.offset, iovec.length)
+         iovec.offset = 0
+      end
    end
    return should_continue, b
 end


### PR DESCRIPTION
Because virtio does not provide a way to specify offsets we use
memmove(3) to adjust the iovec to have offset=0 before sending.

Fixes the problem reported on this mailing list thread:
  https://groups.google.com/forum/#!topic/snabb-devel/ar778eECIL4
