### PR TITLE
[wip] core.timeline: High-resolution event log for diagnostics

### DIFF
--- a/src/core/timeline.dasl
+++ b/src/core/timeline.dasl
@@ -103,7 +103,7 @@ end
 
 function message_args (string)
    local args = {}
-   string:gsub("[$](%w)+", function (arg) table.insert(args, arg) end)
+   string:gsub("[$](%w+)", function (arg) table.insert(args, arg) end)
    return args
 end
 

--- a/src/core/timeline.dasl
+++ b/src/core/timeline.dasl
@@ -1,92 +1,293 @@
+-- timeline: high-resolution event log using in-memory ring buffer
 -- Use of this source code is governed by the Apache 2.0 license; see COPYING.
-
--- timeline: high-resolution event log.
---
--- This module implements an event log that is suitable for logging
--- very fine-grained events during traffic processing.
--- 
--- Design goals:
---   Fast enough to log 1M msg/sec with <1% CPU overhead.
---   Precise timestamps for cross-referencing processes (and PEBS events).
---   Simple format that is easy to post-process.
 
 module(..., package.seeall)
 
 local dasm = require("dasm")
 local ffi = require("ffi")
 local C = ffi.C
+local S = require("syscall")
+local shm = require("core.shm")
 
--- Log message format
+------------------------------------------------------------
+-- Binary data structures
+
+-- Log entry format (ring item)
+
 ffi.cdef[[
-struct timeline_entry {
-  // CPU Time Stamp Counter (cycles)
-  uint64_t tsc;
-  // Instruction Pointer where log is taken
-  uint64_t ip;
-  // Message (could be generalized...)
-  uint64_t msg;
-}
+  struct timeline_entry {
+    uint64_t tsc;                    // CPU timestamp
+    uint64_t ip;                     // Instruction pointer of logger
+    uint64_t msg_id;                 // category:24, message:24, priority:16
+    uint64_t msg0, msg1, msg2, msg3; // message arguments
+    uint64_t reserved;               // pad to 64 bytes
+  };
 ]]
 
--- XXX For test purposes just allocate a 1GB log.
-local log = ffi.cast("struct timeline_entry *", C.malloc(1*1024*1024*1024))
-local log_ptr = ffi.new("struct timeline_entry *[1]", log)
+-- Header of the log file
+
+local magic = 0xa3ff7223441d0001
+local version = 0x00010001
+
+ffi.cdef[[
+  struct timeline_header {
+    // File format magic number.
+    uint32_t magic;
+    uint8_t major_version, minor_version;
+    uint16_t flags;
+    // XXX: does not really need to be stored in the file?
+    uint64_t priority_mask;
+    uint64_t next;
+    uint64_t last;
+    char pad[32];
+    struct timeline_entry entries[0];
+  };
+]]
+
+------------------------------------------------------------
+-- API
+
+-- Create a new timeline under the given shared memory path.
+function new (shmpath,  entries, size_stringtable)
+   entries = entries or 1024*1024
+   size_stringtable = size_stringtable or 1e6
+   -- Calculate size based on number of log entries
+   local size_header = ffi.sizeof("struct timeline_header")
+   local size_entries = entries * ffi.sizeof("struct timeline_entry")
+   local size = size_header + size_entries + size_stringtable
+   -- Allocate one shm object with memory for all data structures
+   local memory      = shm.map(shmpath, ffi.typeof("char["..size.."]"))
+   local header      = ffi.cast("struct timeline_header *", memory)
+   local ring        = ffi.cast("struct timeline_entry *", memory + size_header)
+   local stringtable = ffi.cast("char*", memory + size_header + size_entries)
+   -- Return an object
+   return { memory = memory,
+            entries = entries,
+            header = init_header(ffi.cast("struct timeline_header *", memory), entries),
+            ring = ring,
+            stringtable = init_stringtable(stringtable, size_stringtable) }
+end
+
+function init_header (header, entries)
+   header.magic = magic
+   header.major_version, header.minor_version = 0, 0
+   header.flags = 0
+   header.priority_mask = 0xffff
+   header.next = 0
+   header.last = entries-1      -- XXX entries must be a power of 2
+   return header
+end
+
+local priorities = {['fatal']=1, ['error']=2, ['warning']=3, ['info']=4, ['debug']=5,
+                    ['trace']=6, ['trace+']=7, ['trace++']=8, ['trace+++']=9}
+
+-- Define an event and return the logger function.
+function define (timeline, category, priority, message)
+   local icategory = intern(timeline.stringtable, category)
+   local imessage = intern(timeline.stringtable, message)
+   local prio = priorities[priority] or error("unrecognized priority: "..priority)
+   local id = bit.bor(bit.lshift(icategory, 40),
+                      bit.lshift(imessage, 16),
+                      prio)
+   local n = #(message_args(message))
+   local event = event -- move asm function into local scope
+   local log = timeline.header
+   if n==0 then return function ()        event(log,id,0,0,0,0) end end
+   if n==1 then return function (a)       event(log,id,a,0,0,0) end end
+   if n==2 then return function (a,b)     event(log,id,a,b,0,0) end end
+   if n==3 then return function (a,b,c)   event(log,id,a,b,c,0) end end
+   if n==4 then return function (a,b,c,d) event(log,id,a,b,c,d) end end
+   error("illegal number of arguments: "..n)
+end
+
+function message_args (string)
+   local args = {}
+   string:gsub("[$](%w)+", function (arg) table.insert(args, arg) end)
+   return args
+end
+
+-- Write a copy of the timeline to a file
+function save (tl, filename)
+   local fd, err = S.open(filename, "rdwr,creat", "0600")
+   if not fd then return fd, err end
+   S.write(fd, tl.memory, ffi.sizeof(tl.memory))
+   S.close(fd)
+   return true
+end
+
+-- Choose the minimum priority for a message to be logged
+function priority (level)
+   error("NYI")
+end
+
+-- Print log entries from the file
+function dump (filename,  maxentries)
+   local stat, err = S.stat(filename)
+   if not stat then return stat, err end
+   local fd, err = S.open(filename, "rdonly")
+   if not fd then return fd, err end
+   local ptr = S.mmap(nil, stat.size, "read", "private", fd, 0)
+   local header = ffi.cast("struct timeline_header *", ptr)
+   local ring = header.entries
+   local strings = ffi.cast("char*", header.entries + (header.last + 1))
+   local last = tonumber(header.last)
+   local size = last + 1
+   print(("%8s %-16s %s"):format("cycles", "category", "message"))
+   -- "Fast-forward" to the end (when following entry has earlier timestamp)
+   local index = 0
+   while ring[index].tsc <= ring[(index+1) % size].tsc do
+      index = (index+1) % size
+   end
+   -- "Rewind" printing messages
+   local ref_tsc = nil
+   for i = 0, size-1 do
+      if maxentries and i > maxentries then break end
+      local timedelta = ref_tsc and (ref_tsc - ring[index].tsc) or 0
+      local msgid = ring[index].msg_id
+      local icategory = bit.band(0xffff, bit.rshift(msgid, 40))
+      local imessage = bit.band(0xffff, bit.rshift(msgid, 16))
+      -- Lookup the messages and perform arg substitution
+      local category = ffi.string(strings + icategory)
+      local format = ffi.string(strings + imessage)
+      local args = {tonumber(ring[index].msg3),
+                    tonumber(ring[index].msg2),
+                    tonumber(ring[index].msg1),
+                    tonumber(ring[index].msg0)}
+      local subst = function (match)
+         -- convert "$foo" to "foo(10)"
+         return match:gsub("^[$]", "", 1).."("..table.remove(args)..")"
+      end
+      local message = format:gsub("($%w+)", subst)
+      print(("%8d %-16s %s"):format(tonumber(timedelta), category, message))
+      ref_tsc = ring[index].tsc
+      index = (index == 0) and last or index-1
+   end
+end
+
+------------------------------------------------------------
+-- Defining log message formats
+
+function init_stringtable (pointer, size)
+   return { base = pointer, position = 0, space = size, known = {} }
+end
+
+-- Interns a string in the string table and returns the string's index.
+function intern (tab, str)
+   if tab.known[str] then
+      return tab.known[str]
+   else
+      local bytes = #str + 1 -- include null terminator byte
+      tab.space = tab.space - bytes
+      assert(tab.space >= 0, "timeline string table overflow")
+      local pos = tab.position
+      ffi.copy(tab.base + tab.position, str, bytes)
+      tab.position = tab.position + bytes
+      tab.known[str] = pos
+      return pos
+   end
+end
+
+-- Lookup an interned string by index and return as a Lua string.
+function lookup (tab, index)
+   return ffi.string(tab.base + index)
+end
+
+------------------------------------------------------------
+-- Logging messages
 
 |.arch x64
 |.actionlist actions
 |.globalnames globalnames
 
