### PR TITLE
Avoid interpreter fallback in timer and app core modules

### DIFF
--- a/src/core/timer.lua
+++ b/src/core/timer.lua
@@ -24,17 +24,17 @@ function run ()
 end
 
 -- Run all timers up to the given new time.
-function run_to_time (ns)
-   local function call_timers (l)
-      for i=1,#l do
-         local timer = l[i]
-         if debug then
-            print(string.format("running timer %s at tick %s", timer.name, ticks))
-         end
-         timer.fn(timer)
-         if timer.repeating then activate(timer) end
+local function call_timers (l)
+   for i=1,#l do
+      local timer = l[i]
+      if debug then
+	 print(string.format("running timer %s at tick %s", timer.name, ticks))
       end
+      timer.fn(timer)
+      if timer.repeating then activate(timer) end
    end
+end
+function run_to_time (ns)
    local new_ticks = math.floor(tonumber(ns) / ns_per_tick)
    for tick = ticks, new_ticks do
       ticks = tick


### PR DESCRIPTION
The core modules app.lua and time.lua are causing an excessive amount
of interpreter fallback, leading to a significant performance penalty.
This changeset removes one of the causes and offers a workaround for
the other one through a configuration option.

The definition of call_timers() in core/timer.lua is moved out of
run_to_time() to avoid generation of the non-compileable bytecode
UCLO (bytecode 51 in the current version of LuaJIT).

The code for detecting dead apps by wrapping them in pcall() leads to
frequent trace aborts due to "NYI: return to lower frame".  It is not
entirely clear what exactly this means and whether it can be avoided
somehow.  A new configuration option "dead_app_detection" is
introduced that disables this mechanism when set to false (defaults to
true).  The options for main() are passed on to breathe() to make this
work.
