### PR TITLE
Optimize lib.ipsec.esp

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -306,6 +306,12 @@ Returns the payload length of *packet*.
 
 Returns an exact copy of *packet*.
 
+— Function **packet.resize** *packet*, *length*
+
+Sets the payload length of *packet*, truncating or extending its payload. In
+the latter case the contents of the extended area at the end of the payload are
+undefined.
+
 — Function **packet.append** *packet*, *pointer*, *length*
 
 Appends *length* bytes starting at *pointer* to the end of *packet*. An

--- a/src/README.md
+++ b/src/README.md
@@ -310,7 +310,7 @@ Returns an exact copy of *packet*.
 
 Sets the payload length of *packet*, truncating or extending its payload. In
 the latter case the contents of the extended area at the end of the payload are
-undefined.
+filled with zeros.
 
 — Function **packet.append** *packet*, *pointer*, *length*
 

--- a/src/README.src.md
+++ b/src/README.src.md
@@ -332,6 +332,12 @@ Returns the payload length of *packet*.
 
 Returns an exact copy of *packet*.
 
+— Function **packet.resize** *packet*, *length*
+
+Sets the payload length of *packet*, truncating or extending its payload. In
+the latter case the contents of the extended area at the end of the payload are
+undefined.
+
 — Function **packet.append** *packet*, *pointer*, *length*
 
 Appends *length* bytes starting at *pointer* to the end of *packet*. An

--- a/src/core/packet.lua
+++ b/src/core/packet.lua
@@ -99,6 +99,12 @@ function data (p) return p.data end
 -- Return packet data length.
 function length (p) return p.length end
 
+-- Set packet data length.
+function resize (p, len)
+   assert(len <= max_payload, "packet payload overflow")
+   p.length = len
+end
+
 function preallocate_step()
    if _G.developer_debug then
       assert(packets_allocated + packet_allocation_step <= max_packets)

--- a/src/core/packet.lua
+++ b/src/core/packet.lua
@@ -102,6 +102,7 @@ function length (p) return p.length end
 -- Set packet data length.
 function resize (p, len)
    assert(len <= max_payload, "packet payload overflow")
+   ffi.fill(p.data + p.length, math.max(0, len - p.length))
    p.length = len
 end
 

--- a/src/lib/ipsec/README.md
+++ b/src/lib/ipsec/README.md
@@ -36,7 +36,6 @@ be a table with the following keys:
 * `salt` - Hex string containing four bytes of salt as specified in
   RFC 4106.
 * `spi` - “Security Parameter Index” as specified in RFC 4303.
-  (`esp_v6_encrypt` only.)
 * `window_size` - *Optional*. Width of the window in which out of order packets
   are accepted. The default is 128. (`esp_v6_decrypt` only.)
 

--- a/src/lib/ipsec/esp.lua
+++ b/src/lib/ipsec/esp.lua
@@ -94,7 +94,7 @@ function esp_v6_encrypt:encapsulate (p)
    local overhead = self.ESP_OVERHEAD + pad_length
    packet.resize(p, length + overhead)
    local padding_start = data + length
-   C.memset(padding_start, 0, pad_length)
+   ffi.fill(padding_start, pad_length)
    self.ip:new_from_mem(data + ETHERNET_SIZE, IPV6_SIZE)
    self.esp_tail:new_from_mem(padding_start + pad_length, ESP_TAIL_SIZE)
    self.esp_tail:next_header(self.ip:next_header())

--- a/src/lib/ipsec/esp.lua
+++ b/src/lib/ipsec/esp.lua
@@ -93,10 +93,8 @@ function esp_v6_encrypt:encapsulate (p)
    local pad_length = padding(self.pad_to, payload_length + self.ESP_PAYLOAD_OVERHEAD)
    local overhead = self.ESP_OVERHEAD + pad_length
    packet.resize(p, length + overhead)
-   local padding_start = data + length
-   ffi.fill(padding_start, pad_length)
    self.ip:new_from_mem(data + ETHERNET_SIZE, IPV6_SIZE)
-   self.esp_tail:new_from_mem(padding_start + pad_length, ESP_TAIL_SIZE)
+   self.esp_tail:new_from_mem(data + length + pad_length, ESP_TAIL_SIZE)
    self.esp_tail:next_header(self.ip:next_header())
    self.esp_tail:pad_length(pad_length)
    self:next_seq_no()

--- a/src/lib/ipsec/esp.lua
+++ b/src/lib/ipsec/esp.lua
@@ -36,71 +36,81 @@ local aes_128_gcm = require("lib.ipsec.aes_128_gcm")
 local seq_no_t = require("lib.ipsec.seq_no_t")
 local lib = require("core.lib")
 local ffi = require("ffi")
