### PR TITLE
branches.md: Add kbara-next

### DIFF
--- a/src/doc/branches.md
+++ b/src/doc/branches.md
@@ -63,6 +63,17 @@ The current state of each branch with respect to master is visible here:
 
     Maintainer: Andy Wingo <wingo@igalia.com>
 
+#### kbara-next
+
+    BRANCH: kbara-next git://github.com/kbara/snabbswitch
+    Test and integration branch for maintenance & development.
+
+    - Contains changes proposed to be merged into next.
+    - Merges Pull Requests that pass code review on GitHub.
+    - Integration branch for code vetted by Katerina
+
+    Maintainer: Katerina Barone-Adesi <kbarone@igalia.com>
+
 #### documenation-fixups
 
     BRANCH: documentation-fixups git://github.com/eugeneia/snabbswitch


### PR DESCRIPTION
This branch has already been informally registered via discussions on Github and this commit makes it official (and enables mirroring to the SnabbCo repo).

cc @kbara