### PR TITLE
porting.md: Add notes about Snabb Switch porting & portability

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ Snabb Switch is written using these main techniques:
 
 Snabb Switch compiles into a stand-alone executable called
 `snabb`. This single binary includes multiple applications and runs on
-any modern Linux distribution. (You could think of it as a
-[busybox](http://en.wikipedia.org/wiki/BusyBox#Single_binary) for
-networking.)
+any modern [Linux/x86-64](src/doc/porting.md) distribution. (You could
+think of it as a [busybox](http://en.wikipedia.org/wiki/BusyBox#Single_binary)
+for networking.)
 
 ## How is it being used?
 

--- a/src/core/main.lua
+++ b/src/core/main.lua
@@ -32,6 +32,10 @@ debug_on_error = false
 function main ()
    zone("startup")
    require "lib.lua.strict"
+   -- Warn on unsupported platforms
+   if ffi.arch ~= 'x64' or ffi.os ~= 'Linux' then
+      io.stderr:write("Warning: "..ffi.os.."/"..ffi.arch.." is not a supported platform\n")
+   end
    initialize()
    local args = parse_command_line()
    local program = programname(args[1])

--- a/src/core/main.lua
+++ b/src/core/main.lua
@@ -34,7 +34,7 @@ function main ()
    require "lib.lua.strict"
    -- Warn on unsupported platforms
    if ffi.arch ~= 'x64' or ffi.os ~= 'Linux' then
-      io.stderr:write("Warning: "..ffi.os.."/"..ffi.arch.." is not a supported platform\n")
+      error("fatal: "..ffi.os.."/"..ffi.arch.." is not a supported platform\n")
    end
    initialize()
    local args = parse_command_line()

--- a/src/doc/porting.md
+++ b/src/doc/porting.md
@@ -1,0 +1,67 @@
+# Porting Snabb Switch
+
+## Background
+
+Snabb Switch is a low-level program. The source code includes device
+drivers, assembler code, and optimizations for specific CPU families.
+
+Simplicity, performance, and portability are all important. However,
+simplicity and performance have been more *urgent* than portability.
+For this reason we have allowed ourselves to focus on:
+
+- Linux/x86-64
+- The most popular commodity network adapters
+- Optimizations for Intel "Sandy Bridge" and later processors
+
+This allows us to create simple and performant software but it also
+means that porting work is necessary to support further platforms.
+
+## How to port Snabb Switch
+
+Suppose you want to run Snabb Switch on a new CPU architecture (i386,
+ARM, PPC, ...) or a new operating system (FreeBSD, SmartOS, Windows,
+...). How do you do it?
+
+The short answer is that you run the test suite, see what breaks, and
+keep fixing things until the functional tests succeed and the
+performance tests yield adequate results. Once you are satisfied with
+the results you have ported Snabb Switch: congratulations!
+
+You can submit your port in a Pull Request to have it merged
+"upstream" onto the master branch. This will be accepted if the
+community deems the port to be a net benefit. In that case the
+project will also acquire the relevant hardware and provide automatic
+test coverage via our [Continuous Integration](http://mr.gy/blog/snabb-ci.html)
+system.
+
+If you are actively working on a port that you plan to complete then
+you can advertise this fact by adding your development branch to
+[branches.md](branches.md). This will help potential contributions to
+find your work.
+
+If you are not sure where to start then you are welcome gather
+feedback by filing an Issue or a Pull Request with some draft code.
+However, don't expect portability code to be merged until it is
+complete enough to be useful for end-users and has test coverage. (If
+you update the C sources with `#ifdef WIN32` sections then this only
+becomes interesting for the master branch once it means that users can
+actually run the software on the new platform.)
+
+## Notes on challenges
+
+Here are a few challenges you are likely to encounter when porting
+Snabb Switch:
+
+- The `memory` module encodes the physical address of DMA memory into its virtual address using a 64-bit tagging scheme. This would need to be adapted for a 32-bit CPU.
+- Device drivers depend on allocating physically contiguous memory in blocks of at least 10KB.
+- Virtio-net code assumes a strict (x86-like) memory model that does not reorder stores. If your processor provides a more relaxed memory model then additional hardware memory barrier operations will be needed.
+- The shm/counter mechanism assumes that the processor loads and stores 64-bit values atomically. If your processor does not provide atomic 64-bit loads and stores then additional synchronization may be needed.
+- Certain optimizations depend on specific instruction set extensions such as AVX2. These optimizations may need to be ported in order to achieve adequate performance. (Particularly: multiple SIMD-optimized IP checksum routines.)
+- Certain functions may only be available platform-specific optimized variants. You would either need to live without these routines, or write a generic fallback routine, or write a new optimized variant. (Particularly: AES-GCM encryption with Intel AES-NI instructions.)
+
+Like we said: Snabb Switch is a low-level piece of
+software. Portability is important but simplicity and performance are
+urgent.
+
+Good luck!
+

--- a/src/doc/porting.md
+++ b/src/doc/porting.md
@@ -1,53 +1,21 @@
 # Porting Snabb Switch
 
-## Background
+Snabb Switch targets Linux/x86-64 on the master branch. The source
+code includes device drivers, assembler code, and optimization for
+specific CPU families.
 
-Snabb Switch is a low-level program. The source code includes device
-drivers, assembler code, and optimizations for specific CPU families.
+You are welcome to port Snabb Switch to a new platform. To do this you
+can create a branch for your port and advertise this in
+[branches.md](branches.md). See below for some technical tips.
 
-Simplicity, performance, and portability are all important. However,
-simplicity and performance have been more *urgent* than portability.
-For this reason we have allowed ourselves to focus on:
+Currently there is no roadmap for supporting more platforms on the
+master branch. The first step in this direction would be to have a
+well-maintained port that is important for users.
 
-- Linux/x86-64
-- The most popular commodity network adapters
-- Optimizations for Intel "Sandy Bridge" and later processors
+The master branch accepts code that is specific to Linux/x86-64. It
+does not accept code intended for other platforms.
 
-This allows us to create simple and performant software but it also
-means that porting work is necessary to support further platforms.
-
-## How to port Snabb Switch
-
-Suppose you want to run Snabb Switch on a new CPU architecture (i386,
-ARM, PPC, ...) or a new operating system (FreeBSD, SmartOS, Windows,
-...). How do you do it?
-
-The short answer is that you run the test suite, see what breaks, and
-keep fixing things until the functional tests succeed and the
-performance tests yield adequate results. Once you are satisfied with
-the results you have ported Snabb Switch: congratulations!
-
-You can submit your port in a Pull Request to have it merged
-"upstream" onto the master branch. This will be accepted if the
-community deems the port to be a net benefit. In that case the
-project will also acquire the relevant hardware and provide automatic
-test coverage via our [Continuous Integration](http://mr.gy/blog/snabb-ci.html)
-system.
-
-If you are actively working on a port that you plan to complete then
-you can advertise this fact by adding your development branch to
-[branches.md](branches.md). This will help potential contributions to
-find your work.
-
-If you are not sure where to start then you are welcome gather
-feedback by filing an Issue or a Pull Request with some draft code.
-However, don't expect portability code to be merged until it is
-complete enough to be useful for end-users and has test coverage. (If
-you update the C sources with `#ifdef WIN32` sections then this only
-becomes interesting for the master branch once it means that users can
-actually run the software on the new platform.)
-
-## Notes on challenges
+## Technical tips
 
 Here are a few challenges you are likely to encounter when porting
 Snabb Switch:


### PR DESCRIPTION
This is an attempt to set realistic expectations for users and developers about Snabb Switch portability both now and in the future. This is to avoid causing confusion as we have in #701 for example.

Summary:
- Added `doc/porting.md` to summarize the situation.
- Link from top-level README.
- Print a warning at startup when running on unsupported platform.

Feedback welcome!