+local C = ffi.C
 
 
-local esp_nh = 50 -- https://tools.ietf.org/html/rfc4303#section-2
-local esp_size = esp:sizeof()
-local esp_tail_size = esp_tail:sizeof()
+local ETHERNET_SIZE = ethernet:sizeof()
+local IPV6_SIZE = ipv6:sizeof()
+local PAYLOAD_OFFSET = ETHERNET_SIZE + IPV6_SIZE
+local ESP_NH = 50 -- https://tools.ietf.org/html/rfc4303#section-2
+local ESP_SIZE = esp:sizeof()
+local ESP_TAIL_SIZE = esp_tail:sizeof()
 
 function esp_v6_new (conf)
    assert(conf.mode == "aes-128-gcm", "Only supports aes-128-gcm.")
-   return { aes_128_gcm = aes_128_gcm:new(conf.spi, conf.keymat, conf.salt),
-            seq = ffi.new(seq_no_t),
-            pad_to = 4, -- minimal padding
-            d_in = datagram:new(),
-            d_out = datagram:new()}
+   assert(conf.spi, "Need SPI.")
+   local gcm = aes_128_gcm:new(conf.spi, conf.keymat, conf.salt)
+   local o = {}
+   o.ESP_OVERHEAD = ESP_SIZE + ESP_TAIL_SIZE + gcm.IV_SIZE + gcm.AUTH_SIZE
+   o.aes_128_gcm = gcm
+   o.spi = conf.spi
+   o.seq = ffi.new(seq_no_t)
+   o.pad_to = 4 -- minimal padding
+   o.ip = ipv6:new({})
+   o.esp = esp:new({})
+   o.esp_tail = esp_tail:new({})
+   return o
 end
 
 esp_v6_encrypt = {}
 
 function esp_v6_encrypt:new (conf)
    local o = esp_v6_new(conf)
-   o.zero_buf = ffi.new("uint8_t[?]", math.max(o.pad_to, o.aes_128_gcm.auth_size))
-   o.esp = esp:new({})
-   o.esp:spi(assert(conf.spi, "Need SPI."))
-   o.esp_tail = esp_tail:new({})
+   o.ESP_PAYLOAD_OVERHEAD =  o.aes_128_gcm.IV_SIZE + ESP_TAIL_SIZE
    return setmetatable(o, {__index=esp_v6_encrypt})
 end
 
--- Return next sequence number.
+-- Increment sequence number.
 function esp_v6_encrypt:next_seq_no ()
    self.seq.no = self.seq.no + 1
-   return self.seq:low()
 end
 
 local function padding (a, l) return (a - l%a) % a end
 
-function esp_v6_encrypt:encrypt (nh, payload, length)
-   local gcm = self.aes_128_gcm
-   local p = packet.allocate()
-   self.esp:seq_no(self:next_seq_no())
-   packet.append(p, self.esp:header_ptr(), esp_size)
-   packet.append(p, self.seq, gcm.iv_size)
-   packet.append(p, payload, length)
-   -- Padding, see https://tools.ietf.org/html/rfc4303#section-2.4
-   local pad_length = padding(self.pad_to, gcm.iv_size + length + esp_tail_size)
-   packet.append(p, self.zero_buf, pad_length)
-   self.esp_tail:next_header(nh)
-   self.esp_tail:pad_length(pad_length)
-   packet.append(p, self.esp_tail:header_ptr(), esp_tail_size)
-   packet.append(p, self.zero_buf, gcm.auth_size)
-   local cleartext = packet.data(p) + esp_size + gcm.iv_size
-   gcm:encrypt(cleartext, self.seq, self.seq, cleartext, length + pad_length + esp_tail_size)
-   return p
-end
-
+-- Encapsulation is performed as follows:
+--   1. Grow p to fit ESP overhead
+--   2. Append ESP trailer to p
+--   3. Encrypt payload+trailer in place
+--   4. Move resulting ciphertext to make room for ESP header
+--   5. Write ESP header
 function esp_v6_encrypt:encapsulate (p)
