### PR TITLE
Avoid interpreter fallback in timer and app core modules (fixed and rebased)

### DIFF
--- a/src/core/app.lua
+++ b/src/core/app.lua
@@ -184,7 +184,18 @@ end
 
 -- Call this to "run snabb switch".
 function main (options)
-   options = options or {}
+   local default_options = {
+      dead_app_detection = true,
+   }
+   if options then
+      for k, v in pairs(default_options) do
+	 if options[k] == nil then
+	    options[k] = v
+	 end
+      end
+   else
+      options = default_options
+   end
    local done = options.done
    local no_timers = options.no_timers
    if options.duration then
@@ -193,7 +204,7 @@ function main (options)
    end
    monotonic_now = C.get_monotonic_time()
    repeat
-      breathe()
+      breathe(options)
       if not no_timers then timer.run() end
       pace_breathing()
    until done and done()
@@ -214,10 +225,12 @@ function pace_breathing ()
    end
 end
 
-function breathe ()
+function breathe (options)
    monotonic_now = C.get_monotonic_time()
    -- Restart: restart dead apps
-   restart_dead_apps()
+   if options.dead_app_detection then
+      restart_dead_apps()
+   end
    -- Inhale: pull work into the app network
    for i = 1, #app_array do
       local app = app_array[i]
@@ -225,7 +238,11 @@ function breathe ()
 --         zone(app.zone) app:pull() zone()
       if app.pull and not app.dead then
 	 zone(app.zone)
-	 with_restart(app, 'pull')
+	 if options.dead_app_detection then
+	    with_restart(app, 'pull')
+	 else
+	    app:pull()
+	 end
 	 zone()
       end
    end
@@ -241,7 +258,11 @@ function breathe ()
             local receiver = app_array[link.receiving_app]
             if receiver.push and not receiver.dead then
                zone(receiver.zone)
-               with_restart(receiver, 'push')
+	       if options.dead_app_detection then
+		  with_restart(receiver, 'push')
+	       else
+		  receiver:push()
+	       end
                zone()
                progress = true
             end
@@ -272,7 +293,11 @@ function report (options)
             print (name, ("[dead: %s]"):format(app.dead.error))
          elseif app.report then
             print (name)
-            with_restart(app, 'report')
+	    if options.dead_app_detection then
+	       with_restart(app, 'report')
+	    else
+	       app:report()
+	    end
          end
       end
    end

--- a/src/core/timer.lua
+++ b/src/core/timer.lua
@@ -24,17 +24,17 @@ function run ()
 end
 
 -- Run all timers up to the given new time.
-function run_to_time (ns)
-   local function call_timers (l)
-      for i=1,#l do
-         local timer = l[i]
-         if debug then
-            print(string.format("running timer %s at tick %s", timer.name, ticks))
-         end
-         timer.fn(timer)
-         if timer.repeating then activate(timer) end
+local function call_timers (l)
+   for i=1,#l do
+      local timer = l[i]
+      if debug then
+	 print(string.format("running timer %s at tick %s", timer.name, ticks))
       end
+      timer.fn(timer)
+      if timer.repeating then activate(timer) end
    end
+end
+function run_to_time (ns)
    local new_ticks = math.floor(tonumber(ns) / ns_per_tick)
    for tick = ticks, new_ticks do
       ticks = tick


### PR DESCRIPTION
The core modules app.lua and time.lua are causing an excessive amount
of interpreter fallback, leading to a significant performance penalty.
This changeset removes one of the causes and offers a workaround for
the other one through a configuration option.

The definition of call_timers() in core/timer.lua is moved out of
run_to_time() to avoid generation of the non-compileable bytecode
UCLO (bytecode 51 in the current version of LuaJIT).

The code for detecting dead apps by wrapping them in pcall() leads to
frequent trace aborts due to "NYI: return to lower frame".  It is not
entirely clear what exactly this means and whether it can be avoided
somehow.  A new configuration option "dead_app_detection" is
introduced that disables this mechanism when set to false (defaults to
true).  The options for main() are passed on to breathe() to make this
work.