-|.define arg1, rdi
 
+|.define arg0, rdi
+|.define arg1, rsi
+|.define arg2, rdx
+|.define arg3, rcx
+|.define arg4, r8
+|.define arg5, r9
+
+|.type log, struct timeline_header
 |.type msg, struct timeline_entry
-
--- void log(uint64_t msg)
 local function asmlog (Dst)
    |->log:
-   -- (No registers to save. Using rax, rdx, rcx, rdi, r8 which are
-   -- all caller-save.)
-   | rdtscp                 -- read timestamp counter into edx:eax (trash ecx)
-   | shl rdx, 32            -- reconstruct 64-bit TSC in rax
-   | or rax, rdx            --   ...
-   | mov r8, [log_ptr]      -- Load address of next log entry
-   | mov msg:r8->tsc, rax   -- Store timestamp in log
-   | mov rax, [rsp]         -- Grab caller address from stack
-   | mov msg:r8->ip, rax    --   ... and store in message
-   | mov msg:r8->msg, arg1  -- Store message in log
-   | add r8, #msg           -- Advance log pointer
-   | mov [log_ptr], r8      --   ... XXX must check for overflow
-   -- (No saved registers to restore.)
+   -- Exit if this log message is disabled
+   | mov rax, log:arg0->priority_mask
+   | and rax, arg1
+   | jnz >1
+   | ret
+   |1:
+
+   -- Load and advance next log entry index
+   | mov r11, log:arg0->next
+   | mov rax, r11
+   | add rax, 1
+   | and rax, log:arg0->last
+   | mov log:arg0->next, rax
+
+   -- Convert log entry number to pointer
+   | shl r11, 6
+   | lea r10, log:arg0->entries
+   | add r10, r11
+
+   -- Log the arguments
+   | mov msg:r10->msg_id, arg1
+   | mov msg:r10->msg0, arg2
+   | mov msg:r10->msg1, arg3
+   | mov msg:r10->msg2, arg4
+   | mov msg:r10->msg3, arg5
+
+   -- Log the timestamp
+   | rdtscp
+   | mov msg:r10->tsc, eax
+   | mov [r10+4], edx
+
+   -- Log the instruction pointer
+   | mov rax, [rsp]
+   | mov msg:r10->ip, rax
+
    | ret
 end
 
 local Dst, globals = dasm.new(actions, nil, nil, 1 + #globalnames)
 asmlog(Dst)
 local mcode, size = Dst:build()
---dasm.dump(mcode, size)
 local entry = dasm.globals(globals, globalnames)
 
-event = ffi.cast("void(*)(uint64_t)", entry.log)
+event = ffi.cast("void(*)(struct timeline_header *, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t)", entry.log)
+
 _anchor = mcode
+
+--dasm.dump(mcode, size)
 
 function selftest ()
    print("selftest: timeline")
-   local n = 1e6
+   local tl = new("selftest/timeline")
+   local event1 = define(tl, 'selftest', 'trace', 'event1 $a $b $c $d')
+   local event2 = define(tl, 'selftest', 'trace', 'event2 $a')
+   local event3 = define(tl, 'selftest', 'trace', 'event3')
    -- Log events
-   for i = 0, n-1 do
-      event(i)
-   end
-   -- Check log
-   for i = 0, n-1 do
-      assert(i==0 or log[i].tsc > log[i-1].tsc, "tsc increase")
-      assert(log[i].msg == i, "message value")
+   for i = 0, tl.entries-1 do
+      if i % 3 == 0 then event1(i, i*2, i*3, i*4) end
+      if i % 3 == 1 then event2(i) end
+      if i % 3 == 2 then event3() end
    end
    -- Print statistics
    local times = {}
-   for i = 0, n-1 do
-      if i > 0 then times[#times+1] = tonumber(log[i].tsc - log[i-1].tsc) end
+   for i = 0, tl.entries-1 do
+      if i > 0 then times[#times+1] = tonumber(tl.ring[i].tsc - tl.ring[i-1].tsc) end
    end
    table.sort(times)
-   print("median logging time", times[n/2])
+   local n = tl.entries
+   --print("times:", times[1], times[n/2], times[n/4], times[n*3/4])
+   print("median logging time: "..times[tl.entries/2].." cycles")
+   -- Check log
+   for i = 0, tl.entries-1 do
+      assert(i==0 or tl.ring[i].tsc > tl.ring[i-1].tsc, "tsc increase")
+   end
+   print("selftest: save and dump")
+   save(tl, "selftest-timeline.dat")
+   dump("selftest-timeline.dat", 10)
    print("selftest: ok")
 end
 

--- a/src/core/timeline.dasl
+++ b/src/core/timeline.dasl
@@ -1,0 +1,92 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
+-- timeline: high-resolution event log.
+--
+-- This module implements an event log that is suitable for logging
+-- very fine-grained events during traffic processing.
+-- 
+-- Design goals:
+--   Fast enough to log 1M msg/sec with <1% CPU overhead.
+--   Precise timestamps for cross-referencing processes (and PEBS events).
+--   Simple format that is easy to post-process.
+
+module(..., package.seeall)
+
+local dasm = require("dasm")
+local ffi = require("ffi")
+local C = ffi.C
+
+-- Log message format
+ffi.cdef[[
+struct timeline_entry {
+  // CPU Time Stamp Counter (cycles)
+  uint64_t tsc;
+  // Instruction Pointer where log is taken
+  uint64_t ip;
+  // Message (could be generalized...)
+  uint64_t msg;
+}
+]]
+
+-- XXX For test purposes just allocate a 1GB log.
+local log = ffi.cast("struct timeline_entry *", C.malloc(1*1024*1024*1024))
+local log_ptr = ffi.new("struct timeline_entry *[1]", log)
+
+|.arch x64
+|.actionlist actions
+|.globalnames globalnames
+
+|.define arg1, rdi
+
+|.type msg, struct timeline_entry
+
+-- void log(uint64_t msg)
+local function asmlog (Dst)
+   |->log:
+   -- (No registers to save. Using rax, rdx, rcx, rdi, r8 which are
+   -- all caller-save.)
+   | rdtscp                 -- read timestamp counter into edx:eax (trash ecx)
+   | shl rdx, 32            -- reconstruct 64-bit TSC in rax
+   | or rax, rdx            --   ...
+   | mov r8, [log_ptr]      -- Load address of next log entry
+   | mov msg:r8->tsc, rax   -- Store timestamp in log
+   | mov rax, [rsp]         -- Grab caller address from stack
+   | mov msg:r8->ip, rax    --   ... and store in message
+   | mov msg:r8->msg, arg1  -- Store message in log
+   | add r8, #msg           -- Advance log pointer
+   | mov [log_ptr], r8      --   ... XXX must check for overflow
+   -- (No saved registers to restore.)
+   | ret
+end
+
+local Dst, globals = dasm.new(actions, nil, nil, 1 + #globalnames)
+asmlog(Dst)
+local mcode, size = Dst:build()
+--dasm.dump(mcode, size)
+local entry = dasm.globals(globals, globalnames)
+
+event = ffi.cast("void(*)(uint64_t)", entry.log)
+_anchor = mcode
+
+function selftest ()
+   print("selftest: timeline")
+   local n = 1e6
+   -- Log events
+   for i = 0, n-1 do
+      event(i)
+   end
+   -- Check log
+   for i = 0, n-1 do
+      assert(i==0 or log[i].tsc > log[i-1].tsc, "tsc increase")
+      assert(log[i].msg == i, "message value")
+   end
+   -- Print statistics
+   local times = {}
+   for i = 0, n-1 do
+      if i > 0 then times[#times+1] = tonumber(log[i].tsc - log[i-1].tsc) end
+   end
+   table.sort(times)
+   print("median logging time", times[n/2])
+   print("selftest: ok")
+end
+

--- a/src/core/timeline.dasl
+++ b/src/core/timeline.dasl
@@ -133,7 +133,9 @@ function dump (filename,  maxentries)
    local strings = ffi.cast("char*", header.entries + (header.last + 1))
    local last = tonumber(header.last)
    local size = last + 1
-   print(("%8s %-16s %s"):format("cycles", "category", "message"))
+   -- Print column headers.
+   -- Note: "-cycles" column is time delta between entries (moving backwards in time)
+   print(("%4s %4s %8s %-16s %s"):format("numa", "core", "-cycles", "category", "message"))
    -- "Fast-forward" to the end (when following entry has earlier timestamp)
    local index = 0
    while ring[index].tsc <= ring[(index+1) % size].tsc do
@@ -143,10 +145,17 @@ function dump (filename,  maxentries)
    local ref_tsc = nil
    for i = 0, size-1 do
       if maxentries and i > maxentries then break end
-      local timedelta = ref_tsc and (ref_tsc - ring[index].tsc) or 0
+      local timedelta
+      if ref_tsc == nil then
+         timedelta = '<last>'
+      else
+         timedelta = tonumber(ref_tsc - ring[index].tsc)
+      end
       local msgid = ring[index].msg_id
       local icategory = bit.band(0xffff, bit.rshift(msgid, 40))
       local imessage = bit.band(0xffff, bit.rshift(msgid, 16))
+      local core = bit.band(0xff, ring[index].aux)
+      local numa = bit.band(0x0f, bit.rshift(ring[index].aux, 12))
       -- Lookup the messages and perform arg substitution
       local category = ffi.string(strings + icategory)
       local format = ffi.string(strings + imessage)
@@ -159,7 +168,8 @@ function dump (filename,  maxentries)
          return match:gsub("^[$]", "", 1).."("..table.remove(args)..")"
       end
       local message = format:gsub("($%w+)", subst)
-      print(("%8d %-16s %s"):format(tonumber(timedelta), category, message))
+      print(("%-4d %-4d %8s %-16s %s"):format(
+            numa, core, timedelta, category, message))
       ref_tsc = ring[index].tsc
       index = (index == 0) and last or index-1
    end
@@ -265,14 +275,14 @@ _anchor = mcode
 function selftest ()
    print("selftest: timeline")
    local tl = new("selftest/timeline")
-   local event1 = define(tl, 'selftest', 'trace', 'event1 $a $b $c $d')
-   local event2 = define(tl, 'selftest', 'trace', 'event2 $a')
-   local event3 = define(tl, 'selftest', 'trace', 'event3')
+   local event1 = define(tl, 'selftest', 'trace', 'event with four args: $i, $2i, $3i, and $4i')
+   local event2 = define(tl, 'selftest', 'trace', 'event with one arg: $i')
+   local event3 = define(tl, 'selftest', 'trace', 'event with no args')
    -- Log events
    for i = 0, tl.entries-1 do
-      if i % 3 == 0 then event1(i, i*2, i*3, i*4) end
-      if i % 3 == 1 then event2(i) end
-      if i % 3 == 2 then event3() end
+      event1(i, i*2, i*3, i*4)
+      event2(i)
+      event3()
    end
    -- Print statistics
    local times = {}
@@ -289,7 +299,7 @@ function selftest ()
    end
    print("selftest: save and dump")
    save(tl, "selftest-timeline.dat")
-   dump("selftest-timeline.dat", 10)
+   dump("selftest-timeline.dat", 15)
    print("selftest: ok")
 end
 

--- a/src/core/timeline.dasl
+++ b/src/core/timeline.dasl
@@ -301,6 +301,24 @@ function selftest ()
       assert(i==0 or tl.ring[i].tsc > tl.ring[i-1].tsc, "tsc increase")
    end
 
+   -- Create some log entries showing the logging throughput for
+   -- messages that are disabled by priority.
+   -- (These will be printed below.)
+   local timing_start = define(tl, 'timing', 'trace', 'timing tight loop of disabled events')
+   local timing_loop  = define(tl, 'timing', 'trace',  'invoked many $events')
+   local timing_dis   = define(tl, 'timing', 'library', 'this message will not be logged')
+   priority(tl, 'trace')
+   timing_start()
+   for i = 1, 3 do
+      -- Loop running many disabled events
+      local n = 1e6
+      for j = 1, n do
+         -- Call an event that is disabled
+         timing_dis()
+      end
+      timing_loop(n)
+   end
+
    print("selftest: save and dump")
    save(tl, "selftest-timeline.dat")
    dump("selftest-timeline.dat", 15)
@@ -319,8 +337,6 @@ function selftest ()
       assert(ref_next ~= tl.header.next, "log message expected")
       ref_next = tl.header.next
    end
-   -- (default priority: all)
-                            p_info() yes()  p_trace() yes()  p_packet() yes()
    priority(tl, 'all')      p_info() yes()  p_trace() yes()  p_packet() yes()
    priority(tl, 'library')  p_info() yes()  p_trace() yes()  p_packet() yes()
    priority(tl, 'app')      p_info() yes()  p_trace() yes()  p_packet() no()

--- a/src/core/timeline.dasl
+++ b/src/core/timeline.dasl
@@ -18,9 +18,10 @@ ffi.cdef[[
   struct timeline_entry {
     uint64_t tsc;                    // CPU timestamp
     uint64_t ip;                     // Instruction pointer of logger
+    uint32_t aux;                    // TSC_AUX: core (bits 0-7) + numa (12-15)
+    uint32_t reserved;               // (pad to 64 bytes)
     uint64_t msg_id;                 // category:24, message:24, priority:16
     uint64_t msg0, msg1, msg2, msg3; // message arguments
-    uint64_t reserved;               // pad to 64 bytes
   };
 ]]
 
@@ -241,6 +242,7 @@ local function asmlog (Dst)
    | rdtscp
    | mov msg:r10->tsc, eax
    | mov [r10+4], edx
+   | mov msg:r10->aux, ecx
 
    -- Log the instruction pointer
    | mov rax, [rsp]

--- a/src/core/timeline.dasl
+++ b/src/core/timeline.dasl
@@ -142,7 +142,7 @@ function dump (filename,  maxentries)
    local size = last + 1
    -- Print column headers.
    -- Note: "-cycles" column is time delta between entries (moving backwards in time)
-   print(("%4s %4s %8s %-16s %s"):format("numa", "core", "-cycles", "category", "message"))
+   print(("%4s %4s %12s %-16s %s"):format("numa", "core", "-cycles", "category", "message"))
    -- "Fast-forward" to the end (when following entry has earlier timestamp)
    local index = 0
    while ring[index].tsc <= ring[(index+1) % size].tsc do
@@ -151,13 +151,9 @@ function dump (filename,  maxentries)
    -- "Rewind" printing messages
    local ref_tsc = nil
    for i = 0, size-1 do
+      local previndex = (index == 0) and last or index-1
       if maxentries and i > maxentries then break end
-      local timedelta
-      if ref_tsc == nil then
-         timedelta = '<last>'
-      else
-         timedelta = tonumber(ref_tsc - ring[index].tsc)
-      end
+      local timedelta = tonumber(ring[index].tsc - ring[previndex].tsc)
       local msgid = ring[index].msg_id
       local icategory = bit.band(0xffff, bit.rshift(msgid, 40))
       local imessage = bit.band(0xffff, bit.rshift(msgid, 16))
@@ -175,7 +171,7 @@ function dump (filename,  maxentries)
          return match:gsub("^[$]", "", 1).."("..table.remove(args)..")"
       end
       local message = format:gsub("($%w+)", subst)
-      print(("%-4d %-4d %8s %-16s %s"):format(
+      print(("%-4d %-4d %12s %-16s %s"):format(
             numa, core, timedelta, category, message))
       ref_tsc = ring[index].tsc
       index = (index == 0) and last or index-1

--- a/src/core/timeline.dasl
+++ b/src/core/timeline.dasl
@@ -79,8 +79,8 @@ function init_header (header, entries)
    return header
 end
 
-local priorities = {['fatal']=1, ['error']=2, ['warning']=3, ['info']=4, ['debug']=5,
-                    ['trace']=6, ['trace+']=7, ['trace++']=8, ['trace+++']=9}
+local priorities = {['error']=1, ['warning']=2, ['info']=3,
+                   ['trace']=4, ['app']=5, ['packet']=6, ['library']=7}
 
 -- Define an event and return the logger function.
 function define (timeline, category, priority, message)
@@ -89,8 +89,11 @@ function define (timeline, category, priority, message)
    local prio = priorities[priority] or error("unrecognized priority: "..priority)
    local id = bit.bor(bit.lshift(icategory, 40),
                       bit.lshift(imessage, 16),
-                      prio)
-   local n = #(message_args(message))
+                      bit.lshift(1, prio))
+   -- Parse message arguments on first line
+   local args = {}
+   message:match("^[^\n]*"):gsub("[$](%w+)", function (arg) table.insert(args, arg) end)
+   local n = #(args)
    local event = event -- move asm function into local scope
    local log = timeline.header
    if n==0 then return function ()        event(log,id,0,0,0,0) end end
@@ -102,8 +105,6 @@ function define (timeline, category, priority, message)
 end
 
 function message_args (string)
-   local args = {}
-   string:gsub("[$](%w+)", function (arg) table.insert(args, arg) end)
    return args
 end
 
@@ -117,8 +118,14 @@ function save (tl, filename)
 end
 
 -- Choose the minimum priority for a message to be logged
-function priority (level)
-   error("NYI")
+function priority (timeline, priority)
+   local n
+   if     priority == 'all'  then n = 15
+   elseif priority == 'none' then n = 0
+   else   n = priorities[priority] or error("unrecognized priority: "..priority)
+   end
+   -- Enable all priorities up to this level
+   timeline.header.priority_mask = bit.lshift(1, n+1) - 1
 end
 
 -- Print log entries from the file
@@ -297,9 +304,33 @@ function selftest ()
    for i = 0, tl.entries-1 do
       assert(i==0 or tl.ring[i].tsc > tl.ring[i-1].tsc, "tsc increase")
    end
+
    print("selftest: save and dump")
    save(tl, "selftest-timeline.dat")
    dump("selftest-timeline.dat", 15)
+
+   print("selftest: priorities")
+   local p_info = define(tl, 'selftest', 'info', 'info event')
+   local p_trace = define(tl, 'selftest', 'trace', 'trace event')
+   local p_packet = define(tl, 'selftest', 'packet', 'packet event')
+   local ref_next = tl.header.next
+   -- no: assert that no message was logged
+   local no = function ()
+      assert(ref_next == tl.header.next, "no log message expected")
+   end
+   -- yes: assert that a message was logged
+   local yes = function ()
+      assert(ref_next ~= tl.header.next, "log message expected")
+      ref_next = tl.header.next
+   end
+   -- (default priority: all)
+                            p_info() yes()  p_trace() yes()  p_packet() yes()
+   priority(tl, 'all')      p_info() yes()  p_trace() yes()  p_packet() yes()
+   priority(tl, 'library')  p_info() yes()  p_trace() yes()  p_packet() yes()
+   priority(tl, 'app')      p_info() yes()  p_trace() yes()  p_packet() no()
+   priority(tl, 'info')     p_info() yes()  p_trace() no()   p_packet() no()
+   priority(tl, 'none')     p_info() no()   p_trace() no()   p_packet() no()
+
    print("selftest: ok")
 end
 

--- a/src/core/timeline.md
+++ b/src/core/timeline.md
@@ -82,6 +82,9 @@ The log now contains these entries:
 
 Create a new timeline at the given shared memory path.
 
+- *entries* defaults to 1024*1024 entries (64 megabytes). This could be increased if more events are needed. The value must be a power of 2.
+- *stringtablesize* defaults to one megabyte. This is expected to be more than sufficient.
+
 — Function **define** *timeline* *category* *priority* *message*
 
 Defines a message that can be logged to this timeline. Returns a

--- a/src/core/timeline.md
+++ b/src/core/timeline.md
@@ -126,3 +126,27 @@ strings `all` or `none`.
 
 Print the contents of a timeline, ordered from newest to oldest.
 
+This dump function is intended as a simple example. More sophisticated
+log viewing and analysis tools are eagerly anticipated.
+
+Here is the output:
+
+```
+numa core      -cycles category         message
+0    4         5033652 selftest         invoked many events(1000000)
+0    4         5013972 selftest         invoked many events(1000000)
+0    4         5178340 selftest         invoked many events(1000000)
+0    4      1753835508 selftest         timing tight loop of disabled events
+0    4              60 selftest         event with no args
+0    4              40 selftest         event with one arg: i(1048575)
+0    4              40 selftest         event with four args: i(1048575), 2i(2097150), 3i(3145725), and 4i(4194300)
+0    4              36 selftest         event with no args
+0    4              40 selftest         event with one arg: i(1048574)
+0    4              40 selftest         event with four args: i(1048574), 2i(2097148), 3i(3145722), and 4i(4194296)
+0    4              36 selftest         event with no args
+0    4              40 selftest         event with one arg: i(1048573)
+0    4              40 selftest         event with four args: i(1048573), 2i(2097146), 3i(3145719), and 4i(4194292)
+0    4              36 selftest         event with no args
+0    4              40 selftest         event with one arg: i(1048572)
+0    4              40 selftest         event with four args: i(1048572), 2i(2097144), 3i(3145716), and 4i(4194288)
+```

--- a/src/core/timeline.md
+++ b/src/core/timeline.md
@@ -25,7 +25,7 @@ FFI call.)
 The binary representation has three components:
 
 - header: magic number, file format version, flags.
-- entires: array of 64-byte log entries.
+- entries: array of 64-byte log entries.
 - stringtable: string constants (to referenced by their byte-index)
 
 ```
@@ -44,7 +44,7 @@ The binary representation has three components:
 ```
 
 The timeline can be read by scanning through the entries and detecting
-the first and last entries by comparing timestamps. The entires can be
+the first and last entries by comparing timestamps. The entries can be
 converted from binary data to human-readable strings by using the
 format strings that they reference.
 

--- a/src/core/timeline.md
+++ b/src/core/timeline.md
@@ -72,8 +72,8 @@ proc(50, 60, 8)
 The log now contains these entries:
 
 ```
-<TIMESTAMP> processed tcp(10), udp(20), and other(3)
-<TIMESTAMP> processed tcp(50), udp(60), and other(8)
+<TIMESTAMP> example    processed tcp(10), udp(20), and other(3)
+<TIMESTAMP> example    processed tcp(50), udp(60), and other(8)
 ```
 
 #### API
@@ -84,9 +84,29 @@ Create a new timeline at the given shared memory path.
 
 — Function **define** *timeline* *category* *priority* *message*
 
-Defines a message that can be logged to this timeline. Returns a function that is called to log the event.
+Defines a message that can be logged to this timeline. Returns a
+function that is called to log the event.
 
 - *category* is a short descriptive string like "luajit", "engine", "pci01:00.0".
-- *priority* is one of the strings `fatal`, `error`, `warning`, `info`, `debug`, `trace`, `trace+`, `trace++`, `trace+++`.
-- *message* is text describing the event. This can be a one-liner or a detailed multiline description. Words on the first line starting with `$` define arguments to the logger function which will be stored as 64-bit values (maximum four per message).
+- *priority* is one of the strings `fatal`, `error`, `warning`,
+   `info`, `debug`, `trace`, `trace+`, `trace++`, `trace+++`.
+- *message* is text describing the event. This can be a one-liner or a
+   detailed multiline description. Words on the first line starting
+   with `$` define arguments to the logger function which will be
+   stored as 64-bit values (maximum four per message).
+
+— Function **save** *timeline* *filename*
+
+Save a snapshot of the timeline to a file. The file format is the raw binary timeline format.
+
+— Function **priority** *timeline* *level*
+
+Set the minimum priority that is required for a message to be logged
+on the timeline. This can be used to control the rate at which
+messages are logged to the timeline to manage processing overhead and
+the rate of churn in the ring buffer.
+
+— Function **dump** *filename* *[maxentries]*
+
+Print the contents of a timeline, ordered from newest to oldest.
 

--- a/src/core/timeline.md
+++ b/src/core/timeline.md
@@ -28,6 +28,7 @@ The binary representation has three components:
 - entires: array of 64-byte log entries.
 - stringtable: string constants (to referenced by their byte-index)
 
+```
     DIAGRAM: Timeline
     +-------------------------+
     |      header (64B)       |
@@ -40,6 +41,7 @@ The binary representation has three components:
     +-------------------------+
     |   stringtable (~1MB)    |
     +-------------------------+
+```
 
 The timeline can be read by scanning through the entries and detecting
 the first and last entries by comparing timestamps. The entires can be

--- a/src/core/timeline.md
+++ b/src/core/timeline.md
@@ -14,11 +14,10 @@ that the log always includes a sample of interesting data for
 analysis.
 
 Logging to the timeline is efficient. Logging costs around 50 cycles
-when a message is enabled. The cost of skipping disabled messages is
-much less. The logging function is written in assembly language and is
-called by LuaJIT via the FFI. (Checking whether log messages are
-enabled is invisible to the trace compiler because it is done in the
-FFI call.)
+when a message is enabled and around 5 cycles when disabled. The
+logging function is written in assembly language and is called by
+LuaJIT via the FFI. (Checking whether log messages are enabled is
+invisible to the trace compiler because it is done in the FFI call.)
 
 #### File format and binary representation
 

--- a/src/core/timeline.md
+++ b/src/core/timeline.md
@@ -1,0 +1,90 @@
+### Timeline
+
+The timeline is a high-resolution event log that stores entries in a
+shared-memory ring buffer. Log entries are timestamped with
+cycle-precise wall-clock time based on the CPU [Time Stamp Counter
+(TSC)](https://en.wikipedia.org/wiki/Time_Stamp_Counter). Each log
+message references predefined strings for its category and
+format-string and stores up to four 64-bit argument values.
+
+Timeline messages can be dynamically enabled or disabled based on
+their priority. This supports periodically enabling detailed trace
+messages for short periods of time (e.g. 100 microseconds) to ensure
+that the log always includes a sample of interesting data for
+analysis.
+
+Logging to the timeline is efficient. Logging costs around 50 cycles
+when a message is enabled. The cost of skipping disabled messages is
+much less. The logging function is written in assembly language and is
+called by LuaJIT via the FFI. (Checking whether log messages are
+enabled is invisible to the trace compiler because it is done in the
+FFI call.)
+
+#### File format and binary representation
+
+The binary representation has three components:
+
+- header: magic number, file format version, flags.
+- entires: array of 64-byte log entries.
+- stringtable: string constants (to referenced by their byte-index)
+
+    DIAGRAM: Timeline
+    +-------------------------+
+    |      header (64B)       |
+    +-------------------------+
+    |                         |
+    |                         |
+    |     entries (~10MB)     |
+    |                         |
+    |                         |
+    +-------------------------+
+    |   stringtable (~1MB)    |
+    +-------------------------+
+
+The timeline can be read by scanning through the entries and detecting
+the first and last entries by comparing timestamps. The entires can be
+converted from binary data to human-readable strings by using the
+format strings that they reference.
+
+#### Usage
+
+Create a timeline as a shared memory object with default file size:
+
+```
+tl = timeline.new("/timeline")
+```
+
+Define an event that can be logged on this timeline:
+
+```
+local proc = timeline.define(tl, 'example', 'trace', "processed $tcp, $udp, and $other")
+```
+
+Log a series of events:
+
+```
+proc(10, 20, 3)
+proc(50, 60, 8)
+```
+
+The log now contains these entries:
+
+```
+<TIMESTAMP> processed tcp(10), udp(20), and other(3)
+<TIMESTAMP> processed tcp(50), udp(60), and other(8)
+```
+
+#### API
+
+— Function **new** *shmpath* *[entries]* *[stringtablesize]*
+
+Create a new timeline at the given shared memory path.
+
+— Function **define** *timeline* *category* *priority* *message*
+
+Defines a message that can be logged to this timeline. Returns a function that is called to log the event.
+
+- *category* is a short descriptive string like "luajit", "engine", "pci01:00.0".
+- *priority* is one of the strings `fatal`, `error`, `warning`, `info`, `debug`, `trace`, `trace+`, `trace++`, `trace+++`.
+- *message* is text describing the event. This can be a one-liner or a detailed multiline description. Words on the first line starting with `$` define arguments to the logger function which will be stored as 64-bit values (maximum four per message).
+

--- a/src/core/timeline.md
+++ b/src/core/timeline.md
@@ -91,12 +91,22 @@ Defines a message that can be logged to this timeline. Returns a
 function that is called to log the event.
 
 - *category* is a short descriptive string like "luajit", "engine", "pci01:00.0".
-- *priority* is one of the strings `fatal`, `error`, `warning`,
-   `info`, `debug`, `trace`, `trace+`, `trace++`, `trace+++`.
+- *priority* is one of the strings `error`, `warning`, `info`,
+   `trace`, `app`, `packet`, `library`.
 - *message* is text describing the event. This can be a one-liner or a
    detailed multiline description. Words on the first line starting
    with `$` define arguments to the logger function which will be
    stored as 64-bit values (maximum four per message).
+
+The priority should be chosen according to how frequently events will
+occur. This will make it possible for users to control how much detail
+is included in the log, and how quickly it wraps around, by choosing a
+suitable minimum event priority. Specifically choose `trace` for
+occasional events, `app` for per-breath events, `packet` for
+per-packet events, and `library` for events in library functions that
+could potentially be called in a tight loop. (If none of these
+priority names perfectly describes your use case then pick the one you
+think best matches the frequency of your events.)
 
 — Function **save** *timeline* *filename*
 
@@ -108,6 +118,9 @@ Set the minimum priority that is required for a message to be logged
 on the timeline. This can be used to control the rate at which
 messages are logged to the timeline to manage processing overhead and
 the rate of churn in the ring buffer.
+
+The level can be the strings accepted by `define()` or one of the
+strings `all` or `none`.
 
 — Function **dump** *filename* *[maxentries]*
 

--- a/src/dasm_x86.lua
+++ b/src/dasm_x86.lua
@@ -1230,6 +1230,7 @@ local map_op = {
   shrd_3 =	"mriqdw:0FACRmU|mrC/qq:0FADRm|mrC/dd:|mrC/ww:",
 
   rdtsc_0 =	"0F31", -- P1+
+  rdtscp_0 =    "0F01F9",-- P6+
   rdpmc_0 =	"0F33", -- P6+
   cpuid_0 =	"0FA2", -- P1+
 


### PR DESCRIPTION
## Timeline

Here is a big idea: How about if we create a unified "timeline" of all the events that are happening in a collection of Snabb processes and the hardware they are running on:
- Processes starting and stopping
- Engine breaths entering the pull and push steps
- Apps processing batches of packets
- Software errors being detected and recovered
- Processes dropping into kernel space for interrupts and system calls
- PEBS hardware detecting cache misses and branch mispredictions

The timeline would be a collection of log files that are high-performance (millions of messages per second), high-resolution (cycle precision based on a common time source), and ubiquitous (we would explicitly log events throughout Snabb and source external events e.g. from the kernel too).

This timeline could then serve as a reference for everybody involved in monitoring and troubleshooting the fine-grained behavior of a Snabb application e.g. developers, users, testers, support organizations, etc.

Here is an example (just a mock-up) of what a timeline might look like when printing the combined logs from one Snabb process and also the PMU hardware to see cache misses and branch mispredictions. Both logs are timestamped using the CPU Time Stamp Counter ([TSC](https://en.wikipedia.org/wiki/Time_Stamp_Counter)) and so they can be shown in parallel:

```
CYCLE  SYSTEM          ENGINE          NIC             FIREWALL        PEBS
------ --------------- --------------- --------------- --------------- -----------------------------
00000  jit trace #4
00001                  breath #33 pull
00002                                  output 3 pkts
00003                  breath #33 push
00004                                                  sort by proto   branch-miss ip=0xff0
00005                                                                  branch-miss ip=0xff8
00006                                                  process 82 tcp
00007                                                                  cache-miss ip=0xfa0,addr=0xd00
00008                                                                  cache-miss ip=0xfa0,addr=0xd10
00009                                                                  cache-miss ip=0xfa0,addr=0xd10
00010                                                  process 18 udp
00011                                                                  cache-miss ip=0xfb0,addr=0xc00
00012                                                  process other
00013  GC start                                                        cache-miss
00014  GC end                                                          cache-miss
00015                  breath #34 pull
```

Things to notice in this example:
- Time is measured in CPU-cycles i.e. sub-nanosecond.
- The `SYSTEM` column can tell us what is going on in the LuaJIT runtime system: compiling new JIT traces, garbage collection, and so on. We could also log the addresses of the generated machine code, both for Lua traces and DynASM code, to make them easy to cross-reference.
- The `ENGINE` column shows us the breathe loop operation. Here you could look for e.g. a breath that took an unexpectedly long time to complete (perhaps flagged in your histogram #795).
- The `NIC` and `FIREWALL` columns are showing individual processing steps for each app. This can be used directly like a simple profiler for application developers to divide-and-conquer performance problems by breaking processing into discrete steps (possibly an excellent thing to do for LuaJIT trace performance anyway, must talk with @alexandergall about his latest experiences and coding style).
- The `PEBS` column tells us what performance events are sampled by the CPU. These can be cross-referenced either temporally ("what else is going on in parallel on the timeline?"), by instruction pointer (which trace / dynasm code does this refer to?), or by address (what kind of memory is this cache miss on: Lua, DMA, or QEMU?). Note that PEBS hardware can log these events into memory and timestamp them with a suitable time source (TSC).

The timeline could be sliced and diced. Perhaps you only want to look at the `FIREWALL` column to see how many cycles elapse between each processing step. Perhaps you want to post-process the timeline to calculate statistics e.g. histogram of the durations of certain events. Perhaps you want to import the timeline into a GUI tool that lets you zoom in and out to look for patterns and anomalies.
## Implementation notes

The log function is written in assembler and the selftest function is able to log one message every 36 CPU cycles. I hope that the actual cost will be less in real uses due to instruction-level parallelism. I am not sure exactly how much overhead is acceptable. I believe that the `RDTSCP` instruction is providing quite a good time source: on the one hand not interfering with out-of-order execution and on the other hand not being overly confused by it.
## Related work

This idea is essentially a successor to the `lib.blackbox` (#754) idea. The trouble with the blackbox idea is that you need a GDB-like debugger to understand the log. The timeline seems simpler and more intuitive.

Google image search showed up the [QNX profiler](http://www.qnx.com/developers/docs/6.5.0/index.jsp?topic=%2Fcom.qnx.doc.ide.userguide%2Ftopic%2Fsysprof_SysProf_TimelineView_.html) as the GUI nearest what I have in mind.

One more thing that we need to ubiquitously instrument the codebase with is counters. Could we do both at the same time? (Perhaps we could unify events and counters e.g. incrementing a counter logs an event?)

Intel whitepaper explaining more about `RDTSCP` instruction as a time source: [How to benchmark code execution times](http://www.intel.ch/content/dam/www/public/us/en/documents/white-papers/ia-32-ia-64-benchmark-code-execution-paper.pdf).
## Feedback

If you have thoughts or see problems then leave a comment and I will try to reference/summarize that up here on the PR :).
