### PR TITLE
[core.lib] Add basic "pretty" printing to `store_conf'.

### DIFF
--- a/src/core/lib.lua
+++ b/src/core/lib.lua
@@ -112,22 +112,31 @@ end
 
 -- Store Lua representation of value in file.
 function store_conf (file, value)
+   local indent = 0
+   local function print_indent (stream)
+      for i = 1, indent do stream:write(" ") end
+   end
    local function print_value (value, stream)
       local  type = type(value)
       if     type == 'table'  then
-         stream:write("{ ")
+         indent = indent + 2
+         stream:write("{\n")
          if #value == 0 then
             for key, value in pairs(value) do
+               print_indent(stream)
                stream:write(key, " = ")
                print_value(value, stream)
-               stream:write(", ")
+               stream:write(",\n")
             end
          else
             for _, value in ipairs(value) do
+               print_indent(stream)
                print_value(value, stream)
-               stream:write(", ")
+               stream:write(",\n")
             end
          end
+         indent = indent - 2
+         print_indent(stream)
          stream:write("}")
       elseif type == 'string' then
          stream:write(("%q"):format(value))

--- a/src/test_fixtures/nfvconfig/reference/port0
+++ b/src/test_fixtures/nfvconfig/reference/port0
@@ -1,1 +1,34 @@
-return { { vlan = 43, ingress_filter = { { ethertype = "ipv4", }, { ethertype = "ipv6", }, }, egress_filter = { { ethertype = "ipv6", }, { ethertype = "ipv4", }, }, mac_address = "fa:16:3e:1e:b0:20", tunnel = { next_hop = "2:2:2:2:2:2:2:2", local_cookie = "616263", session = 16, type = "L2TPv3", local_ip = "2006::16", remote_cookie = "646566", remote_ip = "1:2:3:4:5:6:7:8", }, rx_police_gbps = 3, port_id = "523276c7-73e3-4154-8b67-9c7199bdbb8c", gbps = 8, }, }
+return {
+  {
+    vlan = 43,
+    ingress_filter = {
+      {
+        ethertype = "ipv4",
+      },
+      {
+        ethertype = "ipv6",
+      },
+    },
+    egress_filter = {
+      {
+        ethertype = "ipv6",
+      },
+      {
+        ethertype = "ipv4",
+      },
+    },
+    mac_address = "fa:16:3e:1e:b0:20",
+    tunnel = {
+      next_hop = "2:2:2:2:2:2:2:2",
+      local_cookie = "616263",
+      session = 16,
+      type = "L2TPv3",
+      local_ip = "2006::16",
+      remote_cookie = "646566",
+      remote_ip = "1:2:3:4:5:6:7:8",
+    },
+    rx_police_gbps = 3,
+    port_id = "523276c7-73e3-4154-8b67-9c7199bdbb8c",
+    gbps = 8,
+  },
+}

--- a/src/test_fixtures/nfvconfig/reference/port2
+++ b/src/test_fixtures/nfvconfig/reference/port2
@@ -1,1 +1,24 @@
-return { { vlan = 42, ingress_filter = { { ethertype = "ipv4", }, { ethertype = "ipv6", }, }, egress_filter = { { ethertype = "ipv6", }, { ethertype = "ipv4", }, }, mac_address = "fa:16:3e:5d:ed:a3", port_id = "9745ff46-986f-4f74-bc37-a35f481c0b9b", gbps = 8, }, }
+return {
+  {
+    vlan = 42,
+    ingress_filter = {
+      {
+        ethertype = "ipv4",
+      },
+      {
+        ethertype = "ipv6",
+      },
+    },
+    egress_filter = {
+      {
+        ethertype = "ipv6",
+      },
+      {
+        ethertype = "ipv4",
+      },
+    },
+    mac_address = "fa:16:3e:5d:ed:a3",
+    port_id = "9745ff46-986f-4f74-bc37-a35f481c0b9b",
+    gbps = 8,
+  },
+}


### PR DESCRIPTION
The format is as follows:

```
{
  array = {
    1,
    2,
  },
  table = {
    foo = 1,
    bar = 2,
  },
}
```

Its not _really_ pretty, but somewhat readable and the algorithm is simple. Idiomatic Lua formatting would be much more complicated as far as I can imagine.
