### PR TITLE
snabbmark: Add "mp-ring" multiprocess benchmark

### DIFF
--- a/src/program/snabbmark/mp.lua
+++ b/src/program/snabbmark/mp.lua
@@ -1,0 +1,57 @@
+-- Multiprocess benchmarks
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
+module(..., package.seeall)
+
+local ffi = require("ffi")
+local C = ffi.C
+local S = require("syscall")
+
+-- Ring benchmark:
+-- See how quickly packets are cycled through a ring of processes.
+--
+-- Each process copies packets from its input to its output link. Each
+-- link is populated with an initial "burst" of packets.
+function mp_ring (nprocesses, totalpackets, burstpackets)
+   nprocesses = tonumber(nprocesses)
+   totalpackets = tonumber(totalpackets)
+   burstpackets = tonumber(burstpackets)
+   links = {}
+   -- Create links to connect the processes in a loop
+   for i = 0, nprocesses-1 do
+      links[i] = link.new(tostring(i))
+      for j = 1, burstpackets do
+         link.transmit(links[i], packet.allocate())
+      end
+   end
+   -- Create per-process counters
+   local counters = ffi.cast("uint64_t *",
+                             memory.dma_alloc(nprocesses*ffi.sizeof("uint64_t")))
+   -- Start child processes
+   local start = C.get_time_ns()
+   for i = 0, nprocesses-1 do
+      if S.fork() == 0 then
+         -- terminate when parent does
+         S.prctl("set_pdeathsig", "hup")
+         local input = links[i]
+         local output = links[(i+1) % nprocesses]
+         while counters[i] < totalpackets do
+            if not link.empty(input) and not link.full(output) then
+               link.transmit(output, link.receive(input))
+               counters[i] = counters[i] + 1
+            end
+            -- Sync registers with memory
+            core.lib.compiler_barrier()
+         end
+         os.exit(0)
+      end
+   end
+   -- Spin until enough packets have been processed
+   while counters[0] < totalpackets do
+      core.lib.compiler_barrier()
+   end
+   local finish = C.get_time_ns()
+   local seconds = tonumber(finish-start)/1e9
+   local packets = tonumber(counters[0])
+   print(("%7.2f Mpps ring throughput per process"):format(packets/seconds/1e6))
+end

--- a/src/program/snabbmark/mp.lua
+++ b/src/program/snabbmark/mp.lua
@@ -6,50 +6,105 @@ module(..., package.seeall)
 local ffi = require("ffi")
 local C = ffi.C
 local S = require("syscall")
+local pmu = require("lib.pmu")
+local lib = require("core.lib")
 
 -- Ring benchmark:
 -- See how quickly packets are cycled through a ring of processes.
 --
 -- Each process copies packets from its input to its output link. Each
 -- link is populated with an initial "burst" of packets.
-function mp_ring (nprocesses, totalpackets, burstpackets)
-   nprocesses = tonumber(nprocesses)
-   totalpackets = tonumber(totalpackets)
-   burstpackets = tonumber(burstpackets)
+function mp_ring (args)
+   local function usage ()
+      print(require("program.snabbmark.README_mp_inc"))
+      os.exit(1)
+   end
+   local long_opts = {
+      help = "h",
+      mode = "m",
+      processes = "n",
+      packets = "p",
+      burst = "b",
+      events = "e",
+      read = "r",
+      write = "w"
+   }
+   local c = {
+      mode = "basic",
+      processes = 2,
+      packets = 100e6,
+      burst = 100,
+      pmuevents = false,
+      readbytes = 0,
+      writebytes = 0
+   }
+   local opt = {}
+   function opt.m (arg) c.mode = arg end
+   function opt.n (arg) c.processes = tonumber(arg) end
+   function opt.p (arg) c.packets = tonumber(arg) end
+   function opt.b (arg) c.burst = tonumber(arg) end
+   function opt.e (arg) c.pmuevents = arg end
+   function opt.r (arg) c.readbytes = tonumber(arg) end
+   function opt.w (arg) c.writebytes = tonumber(arg) end
+   function opt.h (arg) usage() end
+   local leftover = lib.dogetopt(args, opt, "hn:p:b:e:r:w:", long_opts)
+   if #leftover > 0 then usage () end
+   -- Print summary of configuration
+   print("Benchmark configuration:")
+   for k, v in pairs(c) do
+      print(("%12s: %s"):format(k,v))
+   end
    links = {}
    -- Create links to connect the processes in a loop
-   for i = 0, nprocesses-1 do
+   for i = 0, c.processes-1 do
       links[i] = link.new(tostring(i))
-      for j = 1, burstpackets do
+      for j = 1, c.burst do
          link.transmit(links[i], packet.allocate())
       end
    end
    -- Create per-process counters
    local counters = ffi.cast("uint64_t *",
-                             memory.dma_alloc(nprocesses*ffi.sizeof("uint64_t")))
+                             memory.dma_alloc(c.processes*ffi.sizeof("uint64_t")))
    -- Start child processes
+   if c.pmuevents then error("PMU support NYI") end
    local start = C.get_time_ns()
-   for i = 0, nprocesses-1 do
+   for i = 0, c.processes-1 do
       if S.fork() == 0 then
          -- Child <i> has affinity to CPU core <i>
          S.sched_setaffinity(0, i)
          -- terminate when parent does
          S.prctl("set_pdeathsig", "hup")
          local input = links[i]
