### PR TITLE
branches.md: Add mellanox and multiproc branches

### DIFF
--- a/src/doc/branches.md
+++ b/src/doc/branches.md
@@ -79,14 +79,14 @@ The current state of each branch with respect to master is visible here:
 
 #### mellanox
 
-    BRANCH: mellanox git://github.com/lukego/mellanox
+    BRANCH: mellanox git://github.com/lukego/snabbswitch
     Mellanox ConnectX device driver development.
 
     Maintainer: Luke Gorrie <luke@snabb.co>
 
 #### multiproc
 
-    BRANCH: multiproc git://github.com/lukego/multiproc
+    BRANCH: multiproc git://github.com/lukego/snabbswitch
     Multiple process parallel processing development branch.
 
     Maintainer: Luke Gorrie <luke@snabb.co>

--- a/src/doc/branches.md
+++ b/src/doc/branches.md
@@ -77,3 +77,17 @@ The current state of each branch with respect to master is visible here:
     
     Maintainer: Alexander Gall <gall@switch.ch>
 
+#### mellanox
+
+    BRANCH: mellanox git://github.com/lukego/mellanox
+    Mellanox ConnectX device driver development.
+
+    Maintainer: Luke Gorrie <luke@snabb.co>
+
+#### multiproc
+
+    BRANCH: multiproc git://github.com/lukego/multiproc
+    Multiple process parallel processing development branch.
+
+    Maintainer: Luke Gorrie <luke@snabb.co>
+


### PR DESCRIPTION
Register two new branches for collecting and integrating feature branches that incrementally create a couple of large new features:

- `mellanox`: Collect the changes for ConnectX-4 support until ready for master. See #706.
- `multiproc`: Collect the changes for multiple process parallel processing until ready for master. See #722.

The main intention of creating integration branches is to make it easier to break down the development into smaller independent pieces and have a place where we can fit them together.

I propose to be the subsystem maintainer for `multiproc` and `mellanox` branches. So if somebody sends a PR on these topics then I would be the upstream person merging it onto the appropriate branch. Then once the branch as a whole is in good shape I would send a PR and ask somebody else to be upstream for that.

So the overall workflow would be like:

`feature -> multiproc/mellanox -> max-next/wingo-next/kbara-next -> next -> master`

This allows individual feature development branches to be reviewed and accepted even before the subsystem they contribute to has landed further upstream.

Hope it is a good workflow!