### PR TITLE
Documentation: New structure and table of contents

### DIFF
--- a/src/README.src.md
+++ b/src/README.src.md
@@ -1,77 +1,110 @@
-# Introduction
+### `packet`: Packet data in memory
+   
+A *packet* is a data structure describing one of the network packets that
+is currently being processed. The packet is used to explicitly manage the
+life cycle of the packet. Packets are explicitly allocated and freed by
+using `packet.allocate` and `packet.free`. When a packet is received
+using `link.receive` its ownership is acquired by the calling app. The
+app must then ensure to either transfer the packet ownership to another
+app by calling `link.transmit` on the packet or free the packet using
+`packet.free`. Apps may only use packets they own, e.g. packets that have
+not been transmitted or freed. The number of allocatable packets is
+limited by the size of the underlying "freelist", e.g. a pool of unused
+packet objects from and to which packets are allocated and freed.
 
-*Snabb Switch* is an extensible, virtualized, Ethernet networking
-toolkit.  With Snabb Switch you can implement networking applications
-using the *Lua language*. Snabb Switch includes all the tools you need to
-quickly realize your network designs and its really fast too!
-Furthermore, Snabb Switch is extensible and encourages you to grow the
-ecosystem to match your requirements.
+— Function **packet.allocate**
 
-    DIAGRAM: Architecture
-            +---------------------+
-            | Your Network Design |
-            +----*-----*-----*----+
-                 |     |     |
-    
-    (Built in and custom Apps and Libraries)
-    
-                 |     |     |
-           +-----*-----*-----*-----+
-           |   Snabb Switch Core   |
-           +-----------------------+
+Returns a new empty packet. An an error is raised if there are no packets
+left on the freelist.
 
-The Snabb Switch Core forms a runtime environment (*engine*) which
-executes your *design*. A design is simply a Lua script used to drive the
-Snabb Switch stack, you can think of it as your top-level "main" routine.
+— Function **packet.free** *packet*
 
-In order to add functionality to the Snabb Switch stack you can load
-modules into the Snabb Switch engine. These can be Lua modules as well as
-native code objects. We differentiate between two classes of modules,
-namely libraries and *Apps*. Libraries are simple collections of program
-utilities to be used in your designs, apps or other libraries, just as
-you might expect. Apps, on the other hand, are code objects that
-implement a specific interface, which is used by the Snabb Switch engine
-to organize an *App Network*.
+Frees *packet* and puts in back onto the freelist.
 
-    DIAGRAM: Network
-                   +---------+
-                   |         |
-                +->* Filter0 *--+
-                |  |         |  |
-                |  +---------+  |
-    +---+----+  |               |  +----+---+
-    |        *--+               +->*        |
-    |  NIC0  |                     |  NIC1  |
-    |        *<-+               +--*        |
-    +---+----+  |               |  +----+---+
-                |  +---------+  |
-                |  |         |  |
-                +--* Filter1 *<-+
-                   |         |
-                   +---------+
+— Function **packet.data** *packet*
 
-Usually, a Snabb Switch design will create a series of apps, interconnect
-these in a desired way using *links* and finally pass the resulting app
-network on to the Snabb Switch engine. The engine's job is to:
+Returns a pointer to the payload of *packet*.
 
- * Pump traffic through the app network
- * Keep the app network running (e.g. restart failed apps)
- * Report on the network status
+— Function **packet.length** *packet*
+
+Returns the payload length of *packet*.
+
+— Function **packet.clone** *packet*
+
+Returns an exact copy of *packet*.
+
+— Function **packet.append** *packet*, *pointer*, *length*
+
+Appends *length* bytes starting at *pointer* to the end of *packet*. An
+error is raised if there is not enough space in *packet* to accomodate
+*length* additional bytes.
+
+— Function **packet.prepend** *packet*, *pointer*, *length*
+
+Prepends *length* bytes starting at *pointer* to the front of
+*packet*. An error is raised if there is not enough space in *packet* to
+accomodate *length* additional bytes.
+
+— Function **packet.shiftleft** *packet*, *length*
+
+Truncates *packet* by *length* bytes from the front.
+
+— Function **packet.from_pointer** *pointer*, *length*
+
+Allocate packet and fill it with *length* bytes from *pointer*.
+
+— Function **packet.from_string** *string*
+
+Allocate packet and fill it with the contents of *string*.
 
 
-# Snabb Switch API
+### `link`: Ring to transfer packets
 