-         local output = links[(i+1) % nprocesses]
-         while counters[i] < totalpackets do
-            if not link.empty(input) and not link.full(output) then
-               link.transmit(output, link.receive(input))
-               counters[i] = counters[i] + 1
+         local output = links[(i+1) % c.processes]
+         if c.mode == "basic" then
+            -- Simple reference implementation in idiomatic Lua.
+            local acc = ffi.new("uint8_t[1]")
+            while counters[i] < c.packets do
+               if not link.empty(input) and not link.full(output) then
+                  local p = link.receive(input)
+                  -- Read some packet data
+                  for j = 0, c.readbytes do
+                     acc[0] = acc[0] + p.data[j]
+                  end
+                  -- Write some packet data
+                  for j = 0, c.writebytes do
+                     p.data[j] = i
+                  end
+                  link.transmit(output, p)
+                  counters[i] = counters[i] + 1
+               end
+               -- Sync registers with memory
+               core.lib.compiler_barrier()
             end
-            -- Sync registers with memory
-            core.lib.compiler_barrier()
+         else
+            print("mode not recognized: " .. c.mode)
+            os.exit(1)
          end
          os.exit(0)
       end
    end
    -- Spin until enough packets have been processed
-   while counters[0] < totalpackets do
+   while counters[0] < c.packets do
       core.lib.compiler_barrier()
    end
    local finish = C.get_time_ns()

--- a/src/program/snabbmark/mp.lua
+++ b/src/program/snabbmark/mp.lua
@@ -31,6 +31,8 @@ function mp_ring (nprocesses, totalpackets, burstpackets)
    local start = C.get_time_ns()
    for i = 0, nprocesses-1 do
       if S.fork() == 0 then
+         -- Child <i> has affinity to CPU core <i>
+         S.sched_setaffinity(0, i)
          -- terminate when parent does
          S.prctl("set_pdeathsig", "hup")
          local input = links[i]

--- a/src/program/snabbmark/snabbmark.lua
+++ b/src/program/snabbmark/snabbmark.lua
@@ -22,6 +22,8 @@ function run (args)
       solarflare(unpack(args))
    elseif command == 'intel1g' and #args >= 2 and #args <= 3 then
       intel1g(unpack(args))
+   elseif command == 'mp-ring' then
+      require("program.snabbmark.mp").mp_ring(unpack(args))
    else
       print(usage) 
       main.exit(1)

--- a/src/program/snabbmark/snabbmark.lua
+++ b/src/program/snabbmark/snabbmark.lua
@@ -23,7 +23,7 @@ function run (args)
    elseif command == 'intel1g' and #args >= 2 and #args <= 3 then
       intel1g(unpack(args))
    elseif command == 'mp-ring' then
-      require("program.snabbmark.mp").mp_ring(unpack(args))
+      require("program.snabbmark.mp").mp_ring(args)
    else
       print(usage) 
       main.exit(1)


### PR DESCRIPTION
Add a new `mp-ring` benchmark for measuring the performance of basic multi-process link operations. The benchmark forks worker processes and cycles packets through them via a series of links.

This particular benchmark "just works" in multiprocess mode without any changes to the Snabb core because packets and links are already allocated in shared memory, that is done before the children are forked, and freelists are not used because the same packets keep circulating from link to link.

The intention of this benchmark is to be a framework for investigating any fundamental performance limits of inter-process traffic (see #801) and for reproducing specific issues like inter-core conflicts on the cache-coherence level. The code uses a simple and naive Lua implementation ("basic") but can accommodate more sophisticated implementations (in the spirit of the asm code in #603). This could make it a useful tool for prototyping code like 100G mux/demux (#691).

(I have made no attempt to optimize this benchmark. That is another activity entirely.)

cc @xrme @kbara
#### Examples

```
[luke@lugano-1:~/git/snabbswitch/src]$ make && sudo ./snabb snabbmark mp-ring --processes 1
make: 'snabb' is up to date.
Benchmark configuration:
       burst: 100
  writebytes: 0
   processes: 1
   readbytes: 0
     packets: 100000000
        mode: basic
   pmuevents: false
  65.28 Mpps ring throughput per process

[luke@lugano-1:~/git/snabbswitch/src]$ make && sudo ./snabb snabbmark mp-ring --processes 2
make: 'snabb' is up to date.
Benchmark configuration:
       burst: 100
  writebytes: 0
   processes: 2
   readbytes: 0
     packets: 100000000
        mode: basic
   pmuevents: false
   5.44 Mpps ring throughput per process

[luke@lugano-1:~/git/snabbswitch/src]$ make && sudo ./snabb snabbmark mp-ring --processes 3
make: 'snabb' is up to date.
Benchmark configuration:
       burst: 100
  writebytes: 0
   processes: 3
   readbytes: 0
     packets: 100000000
        mode: basic
   pmuevents: false
   4.39 Mpps ring throughput per process
```
#### Usage

```
Usage:
  snabbmark mp-ring [OPTIONS]

  -m MODE, --mode MODE
                             Mode of operation. Determines which code
                             is used for the worker processes.
                             Currently supported values:
                               basic -- idiomatic Lua code [default]
  -n PROCESSES, --processes PROCESSES
                             Number of worker processes.
                             Default: 2
  -p PACKETS, --packets PACKETS
                             Number of packets processed by each worker.
                             Default: 100e6 (one hundred million)
  -b BURST, --burst BURST
                             Initial number of packets per link.
                             Default: 100
  -e EVENTS, --events EVENTS
                             Comma-separated list of PMU events to count.
  -r BYTES, --read BYTES
                             Number of bytes to read from each packet.
  -w BYTES, --write BYTES
                             Number of bytes to write to each packet.
  -h, --help
                             Print this usage message.
```
