### PR TITLE
Error handling in timers unified with apps RFC

### DIFF
--- a/src/apps/csv.lua
+++ b/src/apps/csv.lua
@@ -17,7 +17,7 @@ function CSV:new (directory)
    o.appfile:flush()
    o.linkfile:write("time,from_app,from_port,to_app,to_port,txbytes,txpackets,rxbytes,rxpackets,dropbytes,droppackets\n")
    o.linkfile:flush()
-   timer.new('CSV',
+   timer.new(o, 'CSV',
              function () o:output() end,
              1e9,
              'repeating')

--- a/src/apps/ipv6/nd_light.lua
+++ b/src/apps/ipv6/nd_light.lua
@@ -146,7 +146,7 @@ function nd_light:new (config)
 					   ipv6:ntop(config.next_hop)))
 		    end
 		 end
-   nh.timer = timer.new("ns retransmit", nh.timer_cb, 1e6 * config.delay)
+   nh.timer = timer.new(o, "ns retransmit", nh.timer_cb, 1e6 * config.delay)
    o._next_hop = nh
 
    -- Prepare packet for solicited neighbor advertisement

--- a/src/apps/rate_limiter/rate_limiter.lua
+++ b/src/apps/rate_limiter/rate_limiter.lua
@@ -126,7 +126,7 @@ function selftest ()
    local seconds_to_run = 5
    -- print packets statistics every second
    timer.activate(timer.new(
-         "report",
+         nil, "report",
          function ()
             app.report()
             seconds_to_run = seconds_to_run - 1

--- a/src/apps/vhost/vhost_user.lua
+++ b/src/apps/vhost/vhost_user.lua
@@ -27,20 +27,18 @@ VhostUser = {}
 
 function VhostUser:new (args)
    local o = { state = 'init',
-      dev = nil,
-      msg = ffi.new("struct vhost_user_msg"),
-      nfds = ffi.new("int[1]"),
-      fds = ffi.new("int[?]", C.VHOST_USER_MEMORY_MAX_NREGIONS),
-      socket_path = args.socket_path,
-      mem_table = {},
-      -- process qemu messages timer
-      process_qemu_timer = timer.new(
-         "process qemu timer",
-         function () self:process_qemu_requests() end,
-         5e8,-- 500 ms
-         'non-repeating'
-      )
-   }
+               dev = nil,
+               msg = ffi.new("struct vhost_user_msg"),
+               nfds = ffi.new("int[1]"),
+               fds = ffi.new("int[?]", C.VHOST_USER_MEMORY_MAX_NREGIONS),
+               socket_path = args.socket_path,
+               mem_table = {} }
+   -- process qemu messages timer
+   o.process_qemu_timer = timer.new(
+      o, "process qemu timer",
+      function () self:process_qemu_requests() end,
+      5e8,-- 500 ms
+      'non-repeating')
    self = setmetatable(o, {__index = VhostUser})
    self.dev = net_device.VirtioNetDevice:new(self)
    if args.is_server then
@@ -345,7 +343,7 @@ function selftest ()
          vhost_user:report()
       end
    end
-   timer.activate(timer.new("report", fn, 10e9, 'repeating'))
+   timer.activate(timer.new(nil, "report", fn, 10e9, 'repeating'))
 
    app.main()
 end

--- a/src/core/restarts.lua
+++ b/src/core/restarts.lua
@@ -13,9 +13,23 @@ end
 function with_restart (app, methodname)
    -- Run app:methodname() in protected mode using pcall.
    local status, err = pcall(app[methodname], app)
-
    -- If pcall caught an error mark app as "dead".
    if not status then mark_dead(app, err) end
+   return status
+end
+
+-- Run timer in protected mode (pcall). If it throws an error the app
+-- owning timer will be marked as dead and restarted eventually.
+function with_restart_timer (timer)
+   -- Run timer in protected mode using pcall.
+   local status, err = pcall(timer.fn, timer)
+   err = ("%s: %s"):format(timer.name, err)
+   -- If pcall caught an error mark app owning (if any) timer as "dead".
+   if not status then
+      if timer.app then mark_dead(timer.app, err)
+      else print(err) end
+   end
+   return status
 end
 
 -- Compute actions to restart dead apps in app_array.

--- a/src/designs/bench/basic1
+++ b/src/designs/bench/basic1
@@ -38,7 +38,7 @@ function run (npackets)
    config.link(c, "Tee.tx2 -> Sink.rx2")
    engine.configure(c)
    local start = C.get_monotonic_time()
-   timer.activate(timer.new("null", function () end, 1e6, 'repeating'))
+   timer.activate(timer.new(nil, "null", function () end, 1e6, 'repeating'))
    while engine.app_table.Source.output.tx.stats.txpackets < npackets do
       engine.main({duration = 0.01, no_report = true})
    end

--- a/src/designs/loadgen/loadgen
+++ b/src/designs/loadgen/loadgen
@@ -37,7 +37,7 @@ function run (args)
                  print("Transmissions (last 1 sec):")
                  app.report_each_app()
               end
-   local t = timer.new("report", fn, 1e9, 'repeating')
+   local t = timer.new(nil, "report", fn, 1e9, 'repeating')
    timer.activate(t)
    buffer.preallocate(100000)
    app.main()

--- a/src/designs/nfv/nfv
+++ b/src/designs/nfv/nfv
@@ -43,7 +43,7 @@ function run (npackets)
    local nic, vm = app.app_table.nic, app.app_table.vm
    nic:set_rx_buffer_freelist(vm:rx_buffers())
    if not npackets then
-      timer.activate(timer.new("report", app.report, 1e9, 'repeating'))
+      timer.activate(timer.new(nil, "report", app.report, 1e9, 'repeating'))
       print("Entering app.main()")
       app.main()
    else


### PR DESCRIPTION
Consider this a Request for Comment. I am myself not completely satisfied with this patch... suggestions?

389fc91 extracts the error handling code from `core.app` to its own module `core.restarts`.

fdf7f83 modifies `core.timer` to use `core.restarts` and extends it to do so. `timer.new()` now requires an additional "app" argument which can be an app or `nil`. If it's an app, the timer is "owned" by that app. If the app dies, its timers will be prevented from being run and removed from the timers table when it is restarted. If an app-owned timer raises an error, its app will be marked dead. If a "loose" timer raises an error, the error is printed (no other action is taken).
Calls to `timer.new()` throughout the code base have been updated.

What I do not like about this:
- Using the new `timer.new()` is clumsy: If you pass it `self` (e.g. the class) instead of the app instance all hell breaks loose.
- I have to use `C.get_monotonic_time` in `core.restarts` because I don't have `core.app`'s `now()`. Extract `core.clock`?
- The refactoring is not very _elegant_ in general.
- Owned and loose timers behave quite differently.