-The core modules defined below  can be loaded using Lua's `require`. For
-example:
+A *link* is a [ring buffer](http://en.wikipedia.org/wiki/Circular_buffer)
+used to store packets between apps. Links can be treated either like
+arrays—accessing their internal structure directly—or as streams of
+packets by using their API functions.
 
-```
-local config = require("core.config")
+— Function **link.empty** *link*
 
-local c = config.new()
-...
-```
+Predicate used to test if a link is empty. Returns true if *link* is
+empty and false otherwise.
 
-## App
+
+— Function **link.full** *link*
+
+Predicate used to test if a link is full. Returns true if *link* is full
+and false otherwise.
+
+
+— Function **link.receive** *link*
+
+Returns the next available packet (and advances the read cursor) on
+*link*. If the link is empty an error is signaled.
+
+
+— Function **link.front** *link*
+
+Return the next available packet without advancing the read cursor on
+*link*. If the link is empty, `nil` is returned.
+
+
+— Function **link.transmit** *link*, *packet*
+
+Transmits *packet* onto *link*. If the link is full *packet* is dropped
+(and the drop counter increased).
+
+
+— Function **link.stats** *link*
+
+Returns a structure holding ring statistics for the *link*:
+
+ * `txbytes`, `rxbytes`: Counts of transferred bytes.
+ * `txpackets`, `rxpackets`: Counts of transferred packets.
+ * `txdrop`: Count of packets dropped due to ring overflow.
+
+
+### *app*: Interface for developing apps
 
 An *app* is an isolated implementation of a specific networking
 function. For example, a switch, a router, or a packet filter.
@@ -137,8 +170,7 @@ implemented the app instance is discarded and a new instance is created.
 (descriptive string). The default is the module name.
 
 
-
-## Config (core.config)
+### `config`: Define an app network
 
 A *config* is a description of a packet-processing network. The network
 is a directed graph. Nodes in the graph are *apps* that each process
@@ -187,8 +219,7 @@ config.link(c, "nic1.tx->nic2.rx")
 ```
 
 
-
-## Engine (core.app)
+### `engine`: Execute an app network
 
 The *engine* executes a config by initializing apps, creating links, and
 driving the flow of execution. The engine also performs profiling and
@@ -251,113 +282,10 @@ how many times per second to poll.
 
 This setting is not used when engine.busywait is true.
 
-## Link (core.link)
 
-A *link* is a [ring buffer](http://en.wikipedia.org/wiki/Circular_buffer)
-used to store packets between apps. Links can be treated either like
-arrays—accessing their internal structure directly—or as streams of
-packets by using their API functions.
+## Base library modules
 
-— Function **link.empty** *link*
-
-Predicate used to test if a link is empty. Returns true if *link* is
-empty and false otherwise.
-
-
-— Function **link.full** *link*
-
-Predicate used to test if a link is full. Returns true if *link* is full
-and false otherwise.
-
-
-— Function **link.receive** *link*
-
-Returns the next available packet (and advances the read cursor) on
-*link*. If the link is empty an error is signaled.
-
-
-— Function **link.front** *link*
-
-Return the next available packet without advancing the read cursor on
-*link*. If the link is empty, `nil` is returned.
-
-
-— Function **link.transmit** *link*, *packet*
-
-Transmits *packet* onto *link*. If the link is full *packet* is dropped
-(and the drop counter increased).
-
-
-— Function **link.stats** *link*
-
-Returns a structure holding ring statistics for the *link*:
-
- * `txbytes`, `rxbytes`: Counts of transferred bytes.
- * `txpackets`, `rxpackets`: Counts of transferred packets.
- * `txdrop`: Count of packets dropped due to ring overflow.
-
-
-## Packet (core.packet)
-   
-A *packet* is a data structure describing one of the network packets that
-is currently being processed. The packet is used to explicitly manage the
-life cycle of the packet. Packets are explicitly allocated and freed by
-using `packet.allocate` and `packet.free`. When a packet is received
-using `link.receive` its ownership is acquired by the calling app. The
-app must then ensure to either transfer the packet ownership to another
-app by calling `link.transmit` on the packet or free the packet using
-`packet.free`. Apps may only use packets they own, e.g. packets that have
-not been transmitted or freed. The number of allocatable packets is
-limited by the size of the underlying "freelist", e.g. a pool of unused
-packet objects from and to which packets are allocated and freed.
-
-— Function **packet.allocate**
-
-Returns a new empty packet. An an error is raised if there are no packets
-left on the freelist.
-
-— Function **packet.free** *packet*
-
-Frees *packet* and puts in back onto the freelist.
-
-— Function **packet.data** *packet*
-
-Returns a pointer to the payload of *packet*.
-
-— Function **packet.length** *packet*
-
-Returns the payload length of *packet*.
-
-— Function **packet.clone** *packet*
-
-Returns an exact copy of *packet*.
-
-— Function **packet.append** *packet*, *pointer*, *length*
-
-Appends *length* bytes starting at *pointer* to the end of *packet*. An
-error is raised if there is not enough space in *packet* to accomodate
-*length* additional bytes.
-
-— Function **packet.prepend** *packet*, *pointer*, *length*
-
-Prepends *length* bytes starting at *pointer* to the front of
-*packet*. An error is raised if there is not enough space in *packet* to
-accomodate *length* additional bytes.
-
-— Function **packet.shiftleft** *packet*, *length*
-
-Truncates *packet* by *length* bytes from the front.
-
-— Function **packet.from_pointer** *pointer*, *length*
-
-Allocate packet and fill it with *length* bytes from *pointer*.
-
-— Function **packet.from_string** *string*
-
-Allocate packet and fill it with the contents of *string*.
-
-
-## Memory (core.memory)
+### `memory`: Allocate physical memory for DMA
 
 Snabb Switch allocates special
 [DMA](https://en.wikipedia.org/wiki/Direct_memory_access) memory that
@@ -378,7 +306,7 @@ Returns the physical address (`uint64_t`) the DMA memory at *pointer*.
 Size of a single huge page in bytes. Read-only.
 
 
-## Lib (core.lib)
+### `lib`: Common library routines
 
 The `core.lib` module contains miscellaneous utilities.
 
@@ -605,8 +533,7 @@ Network to host byte order conversion functions for 32 and 16 bit
 integers *n* respectively.
 
 
-
-## Main
+### `main`: Process start and stop
 
 Snabb Switch designs can be run either with:
 

--- a/src/apps/basic/README.md
+++ b/src/apps/basic/README.md
@@ -1,9 +1,9 @@
-# Basic Apps (apps.basic.basic_apps)
+## Basic: App network plumbing
 
 The module *apps.basic.basic_apps* provides apps with general
 functionality for use in you app networks.
 
-## Source
+### `source`: Transmit artificial packets
 
 The `Source` app is a synthetic packet generator. On each breath it fills
 each attached output link with new packets. The packet data is
@@ -11,7 +11,7 @@ uninitialized garbage and each packet is 60 bytes long.
 
 ![Source](.images/Source.png)
 
-## Join
+### `join`: Combine from multiple inputs
 
 The `Join` app joins together packets from N input links onto one
 output link. On each breath it outputs as many packets as possible
@@ -19,7 +19,7 @@ from the inputs onto the output.
 
 ![Join](.images/Join.png)
 
-## Split
+### `split`: Split onto multiple outputs
 
 The `Split` app splits packets from multiple inputs across multiple
 outputs. On each breath it transfers as many packets as possible from
@@ -27,14 +27,14 @@ the input links to the output links.
 
 ![Split](.images/Split.png)
 
-## Sink
+### `sink`: Discard incoming packets
 
 The `Sink` app receives all packets from any number of input links and
 discards them. This can be handy in combination with a `Source`.
 
 ![Sink](.images/Sink.png)
 
-## Tee
+### `tee`: Duplicate to multiple outputs
 
 The `Tee` app receives all packets from any number of input links and
 transfers each received packet to all output links. It can be used to
@@ -42,7 +42,7 @@ merge and/or duplicate packet streams
 
 ![Tee](.images/Tee.png)
 
-## Repeater
+### `repeater`: Loop input to output
 
 The `Repeater` app collects all packets received from the `input` link
 and repeatedly transfers the accumulated packets to the `output`

--- a/src/apps/basic/README.src.md
+++ b/src/apps/basic/README.src.md
@@ -1,9 +1,9 @@
-# Basic Apps (apps.basic.basic_apps)
+## Basic: App network plumbing
 
 The module *apps.basic.basic_apps* provides apps with general
 functionality for use in you app networks.
 
-## Source
+### `source`: Transmit artificial packets
 
 The `Source` app is a synthetic packet generator. On each breath it fills
 each attached output link with new packets. The packet data is
@@ -20,7 +20,7 @@ uninitialized garbage and each packet is 60 bytes long.
     |        |
     +--------+
 
-## Join
+### `join`: Combine from multiple inputs
 
 The `Join` app joins together packets from N input links onto one
 output link. On each breath it outputs as many packets as possible
@@ -37,7 +37,7 @@ from the inputs onto the output.
               |        |
               +--------+
 
-## Split
+### `split`: Split onto multiple outputs
 
 The `Split` app splits packets from multiple inputs across multiple
 outputs. On each breath it transfers as many packets as possible from
@@ -54,7 +54,7 @@ the input links to the output links.
               |        |
               +--------+
 
-## Sink
+### `sink`: Discard incoming packets
 
 The `Sink` app receives all packets from any number of input links and
 discards them. This can be handy in combination with a `Source`.
@@ -70,7 +70,7 @@ discards them. This can be handy in combination with a `Source`.
               |        |
               +--------+
 
-## Tee
+### `tee`: Duplicate to multiple outputs
 
 The `Tee` app receives all packets from any number of input links and
 transfers each received packet to all output links. It can be used to
@@ -87,7 +87,7 @@ merge and/or duplicate packet streams
               |        |
               +--------+
 
-## Repeater
+### `repeater`: Loop input to output
 
 The `Repeater` app collects all packets received from the `input` link
 and repeatedly transfers the accumulated packets to the `output`

--- a/src/apps/intel/README.md
+++ b/src/apps/intel/README.md
@@ -1,6 +1,4 @@
-# Intel 82599 Ethernet Controller Apps
-
-## Intel10G (apps.intel.intel_app)
+### `intel10g`: Intel 82599/X520 (10G) driver
 
 The `Intel10G` drives one port of an Intel 82599 Ethernet controller.
 Packets taken from the `rx` port are transmitted onto the network.
@@ -25,7 +23,7 @@ Returns a table with the following keys:
 * `packets` - Number of packets sent
 * `bytes` - Total bytes sent
 
-### Configuration
+#### Configuration
 
 The `Intel10G` app accepts a table as its configuration argument. The
 following keys are defined:
@@ -98,12 +96,12 @@ For example, if two apps without *rate_limit* set have the same
 Note that even a low-priority app can use the whole line rate unless other
 (higher priority) apps are using up the available bandwidth.
 
-### Performance
+#### Performance
 
 The `Intel10G` app can transmit and receive at approximately 10 Mpps per
 processor core.
 
-### Hardware limits
+#### Hardware limits
 
 Each physical Intel 82599 port supports the use of up to:
 
@@ -112,7 +110,7 @@ Each physical Intel 82599 port supports the use of up to:
 * 64 VLANs (see the `vlan` configuration option)
 * 4 *mirror pools* (see the `mirror` configuration option)
 
-## Intel1G (apps.intel.intel1g.intel1g)
+### `intel1g`: Intel I210/I350 (1G) driver
 
 The `intel1g` app drives one port of an Intel Gigabit Ethernet
 controller.
@@ -128,7 +126,7 @@ Features:
 
 ![Intel1g](.images/Intel1g.png)
 
-### Configuration
+#### Configuration
 
 — Key **pciaddr**
 
@@ -160,7 +158,7 @@ breath. Default is not specified but assumed to be broadly applicable.
 +— Key **loopback**
 *Optional*. Set to `"MAC"` for MAC loopback, or to `"PHY"` for PHY loopback modes.
 
-## LoadGen (apps.intel.loadgen)
+### `loadgen`: Load generator (based on intel10g)
 
 `LoadGen` is a *load generator* app based on the Intel 82599 Ethernet
 controller. It reads up to 32,000 packets from the `input` port and
@@ -169,12 +167,12 @@ dropped.
 
 ![LoadGen](.images/LoadGen.png)
 
-### Configuration
+#### Configuration
 
 The `LoadGen` app accepts a string as its configuration argument. The
 given string denotes the PCI address of the NIC to use.
 
-### Performance
+#### Performance
 
 The `LoadGen` app can transmit at line-rate (14 Mpps) without significant
 CPU usage.

--- a/src/apps/intel/README.src.md
+++ b/src/apps/intel/README.src.md
@@ -1,6 +1,4 @@
-# Intel 82599 Ethernet Controller Apps
-
-## Intel10G (apps.intel.intel_app)
+### `intel10g`: Intel 82599/X520 (10G) driver
 
 The `Intel10G` drives one port of an Intel 82599 Ethernet controller.
 Packets taken from the `rx` port are transmitted onto the network.
@@ -30,7 +28,7 @@ Returns a table with the following keys:
 * `packets` - Number of packets sent
 * `bytes` - Total bytes sent
 
-### Configuration
+#### Configuration
 
 The `Intel10G` app accepts a table as its configuration argument. The
 following keys are defined:
@@ -103,12 +101,12 @@ For example, if two apps without *rate_limit* set have the same
 Note that even a low-priority app can use the whole line rate unless other
 (higher priority) apps are using up the available bandwidth.
 
-### Performance
+#### Performance
 
 The `Intel10G` app can transmit and receive at approximately 10 Mpps per
 processor core.
 
-### Hardware limits
+#### Hardware limits
 
 Each physical Intel 82599 port supports the use of up to:
 
@@ -117,7 +115,7 @@ Each physical Intel 82599 port supports the use of up to:
 * 64 VLANs (see the `vlan` configuration option)
 * 4 *mirror pools* (see the `mirror` configuration option)
 
-## Intel1G (apps.intel.intel1g.intel1g)
+### `intel1g`: Intel I210/I350 (1G) driver
 
 The `intel1g` app drives one port of an Intel Gigabit Ethernet
 controller.
@@ -138,7 +136,7 @@ Features:
               |          |
               +----------+
 
-### Configuration
+#### Configuration
 
 — Key **pciaddr**
 
@@ -170,7 +168,7 @@ breath. Default is not specified but assumed to be broadly applicable.
 +— Key **loopback**
 *Optional*. Set to `"MAC"` for MAC loopback, or to `"PHY"` for PHY loopback modes.
 
-## LoadGen (apps.intel.loadgen)
+### `loadgen`: Load generator (based on intel10g)
 
 `LoadGen` is a *load generator* app based on the Intel 82599 Ethernet
 controller. It reads up to 32,000 packets from the `input` port and
@@ -184,12 +182,12 @@ dropped.
                |          |
                +----------+
 
-### Configuration
+#### Configuration
 
 The `LoadGen` app accepts a string as its configuration argument. The
 given string denotes the PCI address of the NIC to use.
 
-### Performance
+#### Performance
 
 The `LoadGen` app can transmit at line-rate (14 Mpps) without significant
 CPU usage.

--- a/src/apps/ipv6/README.md
+++ b/src/apps/ipv6/README.md
@@ -1,6 +1,4 @@
-# IPv6 Apps
-
-## Nd_light (apps.ipv6.nd_light)
+### `nd_light`: IPv6 neighbor discovery
 
 The `nd_light` app implements a small subset of IPv6 neighbor discovery
 (RFC4861).  It has two duplex ports, `north` and `south`.  The `south`
@@ -22,7 +20,7 @@ to the `north` port unaltered.
 
 ![nd_light](.images/nd_light.png)
 
-### Configuration
+#### Configuration
 
 The `nd_light` app accepts a table as its configuration argument. The
 following keys are defined:
@@ -50,7 +48,7 @@ milliseconds. Default is 1,000ms.
 *Optional*. Number of neighbor solicitation retransmissions. Default is
 unlimited retransmissions.
 
-## SimpleKeyedTunnel (apps.keyed_ipv6_tunnel.tunnel)
+### `keyed_ipv6_tunnel`: Ethernet-over-IPv6 tunnel
 
 The `SimpleKeyedTunnel` app implements "a simple L2 Ethernet over IPv6
 tunnel encapsulation" as described in
@@ -64,7 +62,7 @@ on the `encapsulated` output port. Packets transmitted on the
 ![SimpleKeyedTunnel](.images/SimpleKeyedTunnel.png)
 
 
-### Configuration
+#### Configuration
 
 The `SimpleKeyedTunnel` app accepts a table as its configuration
 argument. The following keys are defined:

--- a/src/apps/ipv6/README.src.md
+++ b/src/apps/ipv6/README.src.md
@@ -1,6 +1,4 @@
-# IPv6 Apps
-
-## Nd_light (apps.ipv6.nd_light)
+### `nd_light`: IPv6 neighbor discovery
 
 The `nd_light` app implements a small subset of IPv6 neighbor discovery
 (RFC4861).  It has two duplex ports, `north` and `south`.  The `south`
@@ -28,7 +26,7 @@ to the `north` port unaltered.
                |          |   south
                +----------+
 
-### Configuration
+#### Configuration
 
 The `nd_light` app accepts a table as its configuration argument. The
 following keys are defined:
@@ -56,7 +54,7 @@ milliseconds. Default is 1,000ms.
 *Optional*. Number of neighbor solicitation retransmissions. Default is
 unlimited retransmissions.
 
-## SimpleKeyedTunnel (apps.keyed_ipv6_tunnel.tunnel)
+### `keyed_ipv6_tunnel`: Ethernet-over-IPv6 tunnel
 
 The `SimpleKeyedTunnel` app implements "a simple L2 Ethernet over IPv6
 tunnel encapsulation" as described in
@@ -81,7 +79,7 @@ on the `encapsulated` output port. Packets transmitted on the
                           \-----/          decapsulated
 
 
-### Configuration
+#### Configuration
 
 The `SimpleKeyedTunnel` app accepts a table as its configuration
 argument. The following keys are defined:

--- a/src/apps/packet_filter/README.md
+++ b/src/apps/packet_filter/README.md
@@ -1,4 +1,4 @@
-# PcapFilter App (apps.packet_filter.pcap_filter)
+### `pcap_filter`: "Pflang" packet filter
 
 The `PcapFilter` app receives packets on the `input` port and transmits
 conforming packets to the `output` port. In order to conform, a packet
@@ -12,7 +12,7 @@ refer to the same connection by sharing a state table identifer.
 
 ![PcapFilter](.images/PcapFilter.png)
 
-## Configuration
+#### Configuration
 
 The `PcapFilter` app accepts a table as its configuration argument. The
 following keys are available:

--- a/src/apps/packet_filter/README.src.md
+++ b/src/apps/packet_filter/README.src.md
@@ -1,4 +1,4 @@
-# PcapFilter App (apps.packet_filter.pcap_filter)
+### `pcap_filter`: "Pflang" packet filter
 
 The `PcapFilter` app receives packets on the `input` port and transmits
 conforming packets to the `output` port. In order to conform, a packet
@@ -17,7 +17,7 @@ refer to the same connection by sharing a state table identifer.
                |            |
                +------------+
 
-## Configuration
+#### Configuration
 
 The `PcapFilter` app accepts a table as its configuration argument. The
 following keys are available:

--- a/src/apps/pcap/README.md
+++ b/src/apps/pcap/README.md
@@ -1,4 +1,5 @@
-# PcapReader and PcapWriter Apps (apps.pcap.pcap)
+### `pcap_reader`: Read packets from file
+### `pcap_writer`: Write packets to file
 
 The `PcapReader` and `PcapWriter` apps can be used to inject and log raw
 packet data into and out of the app network using the
@@ -9,7 +10,7 @@ port to a PCAP file.
 
 ![PcapReader](.images/PcapReader.png)
 
-## Configuration
+#### Configuration
 
 Both `PcapReader` and `PcapWriter` expect a filename string as their
 configuration arguments to read from and write to respectively.

--- a/src/apps/pcap/README.src.md
+++ b/src/apps/pcap/README.src.md
@@ -1,4 +1,5 @@
-# PcapReader and PcapWriter Apps (apps.pcap.pcap)
+### `pcap_reader`: Read packets from file
+### `pcap_writer`: Write packets to file
 
 The `PcapReader` and `PcapWriter` apps can be used to inject and log raw
 packet data into and out of the app network using the
@@ -14,7 +15,7 @@ port to a PCAP file.
     |            |                          |            |
     +------------+                          +------------+
 
-## Configuration
+#### Configuration
 
 Both `PcapReader` and `PcapWriter` expect a filename string as their
 configuration arguments to read from and write to respectively.

--- a/src/apps/rate_limiter/README.md
+++ b/src/apps/rate_limiter/README.md
@@ -1,4 +1,4 @@
-# RateLimiter App (apps.rate_limiter.rate_limiter)
+### `rate_limiter`: Traffic rate policing
 
 The `RateLimiter` app implements a
 [Token bucket](http://en.wikipedia.org/wiki/Token_bucket) algorithm with a
@@ -17,7 +17,7 @@ fields:
 * `time` - Current time in nanoseconds
 
 
-## Configuration
+#### Configuration
 
 The `RateLimiter` app accepts a table as its configuration argument. The
 following keys are defined:
@@ -37,7 +37,7 @@ limited.
 *Optional*. Initial bucket capacity in bytes. Defaults to
 *bucket_capacity*.
 
-## Performance
+#### Performance
 
 The `RateLimiter` app is able to process more than 20 Mpps per CPU
 core. Refer to its selftest for details.

--- a/src/apps/rate_limiter/README.src.md
+++ b/src/apps/rate_limiter/README.src.md
@@ -1,4 +1,4 @@
-# RateLimiter App (apps.rate_limiter.rate_limiter)
+### `rate_limiter`: Traffic rate policing
 
 The `RateLimiter` app implements a
 [Token bucket](http://en.wikipedia.org/wiki/Token_bucket) algorithm with a
@@ -22,7 +22,7 @@ fields:
 * `time` - Current time in nanoseconds
 
 
-## Configuration
+#### Configuration
 
 The `RateLimiter` app accepts a table as its configuration argument. The
 following keys are defined:
@@ -42,7 +42,7 @@ limited.
 *Optional*. Initial bucket capacity in bytes. Defaults to
 *bucket_capacity*.
 
-## Performance
+#### Performance
 
 The `RateLimiter` app is able to process more than 20 Mpps per CPU
 core. Refer to its selftest for details.

--- a/src/apps/socket/README.md
+++ b/src/apps/socket/README.md
@@ -1,4 +1,4 @@
-# RawSocket App (apps.socket.raw)
+### `raw_socket`: Unix raw socket I/O
 
 The `RawSocket` app is a bridge between Linux network interfaces (`eth0`,
 `lo`, etc.) and a Snabb app network. Packets taken from the `rx` port are
@@ -7,7 +7,7 @@ interface are put on the `tx` port.
 
 ![RawSocket](.images/RawSocket.png)
 
-## Configuration
+#### Configuration
 
 The `RawSocket` app accepts a string as its configuration argument. The
 string denotes the interface to bridge to.

--- a/src/apps/socket/README.src.md
+++ b/src/apps/socket/README.src.md
@@ -1,4 +1,4 @@
-# RawSocket App (apps.socket.raw)
+### `raw_socket`: Unix raw socket I/O
 
 The `RawSocket` app is a bridge between Linux network interfaces (`eth0`,
 `lo`, etc.) and a Snabb app network. Packets taken from the `rx` port are
@@ -12,7 +12,7 @@ interface are put on the `tx` port.
               |           |
               +-----------+
 
-## Configuration
+#### Configuration
 
 The `RawSocket` app accepts a string as its configuration argument. The
 string denotes the interface to bridge to.

--- a/src/apps/solarflare/README.md
+++ b/src/apps/solarflare/README.md
@@ -1,6 +1,4 @@
-# Solarflare Ethernet Controller Apps
-
-## Solarflare (apps.solarflare.solarflare)
+### `solarflare`: Solarflare OpenOnload interface
 
 The `Solarflare` app drives one port of a Solarflare SFN7 Ethernet
 controller. Multiple instances of the Solarflare app can be instantiated
@@ -14,7 +12,7 @@ Packets received from the network are put on the `tx` port.
 The `Solarflare` app requires [OpenOnload](http://www.openonload.org/)
 version *201502* to be installed and the `sfc` module to be loaded.
 
-### Configuration
+#### Configuration
 
 The `Solarflare` app accepts a table as its configuration argument. The
 following keys are defined:

--- a/src/apps/solarflare/README.src.md
+++ b/src/apps/solarflare/README.src.md
@@ -1,6 +1,4 @@
-# Solarflare Ethernet Controller Apps
-
-## Solarflare (apps.solarflare.solarflare)
+### `solarflare`: Solarflare OpenOnload interface
 
 The `Solarflare` app drives one port of a Solarflare SFN7 Ethernet
 controller. Multiple instances of the Solarflare app can be instantiated
@@ -19,7 +17,7 @@ Packets received from the network are put on the `tx` port.
 The `Solarflare` app requires [OpenOnload](http://www.openonload.org/)
 version *201502* to be installed and the `sfc` module to be loaded.
 
-### Configuration
+#### Configuration
 
 The `Solarflare` app accepts a table as its configuration argument. The
 following keys are defined:

--- a/src/apps/vhost/README.md
+++ b/src/apps/vhost/README.md
@@ -1,4 +1,4 @@
-# VhostUser App (apps.vhost.vhost_user)
+### `vhost_user`: Virtio-net interface to QEMU/KVM VMs
 
 The `VhostUser` app implements portions of the
 [Virtio](http://ozlabs.org/~rusty/virtio-spec/virtio-paper.pdf) protocol
@@ -15,7 +15,7 @@ packets send by the virtual machine will arrive on the `tx` port.
 
 ![VhostUser](.images/VhostUser.png)
 
-## Configuration
+#### Configuration
 
 The `VhostUser` app accepts a table as its configuration argument. The
 following keys are defined:

--- a/src/apps/vhost/README.src.md
+++ b/src/apps/vhost/README.src.md
@@ -1,4 +1,4 @@
-# VhostUser App (apps.vhost.vhost_user)
+### `vhost_user`: Virtio-net interface to QEMU/KVM VMs
 
 The `VhostUser` app implements portions of the
 [Virtio](http://ozlabs.org/~rusty/virtio-spec/virtio-paper.pdf) protocol
@@ -20,7 +20,7 @@ packets send by the virtual machine will arrive on the `tx` port.
            |           |
            +-----------+
 
-## Configuration
+#### Configuration
 
 The `VhostUser` app accepts a table as its configuration argument. The
 following keys are defined:

--- a/src/apps/vpn/README.md
+++ b/src/apps/vpn/README.md
@@ -1,4 +1,4 @@
-# VPWS App (apps.vpn.vpws)
+### `vpws`: Virtual Private Wire Service
 
 The `VPWS` app implements a so-called Virtual Private Wire Service
 (VPWS). It provides a L2 VPN on top of IP (v4/v6) and GRE.
@@ -12,7 +12,7 @@ output port.
 
 ![VPWS](.images/VPWS.png)
 
-## Configuration
+#### Configuration
 
 The `vpws` app accepts a table as its configuration argument. The
 following keys are defined:

--- a/src/apps/vpn/README.src.md
+++ b/src/apps/vpn/README.src.md
@@ -1,4 +1,4 @@
-# VPWS App (apps.vpn.vpws)
+### `vpws`: Virtual Private Wire Service
 
 The `VPWS` app implements a so-called Virtual Private Wire Service
 (VPWS). It provides a L2 VPN on top of IP (v4/v6) and GRE.
@@ -23,7 +23,7 @@ output port.
           <------|---/ /----->
                  \-----/    uplink
 
-## Configuration
+#### Configuration
 
 The `vpws` app accepts a table as its configuration argument. The
 following keys are defined:

--- a/src/doc/genbook.sh
+++ b/src/doc/genbook.sh
@@ -29,50 +29,98 @@ being said, discrepancies between this document and the actual Snabb
 Switch implementation are considered to be bugs. Please report them in
 order to help improve this document.*
 
+# Introduction
+
+## Snabb in a nutshell
+## Core software architecture
+## Zen of Snabb
+
+# API
+
+## Core modules
+
 $(cat ../README.md)
 
-$(cat ../apps/basic/README.md)
-
-$(cat ../apps/intel/README.md)
-
-$(cat ../apps/solarflare/README.md)
-
-$(cat ../apps/rate_limiter/README.md)
-
-$(cat ../apps/packet_filter/README.md)
-
-$(cat ../apps/ipv6/README.md)
-
-$(cat ../apps/vhost/README.md)
-
-$(cat ../apps/pcap/README.md)
-
-$(cat ../apps/vpn/README.md)
-
-$(cat ../apps/socket/README.md)
-
-# Libraries
+## Traffic processing
 
 $(cat ../lib/README.checksum.md)
 
 $(cat ../lib/README.ctable.md)
 
-$(cat ../lib/README.pmu.md)
-
-## Hardware
+## System programming
 
 $(cat ../lib/hardware/README.md)
 
-## Protocols
+$(cat ../lib/watchdog/README.md)
+
+$(cat ../lib/README.pmu.md)
+
+## Protocol headers
 
 $(cat ../lib/protocol/README.md)
 
-## Snabb NFV
+# Apps
+
+$(cat ../apps/basic/README.md)
+
+## Hardware I/O
+
+$(cat ../apps/intel/README.md)
+
+$(cat ../apps/solarflare/README.md)
+
+## Software I/O
+
+$(cat ../apps/vhost/README.md)
+
+$(cat ../apps/pcap/README.md)
+
+$(cat ../apps/socket/README.md)
+
+## Protocols
+
+$(cat ../apps/ipv6/README.md)
+
+$(cat ../apps/vpn/README.md)
+
+## Traffic restriction
+
+$(cat ../apps/rate_limiter/README.md)
+
+$(cat ../apps/packet_filter/README.md)
+
+# Programs
+
+## NFV: optimized Virtio-net for QEMU
 
 $(cat ../program/snabbnfv/README.md)
 
-## Watchdog (lib.watchdog.watchdog)
+## lwAFTR: lightweight 4-over-6
+## ALX: Agile Lan eXtender (VPLS)
+## Lisper: LISP dataplane
+## packetblaster: "Infinite load" generator
 
-$(cat ../lib/watchdog/README.md)
+# Development processs
+
+## Git workflow
+
+### Github repository
+### Branches and upstreaming
+### Making a contribution
+### Continuous Integration
+### Mailing list
+
+## Snabb Lab
+
+### Servers for community use
+### NixOS server configuration
+### Getting started
+
+## Policies
+
+### Apache license
+### Copyright
+### Trademarks
+### Code of conduct
 
 EOF

--- a/src/doc/template.latex
+++ b/src/doc/template.latex
@@ -4,6 +4,7 @@
 % Use sans for sections, serif for main
 \usepackage{sectsty}
 \allsectionsfont{\sffamily}
+\def\tightlist{}
 % Nicer chapter headings
 \usepackage{titlesec,color}
 \definecolor{gray75}{gray}{0.75}

--- a/src/lib/README.checksum.md
+++ b/src/lib/README.checksum.md
@@ -1,4 +1,4 @@
-### IP checksum (lib.checksum)
+### `checksum`: IP checksum
 
 The checksum module provides an optimized ones-complement checksum
 routine.

--- a/src/lib/README.ctable.md
+++ b/src/lib/README.ctable.md
@@ -1,4 +1,4 @@
-### Ctable (lib.ctable)
+### `ctable`: Scalable hashtable
 
 A *ctable* is a hash table whose keys and values are instances of FFI
 data types.  In Lua parlance, an FFI value is a "cdata" value, hence the

--- a/src/lib/README.pmu.md
+++ b/src/lib/README.pmu.md
@@ -1,4 +1,4 @@
-### PMU (lib.pmu)
+### `pmu`: CPU Performance Monitoring Unit counters
 
 The CPU's PMU (Performance Monitoring Unit) collects information about
 specific *performance events* such as cache misses, branch

--- a/src/lib/hardware/README.md
+++ b/src/lib/hardware/README.md
@@ -1,4 +1,4 @@
-### PCI (lib.hardware.pci)
+### `pci`: PCI device access
 
 The `lib.hardware.pci` module provides functions that abstract common
 operations on PCI devices on Linux. In order to drive a PCI device using
@@ -87,7 +87,7 @@ Closes memory mapped *file_descriptor* of sysfs resource file and unmaps
 it from *pointer* as returned by `pci.map_pci_memory`.
 
 
-### Register (lib.hardware.register)
+### `register`: Hardware register access
 
 The `lib.hardware.register` module provides an abstraction for hardware
 device registers. This abstraction can be used to declaratively specify

--- a/src/lib/hardware/README.src.md
+++ b/src/lib/hardware/README.src.md
@@ -1,4 +1,4 @@
-### PCI (lib.hardware.pci)
+### `pci`: PCI device access
 
 The `lib.hardware.pci` module provides functions that abstract common
 operations on PCI devices on Linux. In order to drive a PCI device using
@@ -87,7 +87,7 @@ Closes memory mapped *file_descriptor* of sysfs resource file and unmaps
 it from *pointer* as returned by `pci.map_pci_memory`.
 
 
-### Register (lib.hardware.register)
+### `register`: Hardware register access
 
 The `lib.hardware.register` module provides an abstraction for hardware
 device registers. This abstraction can be used to declaratively specify

--- a/src/lib/protocol/README.md
+++ b/src/lib/protocol/README.md
@@ -1,4 +1,4 @@
-### Protocol Header (lib.protocol.header)
+### `protocol.header`
 
 The `lib.protocol.header` module contains the base class from which the
 supported protocol classes are derived. It defines generic methods on all
@@ -41,7 +41,7 @@ layer.
 For instance, on an Ethernet header object this method might return a
 IPv4 or IPv6 header class.
 
-### Ethernet (lib.protocol.ethernet)
+### `protocol.ethernet`
 
 The `lib.protocol.ethernet` module contains a class for representing
 *Ethernet headers*. The `ethernet` protocol class supports two upper
@@ -104,7 +104,7 @@ Returns the MAC address for IPv6 multicast *ip* as defined by RFC2464,
 section 7.
 
 
-### IPv4 (lib.protocol.ipv4)
+### `protocol.ipv4`
 
 The `lib.protocol.ipv4` module contains a class for representing
 *IPv4 headers*. The `ipv4` protocol class supports four upper
@@ -197,7 +197,7 @@ Returns the binary representation of IPv4 address denoted by *string*.
 Returns the string representation of *ip* address.
 
 
-### IPv6 (lib.protocol.ipv6)
+### `protocol.ipv6`
 
 The `lib.protocol.ipv6` module contains a class for representing
 *IPv6 headers*. The `ipv6` protocol class supports four upper
@@ -286,7 +286,7 @@ Returns the solicited-node multicast address from the given unicast
 *ip*.
 
 
-### TCP (lib.protocol.tcp)
+### `protocol.tcp`
 
 The `lib.protocol.tcp` module contains a class for representing *TCP
 headers*.
@@ -365,7 +365,7 @@ and optionally *ip*. If no argument is given the current value of the
 "Checksum" field is returned.
 
 
-### UDP (lib.protocol.udp)
+### `protocol.udp`
 
 The `lib.protocol.udp` module contains a class for representing *UDP
 headers*.
@@ -402,7 +402,7 @@ and optionally *ip*. If no argument is given the current value of the
 "Checksum" field is returned.
 
 
-### GRE (lib.protocol.gre)
+### `protocol.gre`
 
 The `lib.protocol.gre` module contains a class for representing *GRE
 headers*. The `gre` protocol class only supports the checksum and key
@@ -444,7 +444,7 @@ the upper layer protocol to *protocol*. If no argument is given the
 current upper layer protocol is returned.
 
 
-### ICMP (lib.protocol.icmp.header)
+### `protocol.icmp.header`
 
 The `lib.protocol.icmp.header` module contains a class for representing
 *ICMP headers*.  The `icmp` protocol class currently supports two upper
@@ -481,7 +481,7 @@ of *payload*. If the lower protocol layer is `lib.protocol.ipv6` then
 *ipv6* must be set to a true value.
 
 
-#### Neighbor Solicitation (lib.protocol.icmp.nd.ns)
+### `protocol.icmp.nd.ns`
 
 — Method **ns:new** *target*
 
@@ -500,7 +500,7 @@ Predicate to test if the header's value in the "Target Address" field is
 equivalent to *target*.
 
 
-#### Neighbor Advertisement (lib.protocol.icmp.nd.na)
+### `protocol.icmp.nd.na`
 
 — Method **na:new** *target*, *router*, *solicited*, *override*
 
@@ -527,7 +527,7 @@ Predicate to test if the header's value in the "Target Address" field is
 equivalent to *target*.
 
 
-#### Neighbor Discovery Options (lib.protocol.icmp.nd.header)
+### `protocol.icmp.nd.header`
 
 Both Neighbor Solicitation and Advertisement (`lib.protocol.icmp.nd.ns`
 and `lib.protocol.icmp.nd.na`) headers implement an `options` method for
@@ -548,7 +548,7 @@ Parses and returns an array of TLV Options (see
 `lib.protocol.icmp.nd.options.tlv`) from *length* bytes of *payload*.
 
 
-#### TLV Option (lib.protocol.icmp.nd.options.tlv)
+### `protocol.icmp.nd.options.tlv`
 
 The `lib.protocol.icmp.nd.options.tlv` module contains a class for
 representing TLV Options. Currently only two types of options are
@@ -583,7 +583,7 @@ returned.
 Returns an object of the class denoted by the type field. Currently that
 only includes `lladdr` instances.
 
-#### Link-Layer Address Option (lib.protocol.icmp.nd.options.lladdr)
+### `protocol.icmp.nd.options.lladdr`
 
 The `lib.protocol.icmp.nd.options.lladdr` module contains a class for
 representing Link-Layer Address Options.
@@ -604,7 +604,7 @@ to *address*. If no argument is given the current value of the address
 field is returned.
 
 
-### Datagram (lib.protocol.datagram)
+### `protocol.datagram`
 
 The `lib.protocol.datagram` module provides basic mechanisms for parsing,
 building and manipulating a hierarchy of protocol headers and the

--- a/src/lib/protocol/README.src.md
+++ b/src/lib/protocol/README.src.md
@@ -1,4 +1,4 @@
-### Protocol Header (lib.protocol.header)
+### `protocol.header`
 
 The `lib.protocol.header` module contains the base class from which the
 supported protocol classes are derived. It defines generic methods on all
@@ -41,7 +41,7 @@ layer.
 For instance, on an Ethernet header object this method might return a
 IPv4 or IPv6 header class.
 
-### Ethernet (lib.protocol.ethernet)
+### `protocol.ethernet`
 
 The `lib.protocol.ethernet` module contains a class for representing
 *Ethernet headers*. The `ethernet` protocol class supports two upper
@@ -104,7 +104,7 @@ Returns the MAC address for IPv6 multicast *ip* as defined by RFC2464,
 section 7.
 
 
-### IPv4 (lib.protocol.ipv4)
+### `protocol.ipv4`
 
 The `lib.protocol.ipv4` module contains a class for representing
 *IPv4 headers*. The `ipv4` protocol class supports four upper
@@ -197,7 +197,7 @@ Returns the binary representation of IPv4 address denoted by *string*.
 Returns the string representation of *ip* address.
 
 
-### IPv6 (lib.protocol.ipv6)
+### `protocol.ipv6`
 
 The `lib.protocol.ipv6` module contains a class for representing
 *IPv6 headers*. The `ipv6` protocol class supports four upper
@@ -286,7 +286,7 @@ Returns the solicited-node multicast address from the given unicast
 *ip*.
 
 
-### TCP (lib.protocol.tcp)
+### `protocol.tcp`
 
 The `lib.protocol.tcp` module contains a class for representing *TCP
 headers*.
@@ -365,7 +365,7 @@ and optionally *ip*. If no argument is given the current value of the
 "Checksum" field is returned.
 
 
-### UDP (lib.protocol.udp)
+### `protocol.udp`
 
 The `lib.protocol.udp` module contains a class for representing *UDP
 headers*.
@@ -402,7 +402,7 @@ and optionally *ip*. If no argument is given the current value of the
 "Checksum" field is returned.
 
 
-### GRE (lib.protocol.gre)
+### `protocol.gre`
 
 The `lib.protocol.gre` module contains a class for representing *GRE
 headers*. The `gre` protocol class only supports the checksum and key
@@ -444,7 +444,7 @@ the upper layer protocol to *protocol*. If no argument is given the
 current upper layer protocol is returned.
 
 
-### ICMP (lib.protocol.icmp.header)
+### `protocol.icmp.header`
 
 The `lib.protocol.icmp.header` module contains a class for representing
 *ICMP headers*.  The `icmp` protocol class currently supports two upper
@@ -481,7 +481,7 @@ of *payload*. If the lower protocol layer is `lib.protocol.ipv6` then
 *ipv6* must be set to a true value.
 
 
-#### Neighbor Solicitation (lib.protocol.icmp.nd.ns)
+### `protocol.icmp.nd.ns`
 
 — Method **ns:new** *target*
 
@@ -500,7 +500,7 @@ Predicate to test if the header's value in the "Target Address" field is
 equivalent to *target*.
 
 
-#### Neighbor Advertisement (lib.protocol.icmp.nd.na)
+### `protocol.icmp.nd.na`
 
 — Method **na:new** *target*, *router*, *solicited*, *override*
 
@@ -527,7 +527,7 @@ Predicate to test if the header's value in the "Target Address" field is
 equivalent to *target*.
 
 
-#### Neighbor Discovery Options (lib.protocol.icmp.nd.header)
+### `protocol.icmp.nd.header`
 
 Both Neighbor Solicitation and Advertisement (`lib.protocol.icmp.nd.ns`
 and `lib.protocol.icmp.nd.na`) headers implement an `options` method for
@@ -548,7 +548,7 @@ Parses and returns an array of TLV Options (see
 `lib.protocol.icmp.nd.options.tlv`) from *length* bytes of *payload*.
 
 
-#### TLV Option (lib.protocol.icmp.nd.options.tlv)
+### `protocol.icmp.nd.options.tlv`
 
 The `lib.protocol.icmp.nd.options.tlv` module contains a class for
 representing TLV Options. Currently only two types of options are
@@ -583,7 +583,7 @@ returned.
 Returns an object of the class denoted by the type field. Currently that
 only includes `lladdr` instances.
 
-#### Link-Layer Address Option (lib.protocol.icmp.nd.options.lladdr)
+### `protocol.icmp.nd.options.lladdr`
 
 The `lib.protocol.icmp.nd.options.lladdr` module contains a class for
 representing Link-Layer Address Options.
@@ -604,7 +604,7 @@ to *address*. If no argument is given the current value of the address
 field is returned.
 
 
-### Datagram (lib.protocol.datagram)
+### `protocol.datagram`
 
 The `lib.protocol.datagram` module provides basic mechanisms for parsing,
 building and manipulating a hierarchy of protocol headers and the

--- a/src/lib/watchdog/README.md
+++ b/src/lib/watchdog/README.md
@@ -1,3 +1,5 @@
+### `watchdog`: Terminate a hanging process
+
 The `lib.watchdog.watchdog` module implements a per-thread watchdog
 functionality. Its purpose is to watch and kill processes which fail to
 call the watchdog periodically (e.g. hang).


### PR DESCRIPTION
This change creates a new table-of-contents for the Snabb manual. This reorganizes the existing material and puts a structure in place for adding new material -- in particular to include the floating markdown files in the repository and to capture the outcome of discussions on Github.

The main changes are:
- New Introduction (making place for #818 and #822)
- Rebalanced and reordered the API and Apps sections
- New chapter for Programs.
- New chapter for the development process.
- New chapter for policies.

See [snabbswitch-ce38aa12.pdf](https://www.dropbox.com/s/5v4ej6hn83kr9vj/snabbswitch-ce38aa12.pdf?dl=0) for the intended output. This will need to be reconciled with the HTML edition separately e.g. if section names are too long or something like that.

Question is: does this represent the content that we want in the manual and the way that we want to organize it? If so then we could set about filling it all in.
