### PR TITLE
Add lwaftr branch.

### DIFF
--- a/src/doc/branches.md
+++ b/src/doc/branches.md
@@ -77,3 +77,10 @@ The current state of each branch with respect to master is visible here:
     
     Maintainer: Alexander Gall <gall@switch.ch>
 
+#### lwaftr
+
+    BRANCH: lwaftr git://github.com/Igalia/snabbswitch
+    Lightweight 4-over-6 AFTR application development branch.
+
+    Maintainer: Collectively maintained by lwAFTR application developers.
+    Next hop: kbara-next


### PR DESCRIPTION
See #802 for the lwaftr merge.  The current HEAD of the `lwaftr` branch is the same as the current HEAD in that PR.  `lwaftr` will be the development head for new lwaftr development and will not be rebased.  We will merge in from `master` monthly, and will propagate changes back to master through `kbara-next`.

The only big open question to manage for me is how to manage changes to core.  Obviously we will try to avoid them, but let's say we need an urgent fix to something in core and have no time to talk about it with upstream.  What do we do?  Do it in `lwaftr` directly and hope that we'll be able to submit upstream, or revert by the time we go to send to `kbara-next`?  Switch development to a new branch and sort things out later?  To me it's not quite clear.  Suggestions welcome :)