### PR TITLE
Basic benchmarking tool with json output.

### DIFF
--- a/src/apps/basic/basic_apps.lua
+++ b/src/apps/basic/basic_apps.lua
@@ -33,6 +33,12 @@ function Source:stop ()
    packet.free(self.packet)
 end
 
+function benchmarkSourceToSink (c)
+   config.app(c, "source", Source)
+   config.link(c, "source.output -> sink.input")
+   return c
+end
+
 --- # `Join` app: Merge multiple inputs onto one output
 
 Join = {}
@@ -113,6 +119,16 @@ function Tee:push ()
          end
       end
    end
+end
+
+function benchmarkTee (c)
+   config.app(c, "source", Source)
+   config.app(c, "t1", Tee)
+   config.app(c, "t2", Tee)
+   config.link(c, "source.output -> t1.input")
+   config.link(c, "t1.output -> t2.input")
+   config.link(c, "t2.output -> sink.input")
+   return c
 end
 
 --- ### `Repeater` app: Send all received packets in a loop

--- a/src/lib/benchmark.lua
+++ b/src/lib/benchmark.lua
@@ -1,0 +1,83 @@
+module(..., package.seeall)
+
+--[[
+	Things that could be in the json blob
+	-- cpuid
+	-- git commit id
+	-- packet size
+	-- src pcap file
+	-- pcap md5/sha1
+	-- uname
+	-- libc version
+	-- description from benchmark definiton
+	-- comments for benchmark run, eg 'measure impact of adding 1/10/40 counters to link structure'
+]]
+
+function runbenchmarks(module, bname)
+	local vl = require(module)
+	local basic = require("apps.basic.basic_apps")
+	local counter = require("core.counter")
+	local pcap = require("apps.pcap.pcap")
+	local ffi = require("ffi")
+	local C = ffi.C
+
+	local rets = { }
+
+	local blaster = function(self, name, pcapfile)
+		config.app(self,  ("%s_pcap"):format(name), pcap.PcapReader, pcapfile)
+		config.app(self, name, basic.Repeater)
+		config.link(self, ("%s_pcap.output -> %s.input"):format(name,name))
+	end
+	local senv = {}
+	local S = require("syscall")
+	for k,v in pairs(S.environ()) do
+		if k:match('^SNABB_') then 
+			senv[k] = v
+		end
+	end
+	if not bname then
+		bname = "benchmark"
+	end
+	for i,v in pairs(vl) do
+		if i:find( ("^%s"):format(bname) ) then
+			engine.configure(config.new())
+			local c = config.new()
+			c.dur = 5
+			c.src = blaster
+			c.busywait = false
+			c.Hz = false
+			config.app(c, "sink", basic.Sink)
+			c = v(c)
+			engine.configure(c)
+			engine.busywait = c.busywait
+			engine.Hz = c.Hz
+			local start = C.get_monotonic_time()
+			engine.main({ duration = c.dur, no_report = true })
+			local finish = C.get_monotonic_time()
+			stats = {}
+			for i,v in pairs(engine.link_table) do
+				local l = i:match('-> sink%.(.*)')
+				if l then
+					stats[l] = {}
+					stats[l].packets = tonumber(counter.read(v.stats.rxpackets))
+					stats[l].bytes = tonumber(counter.read(v.stats.rxbytes))
+				end
+			end
+			table.insert(rets, {
+				duration = {
+					requested = c.dur,
+					actual = finish - start
+				},
+				busywait = c.busywait,
+				hz = c.Hz,
+				module = module,
+				test = i,
+				links = stats,
+				env = senv,
+				hostname = S.gethostname(),
+				date = os.date("!%Y-%m-%dT%TZ")
+			})
+		end
+	end
+	return rets
+end

--- a/src/lib/json.lua
+++ b/src/lib/json.lua
@@ -1,20 +1,45 @@
+-----------------------------------------------------------------------------
 -- JSON4Lua: JSON encoding / decoding support for the Lua language.
 -- json Module.
 -- Author: Craig Mason-Jones
