### PR TITLE
Rate limiter: fix NFV tests to include rate_limiter

### DIFF
--- a/src/lib/nfv/config.lua
+++ b/src/lib/nfv/config.lua
@@ -12,7 +12,7 @@ local AF_INET6 = 10
 local lib = require("core.lib")
 
 -- Set to true to enable traffic policing via the rate limiter app
-policing = false
+policing = true
 
 -- Compile app configuration from <file> for <pciaddr> and vhost_user
 -- <socket>. Returns configuration and zerocopy pairs.
@@ -72,10 +72,10 @@ function load (file, pciaddr, sockpath)
       end
       if policing and t.gbps then
          local QoS = "QoS_"..name
-         local rate = t.gbps * 1000000 / 8
+         local rate = t.gbps * 1000000000 / 8
          config.app(c, QoS, RateLimiter, ([[{rate = %d, bucket_capacity = %d}]]):format(rate, rate))
-         config.link(c, VM_tx.." -> "..QoS..".rx")
-         VM_tx = QoS..".tx"
+         config.link(c, VM_tx.." -> "..QoS..".input")
+         VM_tx = QoS..".output"
       end
       config.link(c, NIC..".tx -> "..VM_rx)
       config.link(c, VM_tx.." -> "..NIC..".rx")

--- a/src/lib/nfv/selftest.sh
+++ b/src/lib/nfv/selftest.sh
@@ -148,7 +148,7 @@ function same_vlan_tests {
     test_iperf $TELNET_PORT0 $TELNET_PORT1 "$GUEST_IP1%eth0"
     test_jumboping $TELNET_PORT0 $TELNET_PORT1 "$GUEST_IP1%eth0"
     # Repeat iperf test now that jumbo frames are enabled
-    test_iperf $TELNET_PORT0 $TELNET_PORT1 "$GUEST_IP1%eth0"
+    test_iperf $TELNET_PORT1 $TELNET_PORT0 "$GUEST_IP0%eth0"
 #    test_checksum $TELNET_PORT0
 #    test_checksum $TELNET_PORT1
 

--- a/src/test_fixtures/nfvconfig/test_functions/same_vlan.ports
+++ b/src/test_fixtures/nfvconfig/test_functions/same_vlan.ports
@@ -3,14 +3,14 @@ return {
     mac_address = "52:54:00:00:00:00",
     port_id = "A",
     ingress_filter = nil,
-    gbps = nil,
+    gbps = 0.5,
     tunnel = nil
   },
   { vlan = 43,
     mac_address = "52:54:00:00:00:01",
     port_id = "B",
     ingress_filter = nil,
-    gbps = nil,
+    gbps = 1.5,
     tunnel = nil
   },
 }


### PR DESCRIPTION
This completes #292 , running the `iperf` test with `rate_limiter` enabled when the config files include a `gbps` term.

Currently, the throughtput reported by `iperf` is within 10% of the goal, but usually higher than requested, sometimes as much as 8%.
