### PR TITLE
Print out error message in case PCAP app couldn't open file

### DIFF
--- a/src/apps/pcap/pcap.lua
+++ b/src/apps/pcap/pcap.lua
@@ -33,7 +33,8 @@ end
 PcapWriter = {}
 
 function PcapWriter:new (filename)
-   local file = io.open(filename, "w")
+   local file, errno = io.open(filename, "w+")
+   if errno then error(errno) end
    pcap.write_file_header(file)
    return setmetatable({file = file}, {__index = PcapWriter})
 end

--- a/src/apps/pcap/pcap.lua
+++ b/src/apps/pcap/pcap.lua
@@ -32,8 +32,10 @@ end
 
 PcapWriter = {}
 
-function PcapWriter:new (filename)
-   local file, errno = io.open(filename, "w+")
+function PcapWriter:new (filename, arg)
+   local conf = arg and config.parse_app_arg(arg) or {}
+   local mode = conf.overwrite and "w+" or "w"
+   local file, errno = io.open(filename, mode)
    if errno then error(errno) end
    pcap.write_file_header(file)
    return setmetatable({file = file}, {__index = PcapWriter})


### PR DESCRIPTION
I was getting an error, `file` is nil, due to a permissions problem:

```
lib/pcap/pcap.lua:36: attempt to index local 'file' (a nil value)
stack traceback:
        core/main.lua:122: in function '__index'
        lib/pcap/pcap.lua:36: in function 'write_file_header'
        apps/pcap/pcap.lua:36: in function 'new'
        core/app.lua:165: in function <core/app.lua:162>
        core/app.lua:201: in function 'apply_config_actions'
        core/app.lua:110: in function 'configure'
```

Printing out the error status `io.open` returns in case couldn't open a file can be helpful to figure out what is going on:

```
compiled binding table ../data/binding-table.o is up to date.
apps/pcap/pcap.lua:35: /tmp/endoutv4.pcap: Permission denied
stack traceback:
        core/main.lua:122: in function <core/main.lua:120>
        [C]: in function 'error'
        apps/pcap/pcap.lua:35: in function 'new'
        core/app.lua:165: in function <core/app.lua:162>
        core/app.lua:201: in function 'apply_config_actions'
        core/app.lua:110: in function 'configure'
```

Beside this I changed the open mode to "w+", as I understand it's preferred to overwrite a file in case it exits.