-   local plain = self.d_in:new(p)
-   if not plain:parse({{ethernet}, {ipv6}}) then return nil end
-   local eth, ip = unpack(plain:stack())
-   local nh = ip:next_header()
-   local encrypted = self.d_out:new(self:encrypt(nh, plain:payload()))
-   local _, length = encrypted:payload()
-   ip:next_header(esp_nh)
-   ip:payload_length(length)
-   encrypted:push(ip)
-   encrypted:push(eth)
-   return encrypted:packet()
+   local gcm = self.aes_128_gcm
+   local data, length = packet.data(p), packet.length(p)
+   local payload = data + PAYLOAD_OFFSET
+   local payload_length = length - PAYLOAD_OFFSET
+   -- Padding, see https://tools.ietf.org/html/rfc4303#section-2.4
+   local pad_length = padding(self.pad_to, payload_length + self.ESP_PAYLOAD_OVERHEAD)
+   local overhead = self.ESP_OVERHEAD + pad_length
+   packet.resize(p, length + overhead)
+   local padding_start = data + length
+   C.memset(padding_start, 0, pad_length)
+   self.ip:new_from_mem(data + ETHERNET_SIZE, IPV6_SIZE)
+   self.esp_tail:new_from_mem(padding_start + pad_length, ESP_TAIL_SIZE)
+   self.esp_tail:next_header(self.ip:next_header())
+   self.esp_tail:pad_length(pad_length)
+   self:next_seq_no()
+   local ptext_length = payload_length + pad_length + ESP_TAIL_SIZE
+   gcm:encrypt(payload, self.seq, self.seq, payload, ptext_length)
+   local iv = payload + ESP_SIZE
+   local ctext = iv + gcm.IV_SIZE
+   C.memmove(ctext, payload, ptext_length + gcm.AUTH_SIZE)
+   self.esp:new_from_mem(payload, ESP_SIZE)
+   self.esp:spi(self.spi)
+   self.esp:seq_no(self.seq:low())
+   ffi.copy(iv, self.seq, gcm.IV_SIZE)
+   self.ip:next_header(ESP_NH)
+   self.ip:payload_length(payload_length + overhead)
+   return p
 end
 
 
@@ -109,8 +119,9 @@ esp_v6_decrypt = {}
 function esp_v6_decrypt:new (conf)
    local o = esp_v6_new(conf)
    local gcm = o.aes_128_gcm
-   local esp_overhead = esp_size + esp_tail_size + gcm.iv_size + gcm.auth_size
-   o.min_size = esp_overhead + padding(o.pad_to, esp_overhead)
+   o.MIN_SIZE = o.ESP_OVERHEAD + padding(o.pad_to, o.ESP_OVERHEAD)
+   o.CTEXT_OFFSET = ESP_SIZE + gcm.IV_SIZE
+   o.PLAIN_OVERHEAD = PAYLOAD_OFFSET + ESP_SIZE + gcm.IV_SIZE + gcm.AUTH_SIZE
    o.window_size = conf.window_size or 128
    return setmetatable(o, {__index=esp_v6_decrypt})
 end
@@ -132,39 +143,34 @@ function esp_v6_decrypt:check_seq_no (seq_no)
    end
 end
 
-function esp_v6_decrypt:decrypt (payload, length)
+-- Decapsulation is performed as follows:
+--   1. Parse IP and ESP headers and check Sequence Number
+--   2. Decrypt ciphertext in place
+--   3. Parse ESP trailer and update IP header
+--   4. Move cleartext up to IP payload
+--   5. Shrink p by ESP overhead
+function esp_v6_decrypt:decapsulate (p)
    local gcm = self.aes_128_gcm
-   if length < self.min_size then return end
-   local iv_start = payload + esp_size
-   local data_start = payload + esp_size + gcm.iv_size
-   local data_length = length - esp_size - gcm.iv_size - gcm.auth_size
-   local esp = esp:new_from_mem(payload, esp_size)
-   local seq_low, seq_high = self:check_seq_no(esp:seq_no())
-   if seq_low and gcm:decrypt(data_start, seq_low, seq_high, iv_start, data_start, data_length) then
-      local esp_tail_start = data_start + data_length - esp_tail_size
-      local esp_tail = esp_tail:new_from_mem(esp_tail_start, esp_tail_size)
-      local cleartext_length = data_length - esp_tail:pad_length() - esp_tail_size
-      local p = packet.from_pointer(data_start, cleartext_length)
+   local data, length = packet.data(p), packet.length(p)
+   if length - PAYLOAD_OFFSET < self.MIN_SIZE then return end
+   self.ip:new_from_mem(data + ETHERNET_SIZE, IPV6_SIZE)
+   local payload = data + PAYLOAD_OFFSET
+   self.esp:new_from_mem(payload, ESP_SIZE)
+   local iv_start = payload + ESP_SIZE
+   local ctext_start = payload + self.CTEXT_OFFSET
+   local ctext_length = length - self.PLAIN_OVERHEAD
+   local seq_low, seq_high = self:check_seq_no(self.esp:seq_no())
+   if seq_low and gcm:decrypt(ctext_start, seq_low, seq_high, iv_start, ctext_start, ctext_length) then
       self.seq:low(seq_low)
       self.seq:high(seq_high)
