### PR TITLE
Use index instead of pairs in method 'generate' in Fuzz apps

### DIFF
--- a/src/apps/fuzz/ethernet.lua
+++ b/src/apps/fuzz/ethernet.lua
@@ -1,5 +1,6 @@
 module(...,package.seeall)
 
+local lib = require("core.lib")
 local packet = require("core.packet")
 local datagram = require("lib.protocol.datagram")
 local ethernet = require("lib.protocol.ethernet")
@@ -43,11 +44,11 @@ end
 
 function g_ethernet:generate()
    -- save the origin list to iterate over it
-   local origin = {}
-   for _, data in pairs(self.data_list) do origin[#origin+1] = data end
-
-   for _, data in pairs(origin) do
-      self.data_list[#self.data_list + 1] = self:single(data)
+   local origin = lib.array_copy(self.data_list)
+   local size = #self.data_list
+   for i=1,#origin do
+      size = size + 1
+      self.data_list[size] = self:single(origin[i])
    end
 end
 

--- a/src/apps/fuzz/ipv4.lua
+++ b/src/apps/fuzz/ipv4.lua
@@ -1,5 +1,6 @@
 module(...,package.seeall)
 
+local lib = require("core.lib")
 local packet = require("core.packet")
 local datagram = require("lib.protocol.datagram")
 local ethernet = require("lib.protocol.ethernet")
@@ -78,12 +79,9 @@ function g_ipv4:single (data)
 end
 
 function g_ipv4:generate()
-   -- save the origin list to iterate over it
-   local origin = {}
-   for _, data in pairs(self.data_list) do origin[#origin+1] = data end
-
-   for _, data in pairs(origin) do
-      self:single(data)
+   local origin = lib.array_copy(self.data_list)
+   for i=1,#origin do
+      self:single(origin[i])
    end
 end
 

--- a/src/apps/fuzz/ipv6.lua
+++ b/src/apps/fuzz/ipv6.lua
@@ -1,5 +1,6 @@
 module(...,package.seeall)
 
+local lib = require("core.lib")
 local packet = require("core.packet")
 local datagram = require("lib.protocol.datagram")
 local ethernet = require("lib.protocol.ethernet")
@@ -72,11 +73,9 @@ end
 
 function g_ipv6:generate()
    -- save the origin list to iterate over it
-   local origin = {}
-   for _, data in pairs(self.data_list) do origin[#origin+1] = data end
-
-   for _, data in pairs(origin) do
-      self:single(data)
+   local origin = lib.array_copy(self.data_list)
+   for i=1,#origin do
+      self:single(origin[i])
    end
 end
 

--- a/src/apps/fuzz/matcher.lua
+++ b/src/apps/fuzz/matcher.lua
@@ -105,7 +105,7 @@ end
 
 function matcher:report()
    local sent, received = 0,0
-   for _,match in pairs(self.data_list) do
+   for _,match in ipairs(self.data_list) do
       if match.received ~= #match.sg then
          print(string.format("Mismatch for packet %s. Generated %d, received %d.",
             match.desc, #match.sg, match.received))

--- a/src/apps/fuzz/tcp.lua
+++ b/src/apps/fuzz/tcp.lua
@@ -1,5 +1,6 @@
 module(...,package.seeall)
 
+local lib = require("core.lib")
 local packet = require("core.packet")
 local datagram = require("lib.protocol.datagram")
 local ethernet = require("lib.protocol.ethernet")
@@ -145,11 +146,9 @@ end
 
 function g_tcp:generate()
    -- save the origin list to iterate over it
-   local origin = {}
-   for _, data in pairs(self.data_list) do origin[#origin+1] = data end
-
-   for _, data in pairs(origin) do
-      self:single(data)
+   local origin = lib.array_copy(self.data_list)
+   for i=1,#origin do
+      self:single(origin[i])
    end
 end
 

--- a/src/apps/fuzz/udp.lua
+++ b/src/apps/fuzz/udp.lua
@@ -1,5 +1,6 @@
 module(...,package.seeall)
 
+local lib = require("core.lib")
 local packet = require("core.packet")
 local datagram = require("lib.protocol.datagram")
 local ethernet = require("lib.protocol.ethernet")
@@ -127,11 +128,9 @@ end
 
 function g_udp:generate()
    -- save the origin list to iterate over it
-   local origin = {}
-   for _, data in pairs(self.data_list) do origin[#origin+1] = data end
-
-   for _, data in pairs(origin) do
-      self:single(data)
+   local origin = lib.array_copy(self.data_list)
+   for i=1,#origin do
+      self:single(origin[i])
    end
 end
 

--- a/src/core/lib.lua
+++ b/src/core/lib.lua
@@ -297,6 +297,15 @@ function deepcopy(orig)
    return copy
 end
 
+-- 'orig' must be an array, not a sparse array (hash)
+function array_copy(orig)
+   local result = {}
+   for i=1,#orig do
+      result[i] = orig[i]
+   end
+   return result
+end
+
 -- endian conversion helpers written in Lua
 -- avoid C function call overhead while using C.xxxx counterparts
 if ffi.abi("be") then


### PR DESCRIPTION
- src/apps/fuzz/ethernet.lua: Iterate with index instead of pairs.
- src/apps/fuzz/ipv4.lua: Iterate with index instead of pairs.
- src/apps/fuzz/ipv6.lua: Iterate with index instead of pairs.
- src/apps/fuzz/matcher.lua: Use ipairs instead of pairs.
- src/apps/fuzz/tcp.lua: Iterate with index instead of pairs.
- src/apps/fuzz/udp.lua: Iterate with index instead of pairs.
- src/core/lib.lua: Add method for copying arrays.
