### PR TITLE
doc/trademark: Added tracemark policy

### DIFF
--- a/src/doc/trademark.md
+++ b/src/doc/trademark.md
@@ -1,0 +1,34 @@
+## Trademark policy
+
+The Snabb logo is a copyrighted design, and the name "Snabb" is a registered trademark. If you wish to use the name or logo in any way, you must comply with this policy.
+
+1. The name and logo, or derivatives of it may be used to promote Snabb based products or services.
+2. The name and logo, or derivatives of it may be used to promote or serve Snabb or related projects and their communities.
+3. You may not state or otherwise lead people to believe, that you represent the Snabb open source community in any way other than as an individual or corporate contributor to the project.
+
+### Examples
+
+#### Acceptable use
+
+The following are examples of acceptable uses of the logo:
+
+- Inclusion of the name or logo on your website offering Snabb support or consultancy services.
+- Inclusion of the name or logo on your website from which you offer Snabb-related or Snabb-derived software products.
+- Inclusion of a modified version of the logo on a Snabb user forum that you run.
+- Inclusion of the name or logo in your software or documentation to indicate that it runs on or with Snabb.
+- Use of the name or logo on websites, publications or merchandise, modified or unmodified, for Snabb user groups, events, or non-profit organizations which support Snabb.
+- Use of the name or logo to advertise Snabb-related content in a public event.
+- Use of the name or logo in news articles or blogs which reference the Snabb Project.
+
+#### Unacceptable use
+
+The following are example of uses of the logo which are NOT acceptable:
+
+- Use of the name or logo in a software product that is unrelated to Snabb and does not run on it, or work with it.
+- Use of the name or logo to promote a product that directly competes with Snabb but is otherwise unrelated.
+- Use of the name or logo for a club or function that is unrelated to Snabb.
+
+### Contact
+
+If you have any questions about this policy, or its interpretation,
+please open a Github Issue on the SnabbCo/snabbswitch repository.


### PR DESCRIPTION
This is a simple and permissive trademark license taken directly from
the PostgreSQL one: https://wiki.postgresql.org/wiki/Trademark_Policy.

This would make it clear that everybody is welcome to use the Snabb name and logo for diverse Snabb-related activities such as promoting software, conferences, user groups, support services, books, magazine articles, etc. This means that "Snabb" would refer to the union of all these activities.

Suitable for our project?