### PR TITLE
[sketch] Multi-process Snabb Switch, yet again

### DIFF
--- a/src/core/spinlock.dasl
+++ b/src/core/spinlock.dasl
@@ -1,0 +1,46 @@
+module(...,package.seeall)
+
+local dasm = require("dasm")
+local ffi = require("ffi")
+
+| .arch x64
+| .actionlist actions
+| .globalnames globalnames
+
+local function generate(Dst)
+   Dst:growpc(16)
+
+   | .align 16
+   |->lock:
+   -- attempt to acquire
+   | mov eax, 1
+   | xchg eax, dword [rdi]
+   | test eax, eax		-- was it 0 (unlocked)?
+   | jnz >1			-- no, go spin
+   | ret
+   -- spin
+   |1:
+   | pause
+   | cmp dword [rdi], 1		-- does it look locked?
+   | je <1			-- spin if it does
+   | jmp ->lock			-- otherwise try to acquire
+
+   | .align 16
+   |->unlock:
+   | mov dword [rdi], 0
+   | ret
+end
+
+local Dst, globals = dasm.new(actions, nil, nil, 1 + #globalnames)
+generate(Dst)
+local code, size = Dst:build()
+
+if nil then
+   dasm.dump(code, size)
+end
+
+local entry = dasm.globals(globals, globalnames)
+
+return setmetatable ({ lock = ffi.cast("void (*)(int32_t *)", entry.lock),
+		       unlock = ffi.cast("void (*)(int32_t *)", entry.unlock)
+		     }, {_anchor = code})


### PR DESCRIPTION
I am creating this PR to serve as a place to work out yet another approach to making a multi-process Snabb Switch.  I'm mainly just talking to myself here, but please feel free to comment.
### Background

Recall that Snabb Switch talks to network controllers directly.  It is evidently common for these controllers, such as the Intel 82599 10G Ethernet controller, to use physical addresses when dealing with memory.  Linux offers the special file `/proc/self/pagemap`, which can be read to determine the physical page frame that a given virtual page is mapped to.  However, the standard 4K page is not large enough to contain even a single jumbo Ethernet frame.

You may be wondering why the 4K page size is an issue.  After all, it it trivial to use malloc or mmap to get as large a memory region as desired.  The problem is that there is no way to ensure that the pages that make up a given memory region so allocated are _physically_ contiguous.  To solve this, we can use huge pages to ensure that we have sufficient contiguous physical memory.  The typical huge page size is 2MB.

Packet buffers thus reside in a collection of individual Linux huge pages.  Each huge page is allocated individually, because, just as with 4K pages, there is no way to guarantee that multiple huge pages making up a mapping will be physically contiguous in memory.  Each huge page is allocated via shmget, which supports the `SHM_HUGETLB` flag to indicate that the segment should be comprised of huge pages.  Segments are subsequently mapped (via shmat) to a virtual address that is derived in a simple way from that huge page's physical address.  (But see #751, which proposes a scheme using mmap instead.)  This method thus allows the physical addresses of sufficiently large packet buffers to be provided to the network controller, which can then DMA data to or from the buffer in question.

Note that the System V shared memory API is being used for packet buffers solely because it is a way to allocate and map memory backed by huge pages.  Actually sharing the memory has not been a concern to date.

Packets are managed with a process-wide freelist.  `packet.allocate()` obtains a packet from this freelist (possibly creating a batch of new packets if needed). Similarly, `packet.free()` returns a packet to the freelist.  The total number of `struct packet` instances that may be allocated is bounded so that the freelist can be made long enough to guarantee that it will never overflow.  Note that packet memory is never returned to the operating system.
### Multi-process considerations

With that background, we can now attempt to identify some problems that must be solved in order for a multi-process Snabb Switch to work.
#### Links

A link is a ring buffer.  A basic ring buffer is already safe for concurrent access as long as there is only a single producer and a single consumer.  http://www.cse.cuhk.edu.hk/~pclee/www/pubs/ipdps10.pdf describes enhancing a basic ring buffer to be more cache-efficient on multi-core systems.

The design described #601 uses a specialized type of link for transferring packets between processes. I believe that the need for a specialized link can be avoided; see below.

Links are already allocated via `core.shm` API (as "links/some-name"), and this seems like a perfectly good scheme.
#### Packet lifetime management

As previously mentioned, Snabb Switch uses a process-wide freelist to manage packets.  This simple scheme is inadequate when multiple processes are involved.  The design in #601 introduces the idea of a packet payback channel so that a process that sends many packets but receives few (or none) won't starve.

An alternative scheme might be a shared packet freelist that will be protected by a lock (probably a user-level spinlock) and accessed by a group of cooperating Snabb Switch processes.  When a private (per-process) freelist is empty, it would obtain a batch of new packets from the shared freelist.  When the private freelist gets too full, it would return a batch of packets to the shared freelist.  A suitably large batch size would minimize the per-packet cost of taking the lock of the shared freelist. There would need to be an upper limit on the number of packets allocated by all of the cooperating processes to ensure that freelists can be made large enough not to overflow.

Allocating all packet buffers at once at startup time might be a worthwhile simplification.  This might avoid potential complexity involved in safely supporting dynamic allocation of packet memory from multiple processes. (But the design in #751 seems like it would make allocation from multiple processes fairly straightforward.)
#### Shared memory considerations

Packet data is already allocated in shared memory segments (although, as mentioned, this is  essentially coincidental).  Given the identifier returned by shmget, a process can use shmat to map that segment into its address space.  The only trick is to inform other processes of the shared memory segment identifiers and the virtual address to which each segment should be mapped.  See, for instance, javierguerragiraldez@e7a08b9209104cdd3d713eb6a05654d169d0544b, for one possible approach, which uses a memory-mapped file to store the shmid -> addresss mapping, and uses a SIGSEGV handler to map the shared memory segments into the local process on demand.

The already mentioned #751 design can create a memory-mapped "file" (the scare quotes are because the files are on a special hugetlbfs file system, which isn't actually written to persistent storage) for each huge page.  The file is conveniently named after the huge page's physical address.  Here also one could use a SIGSEGV handler to map these files into the local process's virtual address space on demand.
### Other issues
1. The configuration language needs to be able define an app network which consists of multiple processes.
2. There needs to be some way to reconfigure the app network on-the-fly.
3. For user convenience, it should be possible to start an app network with a single command, but it may also be valuable to allow processes to be started individually.  It is thus probably undesirable to require that the cooperating Snabb Switch processes have any sort of parent to child relationship.
4. It might make sense to have a "director" process that monitors the others, and does whatever periodic housekeeping tasks may be required.  Perhaps this process would handle reconfiguration.  See #757.

Just to make people laugh, I will mention that instead of shared memory, one could consider the use of Unix domain sockets. I doubt that this would be a good solution if we want to be really fast (so that we could keep up with a 100G Ethernet controller, for instance). There would be a cost of at least two system calls per-packet (a write and a read), not to mention the cost of copying packet data at least a couple of time.
