### PR TITLE
[wip] Ipv6 tunnel diagnostics

### DIFF
--- a/src/apps/ipv6/README.md
+++ b/src/apps/ipv6/README.md
@@ -98,3 +98,27 @@ the L2TPv3 header will be overwritten with this value.
 
 *Optional*. Destination MAC as a string. Not required if overwritten by
 an app such as `nd_light`.
+
+### Counters
+
+— Key **drop_bad_length**
+
+Ingress packets dropped due to invalid length (packet too short).
+
+— Key **drop_bad_protocol**
+
+Ingress packets dropped due to unrecognized IPv6 protocol ID.
+
+— Key **drop_bad_cookie**
+
+Ingress packets dropped due to wrong cookie value.
+
+— Key **drop_bad_remote_address**
+
+Ingress packets dropped due to wrong remote IPv6 endpoint address.
+
+— Key **drop_bad_local_address**
+
+Ingress packets dropped due to wrong local IPv6 endpoint address.
+
+

--- a/src/apps/ipv6/README.md.src
+++ b/src/apps/ipv6/README.md.src
@@ -115,3 +115,27 @@ the L2TPv3 header will be overwritten with this value.
 
 *Optional*. Destination MAC as a string. Not required if overwritten by
 an app such as `nd_light`.
+
+### Counters
+
+— Key **drop_bad_length**
+
+Ingress packets dropped due to invalid length (packet too short).
+
+— Key **drop_bad_protocol**
+
+Ingress packets dropped due to unrecognized IPv6 protocol ID.
+
+— Key **drop_bad_cookie**
+
+Ingress packets dropped due to wrong cookie value.
+
+— Key **drop_bad_remote_address**
+
+Ingress packets dropped due to wrong remote IPv6 endpoint address.
+
+— Key **drop_bad_local_address**
+
+Ingress packets dropped due to wrong local IPv6 endpoint address.
+
+


### PR DESCRIPTION
Add counters to the `keyed_ipv6_tunnel` app:
- `drop_bad_cookie`
- `drop_bad_length`
- `drop_bad_local_address`
- `drop_bad_protocol`
- `drop_bad_remote_address`

This is to make the reasons for packet drops more transparent.
