### PR TITLE
doc/code-of-conduct.md: Add a community code of conduct

### DIFF
--- a/src/doc/code-of-conduct.md
+++ b/src/doc/code-of-conduct.md
@@ -1,0 +1,7 @@
+### Code of conduct
+
+Follow the [Contributor Covenant](http://contributor-covenant.org/) and report problems to `conduct@snabb.co`.
+
+Help people achieve their goals. Don't stand between people who want to cooperate.
+
+Keep people in the loop. Use Github Issues for important discussions.


### PR DESCRIPTION
I propose this short and sweet code of conduct for the Snabb community. This is intended proactively to frame future discussions when problems come up.

The basic suggestions here are to be civil, for upstream to act as a resource for helping people to cooperate efficiently (even when their goals don't immediately align with the master branch), and to keep important discussions on Github so that watching the project here is sufficient to stay "in the loop."

I have found it frustrating in the past to contribute to projects where the upstream community are rude, don't care whether contributors achieve their own goals, or require unproductive rituals that disrespect contributors' time.

Let's not become one of those projects. Instead let's encourage contributors to whack us on the head with this document any time we accidentally step in that direction.

Just to repeat, this is based on past experience with other projects and not related to anything going on in the Snabb community today. I imagine it would be much harder to introduce a change like this in the middle of a heated discussion about project policies and that is why I like the idea of doing it now.