-      return p, esp_tail:next_header()
-   end
-end
-
-function esp_v6_decrypt:decapsulate (p)
-   local encrypted = self.d_in:new(p)
-   if not encrypted:parse({{ethernet}, {ipv6}}) then return nil end
-   local eth, ip = unpack(encrypted:stack())
-   if ip:next_header() == esp_nh then
-      local payload, nh = self:decrypt(encrypted:payload())
-      if payload then
-         local plain = self.d_out:new(payload)
-         ip:next_header(nh)
-         ip:payload_length(packet.length(payload))
-         plain:push(ip)
-         plain:push(eth)
-         return plain:packet()
-      end
+      local esp_tail_start = ctext_start + ctext_length - ESP_TAIL_SIZE
+      self.esp_tail:new_from_mem(esp_tail_start, ESP_TAIL_SIZE)
+      local ptext_length = ctext_length - self.esp_tail:pad_length() - ESP_TAIL_SIZE
+      self.ip:next_header(self.esp_tail:next_header())
+      self.ip:payload_length(ptext_length)
+      C.memmove(payload, ctext_start, ptext_length)
+      packet.resize(p, PAYLOAD_OFFSET + ptext_length)
+      return p
    end
 end
 

--- a/src/lib/ipsec/seq_no_t.lua
+++ b/src/lib/ipsec/seq_no_t.lua
@@ -3,6 +3,7 @@ local ffi = require("ffi")
 
 -- Sequence number type with accessors for lower/upper order 32 bits
 
+local seq_no_t = ffi.typeof("union { uint64_t no; uint32_t no32[2]; }")
 local seq_no = {}
 
 function seq_no:full () return self.no end
@@ -21,5 +22,4 @@ function seq_no:high (n)
    else return self.no32[high] end
 end
 
-return ffi.metatype("union { uint64_t no; uint32_t no32[2]; }",
-                    {__index=seq_no})
+return ffi.metatype(seq_no_t, {__index=seq_no})

--- a/src/lib/ipsec/track_seq_no.c
+++ b/src/lib/ipsec/track_seq_no.c
@@ -1,0 +1,14 @@
+#include <stdint.h>
+
+// See https://tools.ietf.org/html/rfc4303#page-38
+// This is a only partial implementation that attempts to keep track of the
+// ESN counter, but does not detect replayed packets.
+uint32_t track_seq_no (uint32_t seq_no, uint32_t Tl, uint32_t Th, uint32_t W) {
+  if (Tl >= W - 1) { // Case A
+    if (seq_no >= Tl - W + 1) return Th;
+    else                      return Th + 1;
+  } else {           // Case B
+    if (seq_no >= Tl - W + 1) return Th - 1;
+    else                      return Th;
+  }
+}

--- a/src/lib/ipsec/track_seq_no.h
+++ b/src/lib/ipsec/track_seq_no.h
@@ -1,0 +1,1 @@
+uint32_t track_seq_no (uint32_t, uint32_t, uint32_t, uint32_t);

--- a/src/program/snabbmark/README
+++ b/src/program/snabbmark/README
@@ -37,6 +37,9 @@ Usage:
     Example usage with 10 million packets, packet size 128 bytes:
     sudo SNABB_PCI0="0000:02:00.0"  SNABB_PCI1="0000:03:00.0" ./snabb snabbmark intel1g 10e6 128
 
-  snabbmark esp <npackets> <packet-size>
-    Benchmark ESP encapsulating and decapsulatiing <npackets> of
-    <packet-size>.
+  snabbmark esp <npackets> <packet-size> [<mode>] [<profile>]
+    Benchmark ESP encapsulating or decapsulatiing <npackets> of
+    <packet-size>. <mode> can be either "encapsulate" or "decapsulate", the
+    latter being the default. Optionally, a LuaJIT profiler option string can
+    be supplied as <profile>, which will cause the benchmark run to be profiled
+    accordingly.

--- a/src/program/snabbmark/snabbmark.lua
+++ b/src/program/snabbmark/snabbmark.lua
@@ -22,7 +22,7 @@ function run (args)
       solarflare(unpack(args))
    elseif command == 'intel1g' and #args >= 2 and #args <= 3 then
       intel1g(unpack(args))
-   elseif command == 'esp' and #args == 2 then
+   elseif command == 'esp' and #args >= 2 then
       esp(unpack(args))
    else
       print(usage) 
@@ -332,11 +332,12 @@ receive_device.interface= "rx1GE"
    end
 end
 
