### PR TITLE
branches.md: Add branch pdf-manual

### DIFF
--- a/src/doc/branches.md
+++ b/src/doc/branches.md
@@ -79,7 +79,7 @@ The current state of each branch with respect to master is visible here:
 
 #### pdf-manual
 
-    BRANCH: pdf-manual git://github.com/lukego/pdf-manual
+    BRANCH: pdf-manual git://github.com/lukego/snabbswitch
     Maintenance branch for the PDF edition of the Snabb manual.
 
     - Ensures that the PDF manual builds and looks good.

--- a/src/doc/branches.md
+++ b/src/doc/branches.md
@@ -77,3 +77,13 @@ The current state of each branch with respect to master is visible here:
     
     Maintainer: Alexander Gall <gall@switch.ch>
 
+#### pdf-manual
+
+    BRANCH: pdf-manual git://github.com/lukego/pdf-manual
+    Maintenance branch for the PDF edition of the Snabb manual.
+
+    - Ensures that the PDF manual builds and looks good.
+    - Supports documentation revision and integration efforts.
+    - Feeds upstream to documentation-fixes.
+
+    Maintainer: Luke Gorrie <luke@snabb.co>


### PR DESCRIPTION
Register my `pdf-manual` branch in branches.md.

The short-term objective of this branch is to create a high-quality PDF manual by whatever means necessary. That can include integrating separately contributed chapters of documentation, editorializing by documentation how things *should* be rather than how they are right now, etc. I will be satisfied when I can put a nice copy of the documentation up on [Lulu](http://lulu.com).

This will feed upstream towards `documentation-fixes` and will likely require some edits before it is accepted there.

The long-term objective could be to maintain the PDF edition of the manual e.g. ensure that it builds cleanly and has no glaring formatting problems.

Content:

    BRANCH: pdf-manual git://github.com/lukego/pdf-manual
    Maintenance branch for the PDF edition of the Snabb manual.

    - Ensures that the PDF manual builds and looks good.
    - Supports documentation revision and integration efforts.
    - Feeds upstream to documentation-fixes.

    Maintainer: Luke Gorrie <luke@snabb.co>

