### PR TITLE
[wip] Rename "Snabb Switch" to "Snabb"

### DIFF
--- a/src/README.src.md
+++ b/src/README.src.md
@@ -1,10 +1,10 @@
 # Introduction
 
-*Snabb Switch* is an extensible, virtualized, Ethernet networking
-toolkit.  With Snabb Switch you can implement networking applications
-using the *Lua language*. Snabb Switch includes all the tools you need to
+*Snabb* is an extensible, virtualized, Ethernet networking
+toolkit.  With Snabb you can implement networking applications
+using the *Lua language*. Snabb includes all the tools you need to
 quickly realize your network designs and its really fast too!
-Furthermore, Snabb Switch is extensible and encourages you to grow the
+Furthermore, Snabb is extensible and encourages you to grow the
 ecosystem to match your requirements.
 
     DIAGRAM: Architecture


### PR DESCRIPTION
I hereby propose that we rename the project from "Snabb Switch" to simply "Snabb" for the next release, following the discussion on #738. The trademark "Snabb" will be available to all users under terms that we will nail down in discussions here on Github. (I will do my own business under another name.)

If we are happy with this idea then I plan to "make it so" using this branch. Specifically, early next week I would update this PR to do the moral equivalent of `s/snabb switch/snabb/` on the entire `next` branch and then we would ship that as `v2016.04`.

Objections? Speak now or forever hold your peace!