### PR TITLE
Add ipsec branch

### DIFF
--- a/src/doc/branches.md
+++ b/src/doc/branches.md
@@ -77,3 +77,9 @@ The current state of each branch with respect to master is visible here:
     
     Maintainer: Alexander Gall <gall@switch.ch>
 
+#### ipsec
+
+    BRANCH: ipsec git://github.com/eugeneia/snabbswitch
+    IPsec library development branch.
+
+    Maintainer: Max Rottenkolber <max@mr.gy>


### PR DESCRIPTION
Adds a named branch for IPsec development.

#820 was the first PR to be merged into this branch.