--- Homepage: http://json.luaforge.net/
--- Version: 0.9.40
+-- Homepage: http://github.com/craigmj/json4lua/
+-- Version: 1.0.0
 -- This module is released under the MIT License (MIT).
+-- Please see LICENCE.txt for details.
 --
--- NOTE: This is only the decode functionality ripped out from JSON4Lua.
--- See: https://github.com/craigmj/json4lua
+-- USAGE:
+-- This module exposes two functions:
+--   json.encode(o)
+--     Returns the table / string / boolean / number / nil / json.null value as a JSON-encoded string.
+--   json.decode(json_string)
+--     Returns a Lua object populated with the data encoded in the JSON string json_string.
+--
+-- REQUIREMENTS:
+--   compat-5.1 if using Lua 5.0
+--
+-- CHANGELOG
+--   0.9.20 Introduction of local Lua functions for private functions (removed _ function prefix).
+--          Fixed Lua 5.1 compatibility issues.
+--      Introduced json.null to have null values in associative arrays.
+--          json.encode() performance improvement (more than 50%) through table.concat rather than ..
+--          Introduced decode ability to ignore /**/ comments in the JSON string.
+--   0.9.10 Fix to array encoding / decoding to correctly manage nil/null values in arrays.
+-----------------------------------------------------------------------------
 
-module(..., package.seeall)
-
+-----------------------------------------------------------------------------
+-- Imports and dependencies
+-----------------------------------------------------------------------------
 local math = require('math')
 local string = require("string")
 local table = require("table")
 
-local base = _G
+-----------------------------------------------------------------------------
+-- Module declaration
+-----------------------------------------------------------------------------
+local json = {}             -- Public namespace
+local json_private = {}     -- Private namespace
+
+-- Public functions
 
 -- Private functions
 local decode_scanArray
@@ -24,6 +49,65 @@ local decode_scanNumber
 local decode_scanObject
 local decode_scanString
 local decode_scanWhitespace
+local encodeString
+local isArray
+local isEncodable
+
+-----------------------------------------------------------------------------
+-- PUBLIC FUNCTIONS
+-----------------------------------------------------------------------------
+--- Encodes an arbitrary Lua object / variable.
+-- @param v The Lua object / variable to be JSON encoded.
+-- @return String containing the JSON encoding in internal Lua string format (i.e. not unicode)
+function json.encode (v)
+  -- Handle nil values
+  if v==nil then
+    return "null"
+  end
+
+  local vtype = type(v)
+
+  -- Handle strings
+  if vtype=='string' then
+    return '"' .. json_private.encodeString(v) .. '"'     -- Need to handle encoding in string
+  end
+
+  -- Handle booleans
+  if vtype=='number' or vtype=='boolean' then
+    return tostring(v)
+  end
+
+  -- Handle tables
+  if vtype=='table' then
+    local rval = {}
+    -- Consider arrays separately
+    local bArray, maxCount = isArray(v)
+    if bArray then
+      for i = 1,maxCount do
+        table.insert(rval, json.encode(v[i]))
+      end
+    else  -- An object, not an array
+      for i,j in pairs(v) do
+        if isEncodable(i) and isEncodable(j) then
+          table.insert(rval, '"' .. json_private.encodeString(i) .. '":' .. json.encode(j))
+        end
+      end
+    end
+    if bArray then
+      return '[' .. table.concat(rval,',') ..']'
+    else
+      return '{' .. table.concat(rval,',') .. '}'
+    end
+  end
+
+  -- Handle null values
+  if vtype=='function' and v==null then
+    return 'null'
+  end
+
+  assert(false,'encode attempt to encode unsupported type ' .. vtype .. ':' .. tostring(v))
+end
+
 
 --- Decodes a JSON string and returns the decoded value as a Lua data structure / value.
 -- @param s The string to scan.
@@ -31,10 +115,10 @@ local decode_scanWhitespace
 -- @param Lua object, number The object that was scanned, as a Lua table / string / number / boolean or nil,
 -- and the position of the first character after
 -- the scanned JSON object.
