### PR TITLE
Cache C interface

### DIFF
--- a/src/apps/keyed_ipv6_tunnel/tunnel.lua
+++ b/src/apps/keyed_ipv6_tunnel/tunnel.lua
@@ -135,11 +135,11 @@ function SimpleKeyedTunnel:new (confstring)
 
    -- convert dest, sorce ipv6 addressed to network order binary
    local result =
-      ffi.C.inet_pton(AF_INET6, config.local_address, header + SRC_IP_OFFSET)
+      C.inet_pton(AF_INET6, config.local_address, header + SRC_IP_OFFSET)
    assert(result == 1,"malformed IPv6 address: " .. config.local_address)
 
    result =
-      ffi.C.inet_pton(AF_INET6, config.remote_address, header + DST_IP_OFFSET)
+      C.inet_pton(AF_INET6, config.remote_address, header + DST_IP_OFFSET)
    assert(result == 1,"malformed IPv6 address: " .. config.remote_address)
 
    -- store casted pointers for fast matching

--- a/src/apps/packet_filter/packet_filter.lua
+++ b/src/apps/packet_filter/packet_filter.lua
@@ -1,6 +1,7 @@
 module(...,package.seeall)
 
 local ffi = require("ffi")
+local C = ffi.C
 local bit = require("bit")
 
 local app = require("core.app")
@@ -133,7 +134,7 @@ local function parse_cidr_ipv4 (cidr)
    end
 
    local in_addr  = ffi.new("int32_t[1]")
-   local result = ffi.C.inet_pton(AF_INET, address, in_addr)
+   local result = C.inet_pton(AF_INET, address, in_addr)
    if result ~= 1 then
       return false, "malformed IPv4 address: " .. address
    end
@@ -164,7 +165,7 @@ local function parse_cidr_ipv6 (cidr)
    end
 
    local in6_addr  = ffi.new("uint64_t[2]")
-   local result = ffi.C.inet_pton(AF_INET6, address, in6_addr)
+   local result = C.inet_pton(AF_INET6, address, in6_addr)
    if result ~= 1 then
       return false, "malformed IPv6 address: " .. address
    end

--- a/src/lib/protocol/ipv4.lua
+++ b/src/lib/protocol/ipv4.lua
@@ -70,7 +70,7 @@ end
 
 function ipv4:pton (p)
    local in_addr  = ffi.new("uint8_t[4]")
-   local result = ffi.C.inet_pton(AF_INET, p, in_addr)
+   local result = C.inet_pton(AF_INET, p, in_addr)
    if result ~= 1 then
       return false, "malformed IPv4 address: " .. address
    end

--- a/src/lib/protocol/ipv6.lua
+++ b/src/lib/protocol/ipv6.lua
@@ -71,7 +71,7 @@ end
 
 function ipv6:pton (p)
    local in_addr  = ffi.new("uint8_t[16]")
-   local result = ffi.C.inet_pton(AF_INET6, p, in_addr)
+   local result = C.inet_pton(AF_INET6, p, in_addr)
    if result ~= 1 then
       return false, "malformed IPv6 address: " .. address
    end


### PR DESCRIPTION
It's a common idiom in Lua to cache the C interface:

```
local ffi = require('ffi')
local C = ffi.C
```

Caching the C namespace allows faster access to C functions. The codebase of Snabbswitch uses this idiom but there are a few places which don't, even when the C namespace was previously cached.
