### PR TITLE
snabbswitch.c: Compile error on non-64bit platforms

### DIFF
--- a/src/core/snabbswitch.c
+++ b/src/core/snabbswitch.c
@@ -4,6 +4,10 @@
 #include "lualib.h"
 #include "lauxlib.h"
 
+#if sizeof(uint64_t) != sizeof(uintptr_t)
+#error "Snabb only supports 64-bit platforms. See https://github.com/SnabbCo/snabbswitch/blob/master/src/doc/porting.md"
+#end
+
 int argc;
 char** argv;
 

--- a/src/core/snabbswitch.c
+++ b/src/core/snabbswitch.c
@@ -4,9 +4,11 @@
 #include "lualib.h"
 #include "lauxlib.h"
 
-#if sizeof(uint64_t) != sizeof(uintptr_t)
-#error "Snabb only supports 64-bit platforms. See https://github.com/SnabbCo/snabbswitch/blob/master/src/doc/porting.md"
-#end
+#include <stdint.h>
+
+#if UINTPTR_MAX != UINT64_MAX
+#error "64-bit word size required. See doc/porting.md."
+#endif
 
 int argc;
 char** argv;


### PR DESCRIPTION
Provide a clear compilation error on platforms that don't have a 64bit integer size, for example i386. Include a link to porting information so that the user will understand that this is not an arbitrary
restriction.

This does not work: I did not formulate the C preprocessor directive correctly. Can somebody tell me how to write it in a way that works?

This depends on the `porting.md` document from #712 to land upstream.

See also #700 #750 cc @kbara.