### PR TITLE
[sketch] src/Makefile: Flatten Lua module names (no directory)

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -116,12 +116,12 @@ $(OBJDIR) bin testlog:
 
 $(LUAOBJ): obj/%_lua.o: %.lua Makefile | $(OBJDIR)
 	$(E) "LUA       $@"
-	$(Q) luajit -bg -n $(subst /,.,$*) $< $@
+	$(Q) luajit -bg $< $@
 
 $(PFLUAOBJ): obj/%_lua.o: ../lib/pflua/src/%.lua Makefile
 	$(E) "LUA       $@"
 	$(Q) mkdir -p $(dir $@)
-	$(Q) luajit -bg -n $(subst /,.,$*) $< $@
+	$(Q) luajit -bg $< $@
 
 $(COBJ): obj/%_c.o: %.c $(CHDR) Makefile | $(OBJDIR)
 	$(E) "C         $@"
@@ -140,12 +140,12 @@ $(HOBJ): obj/%_h.o: %.h Makefile | $(OBJDIR)
 	@(echo -n "module(...,package.seeall); require(\"ffi\").cdef[=============["; \
 	 cat $<; \
 	 echo "]=============]") > $(basename $@).luah
-	$(Q) luajit -bg -n $(subst /,.,$*)_h $(basename $@).luah $@
+	$(Q) luajit -bg $(basename $@).luah $@
 
 $(ASMOBJ): obj/%_dasl.o: %.dasl $(CHDR) Makefile | $(OBJDIR)
 	$(E) "ASM       $@"
 	$(Q) luajit dynasm.lua -o $@.gen $<
-	$(Q) luajit -bg -n $(subst /,.,$*) $@.gen $@
+	$(Q) luajit -bg $@.gen $@
 
 $(JITOBJS): obj/jit_%.o: ../lib/luajit/src/jit/%.lua $(OBJDIR)
 	$(E) "LUA       $@"
@@ -161,7 +161,7 @@ $(INCOBJ): obj/%_inc.o: %.inc Makefile | $(OBJDIR)
 	@(echo -n "return [=============["; \
 	 cat $<; \
 	 echo "]=============]") > $(basename $@).luainc
-	$(Q) luajit -bg -n $(subst /,.,$*)_inc $(basename $@).luainc $@
+	$(Q) luajit -bg $(basename $@).luainc $@
 
 # Create list of programs that exist
 programs.inc: program


### PR DESCRIPTION
This change puts all Lua module names at the top-level and ignores their directory prefixes. So instead of `core.link` we have `link` and instead of `program.snabbnfv.traffic.traffic` we have `traffic` (which would perhaps be renamed to `snabbnfv_traffic`).

This is based on a suggestion by @capr on #734.

The basic idea here is to make the directory structure a pure implementation detail that is not visible to users. This is motivated by the idea that users don't care about the internal structure and implementors prefer more flexibility about how code is organized.

One way this could simplify the organization of code would be to simply have:

```
src/lwaftr
```

instead of

```
src/program/lwaftr
src/apps/lwaftr
```

i.e. an obvious place to collect all of the code that is specific to one application independent of the content of that code (apps, libraries, command-line programs, etc).

One way it would simplify the API is by hiding the distinction between `core` and `lib` that is perhaps more of an implementation detail anyway.

To make this change actually work we would need to:
- Give every module a unique name.
- Update `require()` lines.
- Invent new rules for finding programs (and perhaps apps).

Some thought would be needed to decide how to do that and how this change relates to the broader topic of #734.