-function decode(s, startPos)
+function json.decode(s, startPos)
   startPos = startPos and startPos or 1
   startPos = decode_scanWhitespace(s,startPos)
-  base.assert(startPos<=string.len(s), 'Unterminated JSON encoded object found at position in [' .. s .. ']')
+  assert(startPos<=string.len(s), 'Unterminated JSON encoded object found at position in [' .. s .. ']')
   local curChar = string.sub(s,startPos,startPos)
   -- Object
   if curChar=='{' then
@@ -77,14 +161,14 @@ end
 -- @param startPos The starting position for the scan.
 -- @return table, int The scanned array as a table, and the position of the next character to scan.
 function decode_scanArray(s,startPos)
-  local array = {}        -- The return value
+  local array = {}  -- The return value
   local stringLen = string.len(s)
-  base.assert(string.sub(s,startPos,startPos)=='[','decode_scanArray called but array does not start at position ' .. startPos .. ' in string:\n'..s )
+  assert(string.sub(s,startPos,startPos)=='[','decode_scanArray called but array does not start at position ' .. startPos .. ' in string:\n'..s )
   startPos = startPos + 1
   -- Infinite loop for array elements
   repeat
     startPos = decode_scanWhitespace(s,startPos)
-    base.assert(startPos<=stringLen,'JSON String ended unexpectedly scanning array.')
+    assert(startPos<=stringLen,'JSON String ended unexpectedly scanning array.')
     local curChar = string.sub(s,startPos,startPos)
     if (curChar==']') then
       return array, startPos+1
@@ -92,8 +176,8 @@ function decode_scanArray(s,startPos)
     if (curChar==',') then
       startPos = decode_scanWhitespace(s,startPos+1)
     end
-    base.assert(startPos<=stringLen, 'JSON String ended unexpectedly scanning array.')
-    object, startPos = decode(s,startPos)
+    assert(startPos<=stringLen, 'JSON String ended unexpectedly scanning array.')
+    object, startPos = json.decode(s,startPos)
     table.insert(array,object)
   until false
 end
@@ -103,9 +187,9 @@ end
 -- @param string s The JSON string to scan.
 -- @param int startPos The starting position of the comment
 function decode_scanComment(s, startPos)
-  base.assert( string.sub(s,startPos,startPos+1)=='/*', "decode_scanComment called but comment does not start at position " .. startPos)
+  assert( string.sub(s,startPos,startPos+1)=='/*', "decode_scanComment called but comment does not start at position " .. startPos)
   local endPos = string.find(s,'*/',startPos+2)
-  base.assert(endPos~=nil, "Unterminated comment in string at " .. startPos)
+  assert(endPos~=nil, "Unterminated comment in string at " .. startPos)
   return endPos+2
 end
 
@@ -113,19 +197,18 @@ end
 -- Returns the appropriate Lua type, and the position of the next character to read.
 -- @param s The string being scanned.
 -- @param startPos The position in the string at which to start scanning.
--- @return object, int The object (true, false or nil) and the position at which the next character should be
+-- @return object, int The object (true, false or nil) and the position at which the next character should be 
 -- scanned.
 function decode_scanConstant(s, startPos)
   local consts = { ["true"] = true, ["false"] = false, ["null"] = nil }
   local constNames = {"true","false","null"}
 
-  for i,k in base.pairs(constNames) do
-    --print ("[" .. string.sub(s,startPos, startPos + string.len(k) -1) .."]", k)
+  for i,k in pairs(constNames) do
     if string.sub(s,startPos, startPos + string.len(k) -1 )==k then
       return consts[k], startPos + string.len(k)
     end
   end
-  base.assert(nil, 'Failed to scan constant from string ' .. s .. ' at starting position ' .. startPos)
+  assert(nil, 'Failed to scan constant from string ' .. s .. ' at starting position ' .. startPos)
 end
 
 --- Scans a number from the JSON encoded string.
