### PR TITLE
Remove last_size check.

### DIFF
--- a/src/lib/virtio/net_device.lua
+++ b/src/lib/virtio/net_device.lua
@@ -232,7 +232,6 @@ function VirtioNetDevice:more_vm_buffers ()
 end
 
 -- return the buffer from a iovec, ensuring it originates from the vm
-local last_size = nil
 function VirtioNetDevice:vm_buffer (iovec)
    local should_continue = true
    local b = iovec.buffer
@@ -259,7 +258,6 @@ function VirtioNetDevice:vm_buffer (iovec)
          iovec.offset = 0
       end
    end
-   if last_size ~= b.size then print("size=", b.size) last_size=b.size end
    return should_continue, b
 end
 


### PR DESCRIPTION
- The variable last_size is not used in any part of the code other than
  this two lines. This seems to have been added for debug purposes and
  was left there.
- This code starts triggering on a kernel >= 3.14 (Ubuntu 14.04 uses
  3.13, so this went unnoticed). It causes a lot of flood because it
  triggers constantly.
- Example of the output from snabswitch when running same_vlan.ports
  with both VMs running Kernel 3.14.23 and running an iperf test
  (MTU 1500) between both VMs:

```
      size=  2036
      size=  1524
      size=  2036
      size=  1524
      size=  2036
      size=  1524
      [ .... repeated ad-infinitum ]
```
- I have bisected the Linux kernel, the commit that causes this print to
  trigger is fb51879dbceab9c40a39018d5322451691909e15 (merged on 3.14)
  https://git.kernel.org/linus/fb51879
