### PR TITLE
Fix memory corruption in lib.ipsec.aes_128_gcm

### DIFF
--- a/src/lib/ipsec/aes_128_gcm.lua
+++ b/src/lib/ipsec/aes_128_gcm.lua
@@ -69,9 +69,9 @@ local function u8_ptr (ptr) return ffi.cast("uint8_t *", ptr) end
 
 -- Encrypt a single 128-bit block with the basic AES block cipher.
 local function aes_128_block (block, keymat)
-   local state = ffi.new("uint8_t[16] __attribute__((aligned(16)))")
-   ASM.aes_keyexp_128_enc_avx(keymat, state)
-   ASM.aesni_encrypt_single_block(state, block)
+   local gcm_data = ffi.new("gcm_data __attribute__((aligned(16)))")
+   ASM.aes_keyexp_128_enc_avx(keymat, gcm_data)
+   ASM.aesni_encrypt_single_block(gcm_data, block)
 end
 
 local aes_128_gcm = {}
@@ -92,8 +92,8 @@ function aes_128_gcm:new (spi, keymat, salt)
    -- Compute subkey (H)
    o.hash_subkey = ffi.new("uint8_t[?] __attribute__((aligned(16)))", 16)
    aes_128_block(o.hash_subkey, o.keymat)
-   o.gcm_data = ffi.new("gcm_data[1] __attribute__((aligned(16)))")
-   ASM.aes_keyexp_128_enc_avx(o.keymat, o.gcm_data[0].expanded_keys)
+   o.gcm_data = ffi.new("gcm_data __attribute__((aligned(16)))")
+   ASM.aes_keyexp_128_enc_avx(o.keymat, o.gcm_data)
    ASM.aesni_gcm_precomp_avx_gen4(o.gcm_data, o.hash_subkey)
    return setmetatable(o, {__index=aes_128_gcm})
 end

--- a/src/lib/ipsec/aes_128_gcm_avx.dasl
+++ b/src/lib/ipsec/aes_128_gcm_avx.dasl
@@ -497,9 +497,9 @@ local mcode, size = Dst:build()
 local entry = dasm.globals(globals, globalnames)
 local fn_t = ffi.typeof("void(*)(gcm_data*, uint8_t*, const uint8_t*, uint64_t, uint8_t*, const uint8_t*, uint64_t, uint8_t*, uint64_t)")
 return setmetatable({
-  aes_keyexp_128_enc_avx = ffi.cast("void(*)(void*, void*)", entry.aes_keyexp_128_enc_avx),
+  aes_keyexp_128_enc_avx = ffi.cast("void(*)(uint8_t*, gcm_data*)", entry.aes_keyexp_128_enc_avx),
   aesni_gcm_precomp_avx_gen4 = ffi.cast("void(*)(gcm_data*, uint8_t*)", entry.aesni_gcm_precomp_avx_gen4),
   aesni_gcm_enc_avx_gen4 = ffi.cast(fn_t, entry.aesni_gcm_enc_avx_gen4),
   aesni_gcm_dec_avx_gen4 = ffi.cast(fn_t, entry.aesni_gcm_dec_avx_gen4),
-  aesni_encrypt_single_block = ffi.cast("void(*)(void *key, void *data)", entry.aesni_encrypt_single_block)
+  aesni_encrypt_single_block = ffi.cast("void(*)(gcm_data*, uint8_t*)", entry.aesni_encrypt_single_block)
 }, {_anchor = mcode})


### PR DESCRIPTION
This fixed a memory corruption caused by an out of bounds write by the DynASM code used in `lib.ipsec.aes_128_gcm`. This patch also adds stricter type signatures to the API exported from the DynASM code which would have caught this error. Review of my C type interpretations would be appreciated (see inline comments below). The memory corruption is reproducible using the following script:

```
datagram = require("lib.protocol.datagram")
esp = require("lib.ipsec.esp")

-- When I set this to 30000 it runs fine
local npackets = 31000

_G.developer_debug = true

io.stdout:setvbuf("no")
print("setup")

local packets = {}
print("allocate"..npackets)
for i = 1, npackets do
   -- When I skip the datagram and do `plain = packet.allocate()' it runs fine
   local d = datagram:new(packet.allocate())
   packets[i] = { plain = d:packet(), encapsulated = 0 }
end
print("encrypt")
local conf = { spi = 0x0,
               mode = "aes-128-gcm",
               keymat = "00112233445566778899AABBCCDDEEFF",
               salt = "00112233"}

-- When I comment out this line it runs fine
local enc, dec = esp.esp_v6_encrypt:new(conf), esp.esp_v6_decrypt:new(conf)

print("operate on packets")
for i, p in ipairs(packets) do
   p.encapsulated = packet.clone(p.plain)
end
```

Cc @lukego 