@@ -141,13 +224,13 @@ function decode_scanNumber(s,startPos)
   local stringLen = string.len(s)
   local acceptableChars = "+-0123456789.e"
   while (string.find(acceptableChars, string.sub(s,endPos,endPos), 1, true)
-        and endPos<=stringLen
-        ) do
+  and endPos<=stringLen
+  ) do
     endPos = endPos + 1
   end
   local stringValue = 'return ' .. string.sub(s,startPos, endPos-1)
-  local stringEval = base.loadstring(stringValue)
-  base.assert(stringEval, 'Failed to scan number [ ' .. stringValue .. '] in JSON string at position ' .. startPos .. ' : ' .. endPos)
+  local stringEval = loadstring(stringValue)
+  assert(stringEval, 'Failed to scan number [ ' .. stringValue .. '] in JSON string at position ' .. startPos .. ' : ' .. endPos)
   return stringEval(), endPos
 end
 
@@ -161,11 +244,11 @@ function decode_scanObject(s,startPos)
   local object = {}
   local stringLen = string.len(s)
   local key, value
-  base.assert(string.sub(s,startPos,startPos)=='{','decode_scanObject called but object does not start at position ' .. startPos .. ' in string:\n' .. s)
+  assert(string.sub(s,startPos,startPos)=='{','decode_scanObject called but object does not start at position ' .. startPos .. ' in string:\n' .. s)
   startPos = startPos + 1
   repeat
     startPos = decode_scanWhitespace(s,startPos)
-    base.assert(startPos<=stringLen, 'JSON string ended unexpectedly while scanning object.')
+    assert(startPos<=stringLen, 'JSON string ended unexpectedly while scanning object.')
     local curChar = string.sub(s,startPos,startPos)
     if (curChar=='}') then
       return object,startPos+1
@@ -173,19 +256,35 @@ function decode_scanObject(s,startPos)
     if (curChar==',') then
       startPos = decode_scanWhitespace(s,startPos+1)
     end
-    base.assert(startPos<=stringLen, 'JSON string ended unexpectedly scanning object.')
+    assert(startPos<=stringLen, 'JSON string ended unexpectedly scanning object.')
     -- Scan the key
-    key, startPos = decode(s,startPos)
-    base.assert(startPos<=stringLen, 'JSON string ended unexpectedly searching for value of key ' .. key)
+    key, startPos = json.decode(s,startPos)
+    assert(startPos<=stringLen, 'JSON string ended unexpectedly searching for value of key ' .. key)
     startPos = decode_scanWhitespace(s,startPos)
-    base.assert(startPos<=stringLen, 'JSON string ended unexpectedly searching for value of key ' .. key)
-    base.assert(string.sub(s,startPos,startPos)==':','JSON object key-value assignment mal-formed at ' .. startPos)
+    assert(startPos<=stringLen, 'JSON string ended unexpectedly searching for value of key ' .. key)
+    assert(string.sub(s,startPos,startPos)==':','JSON object key-value assignment mal-formed at ' .. startPos)
     startPos = decode_scanWhitespace(s,startPos+1)
-    base.assert(startPos<=stringLen, 'JSON string ended unexpectedly searching for value of key ' .. key)
-    value, startPos = decode(s,startPos)
+    assert(startPos<=stringLen, 'JSON string ended unexpectedly searching for value of key ' .. key)
+    value, startPos = json.decode(s,startPos)
     object[key]=value
-  until false        -- infinite loop while key-value pairs are found
+  until false -- infinite loop while key-value pairs are found
 end
+
+-- START SoniEx2
+-- Initialize some things used by decode_scanString
+-- You know, for efficiency
+local escapeSequences = {
+  ["\\t"] = "\t",
+  ["\\f"] = "\f",
+  ["\\r"] = "\r",
+  ["\\n"] = "\n",
+  ["\\b"] = "\b"
+}
+setmetatable(escapeSequences, {__index = function(t,k)
+  -- skip "\" aka strip escape
+  return string.sub(k,2)
+end})
+-- END SoniEx2
 
 --- Scans a JSON string from the opening inverted comma or single quote to the
 -- end of the string.
