### PR TITLE
Redeclaration of 'should_continue' is hidding external variable

### DIFF
--- a/src/lib/virtio/net_device.lua
+++ b/src/lib/virtio/net_device.lua
@@ -280,7 +280,8 @@ function VirtioNetDevice:transmit_packets_to_vm ()
       for i = 0, p.niovecs - 1 do
 
          local iovec = p.iovecs[i]
-         local should_continue, b = self:vm_buffer(iovec)
+         local b
+         should_continue, b = self:vm_buffer(iovec)
          local size = iovec.length
 
          -- fill in the virtio header


### PR DESCRIPTION
Redeclaration of variable 'should_continue' in the inner loop is hiding value of external variable 'should_continue'.

We have doubts this is the intended behaviour. It seems 'should_continue' is used to keep track of whether exit the outer loop. Apparently this change was introduced in d62ffc17 (net_device: Refactor vrings).