-function esp (npackets, packet_size)
+function esp (npackets, packet_size, mode, profile)
    local esp = require("lib.ipsec.esp")
    local ethernet = require("lib.protocol.ethernet")
    local ipv6 = require("lib.protocol.ipv6")
    local datagram = require("lib.protocol.datagram")
+   local profiler = profile and require("jit.p")
 
    npackets = assert(tonumber(npackets), "Invalid number of packets: " .. npackets)
    packet_size = assert(tonumber(packet_size), "Invalid packet size: " .. packet_size)
@@ -345,44 +346,43 @@ function esp (npackets, packet_size)
    local ip = ipv6:new({})
    ip:payload_length(payload_size)
    local eth = ethernet:new({type=0x86dd})
-   local packets = {}
-   for i = 1, npackets do
-      local d = datagram:new(packet.allocate())
-      d:payload(payload, payload_size)
-      d:push(ip)
-      d:push(eth)
-      packets[i] = d:packet()
-   end
+   local d = datagram:new(packet.allocate())
+   d:payload(payload, payload_size)
+   d:push(ip)
+   d:push(eth)
+   local plain = d:packet()
    local conf = { spi = 0x0,
                   mode = "aes-128-gcm",
                   keymat = "00112233445566778899AABBCCDDEEFF",
                   salt = "00112233"}
    local enc, dec = esp.esp_v6_encrypt:new(conf), esp.esp_v6_decrypt:new(conf)
 
-   require("jit.p").start("Fpv")
-   local start = C.get_monotonic_time()
-   for i, p in ipairs(packets) do
-      packets[i] = enc:encapsulate(p)
-   end
-   local finish = C.get_monotonic_time()
-   require("jit.p").stop()
-   local bps = (packet_size * npackets) / (finish - start)
-   print(("Encapsulation (packet size = %d): %.2f Gbit/s")
-         :format(packet_size, gbits(bps)))
-
-   require("jit.p").start("Fpv")
-   local start = C.get_monotonic_time()
-   for i, p in ipairs(packets) do
-      packets[i] = dec:decapsulate(p)
-   end
-   local finish = C.get_monotonic_time()
-   require("jit.p").stop()
-   local bps = (packet_size * npackets) / (finish - start)
-   print(("Decapsulation (packet size = %d): %.2f Gbit/s")
-         :format(packet_size, gbits(bps)))
-
-   for _, p in ipairs(packets) do
-      assert(p, "Decapsulation of some packets failed.")
-      packet.free(p)
+   if mode == "encapsulate" then
+      if profile then profiler.start(profile) end
+      local start = C.get_monotonic_time()
+      local encapsulated
+      for i = 1, npackets do
+         encapsulated = enc:encapsulate(packet.clone(plain))
+         packet.free(encapsulated)
+      end
+      local finish = C.get_monotonic_time()
+      if profile then profiler.stop() end
+      local bps = (packet_size * npackets) / (finish - start)
+      print(("Encapsulation (packet size = %d): %.2f Gbit/s")
+            :format(packet_size, gbits(bps)))
+   else
+      local encapsulated = enc:encapsulate(plain)
+      if profile then profiler.start(profile) end
+      local start = C.get_monotonic_time()
+      local plain
+      for i = 1, npackets do
+         plain = dec:decapsulate(packet.clone(encapsulated))
+         packet.free(plain)
+      end
+      local finish = C.get_monotonic_time()
+      if profile then profiler.stop() end
+      local bps = (packet_size * npackets) / (finish - start)
+      print(("Decapsulation (packet size = %d): %.2f Gbit/s")
+            :format(packet_size, gbits(bps)))
    end
 end


### PR DESCRIPTION
This optimizes the encapsulation and decapsulation routines provided by `lib.ipsec.esp`:

* The routines now use raw buffer mutations instead of `packet.append`, and no longer create a new packet, instead they only mutate the input packet. For this I added a function `packet.resize` that is really just a setter for `packet.length` that additionally checks for overflow.
* Following the awesome [JIT tracology research](https://github.com/SnabbCo/snabbswitch/pull/638) by @alexandergall, the branch heavy sequence number tracking is now implemented as a C function. (This is actually not a caveat, it would probably have to become a C function anyways in the course of implementing efficient anti-replay functionality.)

Benchmark results:

```
$ sudo ./snabb snabbmark esp 1e7 1024 encapsulate
Encapsulation (packet size = 1024): 13.78 Gbit/s
```

```
$ sudo ./snabb snabbmark esp 1e7 1024 decapsulate
Decapsulation (packet size = 1024): 14.23 Gbit/s
```

Cc @lukego 