### PR TITLE
Performance tweaks in core/timer.lua

### DIFF
--- a/src/core/timer.lua
+++ b/src/core/timer.lua
@@ -20,21 +20,21 @@ end
 
 -- Run all timers that have expired.
 function run ()
-   if ticks then run_to_time(C.get_time_ns()) end
+   if ticks then run_to_time(tonumber(C.get_time_ns())) end
 end
 
 -- Run all timers up to the given new time.
-function run_to_time (ns)
-   local function call_timers (l)
-      for i=1,#l do
-         local timer = l[i]
-         if debug then
-            print(string.format("running timer %s at tick %s", timer.name, ticks))
-         end
-         timer.fn(timer)
-         if timer.repeating then activate(timer) end
+local function call_timers (l)
+   for i=1,#l do
+      local timer = l[i]
+      if debug then
+	 print(string.format("running timer %s at tick %s", timer.name, ticks))
       end
+      timer.fn(timer)
+      if timer.repeating then activate(timer) end
    end
+end
+function run_to_time (ns)
    local new_ticks = math.floor(tonumber(ns) / ns_per_tick)
    for tick = ticks, new_ticks do
       ticks = tick


### PR DESCRIPTION
The definition of call_timers() in core/timer.lua is moved out of
run_to_time() to avoid generation of the non-compileable bytecode
UCLO (bytecode 51 in the current version of LuaJIT).

Wrapping the call to ffi.C.get_time_ns() in run() with tonumber()
avoids the allocation of a cdata object that is difficult for the sink
optimizer to remove.  Here is the IR of a typical trace without tonumber():

0036       >  p32 UREFC  timer.lua:22  #0  
0037       >  udt ULOAD  0036
0038       >  p32 EQ     0037  [0x4123cfa0]
0039 r15      u64 CALLXS [0x408c78]()
0040 rax   >  cdt CNEWI  +12   0039
0041       >  fun EQ     0035  timer.lua:37

The allocation of the uint64_t cdata object (CNEWI +12) at 0040 is not sunk. With tonumber():

0050       >  p32 UREFC  timer.lua:22  #0  
0051       >  udt ULOAD  0050
0052       >  p32 EQ     0051  [0x40465fa0]
0053 rax      u64 CALLXS [0x408c78]()
0054  {sink}  cdt CNEWI  +12   0053
0055       >  fun EQ     0049  tonumber
0056 xmm7     num CONV   0053  num.u64
0057       >  fun EQ     0035  timer.lua:37

The allocation at 0054 is trivially sunk due to tonumber() acting directly on the return value of the call to get_time_ns().
