### PR TITLE
allow lib.malloc to take the pointer directly.

### DIFF
--- a/src/core/buffer.lua
+++ b/src/core/buffer.lua
@@ -30,7 +30,7 @@ function new_buffer ()
    assert(allocated < max, "out of buffers")
    allocated = allocated + 1
    local pointer, physical, bytes = memory.dma_alloc(buffersize)
-   local b = lib.malloc("struct buffer")
+   local b = lib.malloc(buffer_t, buffer_ptr_t)
    b.pointer, b.physical, b.size = pointer, physical, buffersize
    b.origin.type = C.BUFFER_ORIGIN_UNKNOWN
    return b

--- a/src/core/lib.lua
+++ b/src/core/lib.lua
@@ -266,14 +266,18 @@ function finish_csum (sum)
    return bit.band(bit.bnot(sum), 0xffff)
 end
 
-
-function malloc (etype)
+-- NOTE: ffi.typeof() will cause NYI in many cases.
+-- avoid using just malloc("struct foo") on loops.
+function malloc (etype, etype_ptr)
    if type(etype) == 'string' then
       etype = ffi.typeof(etype)
    end
    local size = ffi.sizeof(etype)
    local ptr = memory.dma_alloc(size)
-   return ffi.cast(ffi.typeof("$*", etype), ptr)
+   if etype_ptr == nil then
+      etype_ptr = ffi.typeof("$*", etype)
+   end
+   return ffi.cast(etype_ptr, ptr)
 end
 
 

--- a/src/lib/virtio/net_device.lua
+++ b/src/lib/virtio/net_device.lua
@@ -25,7 +25,6 @@ local virtio_net_hdr_size = ffi.sizeof("struct virtio_net_hdr")
 local virtio_net_hdr_mrg_rxbuf_size = ffi.sizeof("struct virtio_net_hdr_mrg_rxbuf")
 local virtio_net_hdr_mrg_rxbuf_type = ffi.typeof("struct virtio_net_hdr_mrg_rxbuf *")
 local packet_info_size = ffi.sizeof("struct packet_info")
-local buffer_t = ffi.typeof("struct buffer")
 
 local invalid_header_id = 0xffff
 
@@ -125,7 +124,7 @@ function VirtioNetDevice:rx_packet_start(header_id, addr, len)
 end
 
 function VirtioNetDevice:rx_buffer_add(rx_p, addr, len, rx_total_size, tx)
-   local buf = freelist.remove(self.buffer_recs) or lib.malloc(buffer_t)
+   local buf = freelist.remove(self.buffer_recs) or lib.malloc(buffer.buffer_t, buffer.buffer_ptr_t)
 
    local addr = self:map_from_guest(addr)
    buf.pointer = ffi.cast(char_ptr_t, addr)
@@ -185,7 +184,7 @@ function VirtioNetDevice:tx_packet_start(header_id, addr, len)
 end
 
 function VirtioNetDevice:tx_buffer_add(tx_p, addr, len, tx_total_size, tx)
-   local buf = freelist.remove(self.buffer_recs) or lib.malloc(buffer_t)
+   local buf = freelist.remove(self.buffer_recs) or lib.malloc(buffer.buffer_t, buffer.buffer_ptr_t)
 
    local addr = self:map_from_guest(addr)
    buf.pointer = ffi.cast(char_ptr_t, addr)


### PR DESCRIPTION
- This is useful for improved performance on loops because
  ffi.typeof() is not compiled in many cases.