@@ -196,33 +295,50 @@ end
 -- @param startPos The starting position of the scan.
 -- @return string, int The extracted string as a Lua string, and the next character to parse.
 function decode_scanString(s,startPos)
-  base.assert(startPos, 'decode_scanString(..) called without start position')
+  assert(startPos, 'decode_scanString(..) called without start position')
   local startChar = string.sub(s,startPos,startPos)
-  base.assert(startChar==[[']] or startChar==[["]],'decode_scanString called for a non-string')
-  local escaped = false
-  local endPos = startPos + 1
-  local bEnded = false
-  local stringLen = string.len(s)
-  repeat
-    local curChar = string.sub(s,endPos,endPos)
-    -- Character escaping is only used to escape the string delimiters
-    if not escaped then
-      if curChar==[[\]] then
-        escaped = true
-      else
-        bEnded = curChar==startChar
-      end
-    else
-      -- If we're escaped, we accept the current character come what may
-      escaped = false
+  -- START SoniEx2
+  -- PS: I don't think single quotes are valid JSON
+  assert(startChar == [["]] or startChar == [[']],'decode_scanString called for a non-string')
+  --assert(startPos, "String decoding failed: missing closing " .. startChar .. " for string at position " .. oldStart)
+  local t = {}
+  local i,j = startPos,startPos
+  while string.find(s, startChar, j+1) ~= j+1 do
+    local oldj = j
+    i,j = string.find(s, "\\.", j+1)
+    local x,y = string.find(s, startChar, oldj+1)
+    if not i or x < i then
+      i,j = x,y-1
     end
-    endPos = endPos + 1
-    base.assert(endPos <= stringLen+1, "String decoding failed: unterminated string at position " .. endPos)
-  until bEnded
-  local stringValue = 'return ' .. string.sub(s, startPos, endPos-1)
-  local stringEval = base.loadstring(stringValue)
-  base.assert(stringEval, 'Failed to load string [ ' .. stringValue .. '] in JSON4Lua.decode_scanString at position ' .. startPos .. ' : ' .. endPos)
-  return stringEval(), endPos
+    table.insert(t, string.sub(s, oldj+1, i-1))
+    if string.sub(s, i, j) == "\\u" then
+      local a = string.sub(s,j+1,j+4)
+      j = j + 4
+      local n = tonumber(a, 16)
+      assert(n, "String decoding failed: bad Unicode escape " .. a .. " at position " .. i .. " : " .. j)
+      -- math.floor(x/2^y) == lazy right shift
+      -- a % 2^b == bitwise_and(a, (2^b)-1)
+      -- 64 = 2^6
+      -- 4096 = 2^12 (or 2^6 * 2^6)
+      local x
+      if n < 0x80 then
+        x = string.char(n % 0x80)
+      elseif n < 0x800 then
+        -- [110x xxxx] [10xx xxxx]
+        x = string.char(0xC0 + (math.floor(n/64) % 0x20), 0x80 + (n % 0x40))
+      else
+        -- [1110 xxxx] [10xx xxxx] [10xx xxxx]
+        x = string.char(0xE0 + (math.floor(n/4096) % 0x10), 0x80 + (math.floor(n/64) % 0x40), 0x80 + (n % 0x40))
+      end
+      table.insert(t, x)
+    else
+      table.insert(t, escapeSequences[string.sub(s, i, j)])
+    end
+  end
+  table.insert(t,string.sub(j, j+1))
+  assert(string.find(s, startChar, j+1), "String decoding failed: missing closing " .. startChar .. " at position " .. j .. "(for string at position " .. startPos .. ")")
+  return table.concat(t,""), j+2
+  -- END SoniEx2
 end
 
 --- Scans a JSON string skipping all whitespace from the current start position.
@@ -239,3 +355,63 @@ function decode_scanWhitespace(s,startPos)
   end
   return startPos
 end
+
+--- Encodes a string to be JSON-compatible.
+-- This just involves back-quoting inverted commas, back-quotes and newlines, I think ;-)
+-- @param s The string to return as a JSON encoded (i.e. backquoted string)
+-- @return The string appropriately escaped.
+
+local escapeList = {
+    ['"']  = '\\"',
+    ['\\'] = '\\\\',
+    ['/']  = '\\/', 
+    ['\b'] = '\\b',
+    ['\f'] = '\\f',
+    ['\n'] = '\\n',
+    ['\r'] = '\\r',
+    ['\t'] = '\\t'
+}
+
+function json_private.encodeString(s)
+ local s = tostring(s)
+ return s:gsub(".", function(c) return escapeList[c] end) -- SoniEx2: 5.0 compat
+end
+
+-- Determines whether the given Lua type is an array or a table / dictionary.
+-- We consider any table an array if it has indexes 1..n for its n items, and no
+-- other data in the table.
+-- I think this method is currently a little 'flaky', but can't think of a good way around it yet...
+-- @param t The table to evaluate as an array
+-- @return boolean, number True if the table can be represented as an array, false otherwise. If true,
+-- the second returned value is the maximum
+-- number of indexed elements in the array.
+function isArray(t)
+  -- Next we count all the elements, ensuring that any non-indexed elements are not-encodable
+  -- (with the possible exception of 'n')
+  local maxIndex = 0
+  for k,v in pairs(t) do
+    if (type(k)=='number' and math.floor(k)==k and 1<=k) then -- k,v is an indexed pair
+      if (not isEncodable(v)) then return false end -- All array elements must be encodable
+      maxIndex = math.max(maxIndex,k)
+    else
+      if (k=='n') then
+        if v ~= table.getn(t) then return false end  -- False if n does not hold the number of elements
+      else -- Else of (k=='n')
+        if isEncodable(v) then return false end
+      end  -- End of (k~='n')
+    end -- End of k,v not an indexed pair
+  end  -- End of loop across all pairs
+  return true, maxIndex
+end
+
+--- Determines whether the given Lua object / table / variable can be JSON encoded. The only
+-- types that are JSON encodable are: string, boolean, number, nil, table and json.null.
+-- In this implementation, all other types are ignored.
+-- @param o The object to examine.
+-- @return boolean True if the object should be JSON encoded, false if it should be ignored.
+function isEncodable(o)
+  local t = type(o)
+  return (t=='string' or t=='boolean' or t=='number' or t=='nil' or t=='table') or (t=='function' and o==null)
+end
+
+return json

--- a/src/program/snabbmark/snabbmark.lua
+++ b/src/program/snabbmark/snabbmark.lua
@@ -9,10 +9,16 @@ local freelist      = require("core.freelist")
 local lib = require("core.lib")
 local ffi = require("ffi")
 local C = ffi.C
+local bench = require("lib.benchmark")
+local json = require("lib.json")
 
 function run (args)
    local command = table.remove(args, 1)
-   if command == 'basic1' and #args == 1 then
+   if command == 'lib' and (#args == 1 or #args == 2) then
+      for _, v in pairs(bench.runbenchmarks(unpack(args))) do
+         print(json.encode(v))
+      end
+   elseif command == 'basic1' and #args == 1 then
       basic1(unpack(args))
    elseif command == 'nfvconfig' and #args == 3 then
       nfvconfig(unpack(args))


### PR DESCRIPTION
Further to [688](https://github.com/SnabbCo/snabbswitch/issues/688)
This is a discussion point rather than a 'pull request'.

This provides go like benchmark functions that can be embedded in apps with json output. 
They are run from snabbmark. The work flow is envisaged to be something like

`make && sudo ./snabb snabbmark lib apps.basic.basic_apps >> test.json`
Make changes 
`make && sudo ./snabb snabbmark lib apps.basic.basic_apps >> test.json`

Then use jq to extract and compare benchmark runs.
jq -s 'sort_by(.date) | .[] | select(.hostname == "dock" and .test == "benchmarkSourceToSink" ) | "(.date) (.links.input.packets)"' tests.json

Import version 1.0.0 of json4lua and bring back encode
Add benchmarks for Tee and Source
Allow snabbmark to run benchmarks
