### PR TITLE
[sketch] Link test

### DIFF
--- a/src/linktest/Makefile
+++ b/src/linktest/Makefile
@@ -1,0 +1,12 @@
+LINK = BASIC_LINK #FF_LINK
+CFLAGS = -D_GNU_SOURCE -pthread -D$(LINK) -std=c99 -g -O
+OBJS = pipeline.o fan.o threadprocs.o utils.o main.o
+
+linktest: $(OBJS) linktest.h basic.h ff.h
+	cc $(CFLAGS) -o linktest $(OBJS)
+
+clean:
+	rm -f $(OBJS) linktest
+
+$(OBJS): linktest.h 
+

--- a/src/linktest/basic.h
+++ b/src/linktest/basic.h
@@ -1,0 +1,36 @@
+#define LINK_RING_SIZE 256
+#define NEXT(n) ((n + 1) & (LINK_RING_SIZE - 1))
+
+/*
+ * Classic lock-free ring buffer.
+ */
+struct basic_link {
+  void *buffer[LINK_RING_SIZE];
+  int32_t read;
+  int32_t write;
+};
+
+static inline void *
+basic_transmit(struct basic_link *link, void *datum)
+{
+  int32_t next = NEXT(link->write);
+  if (next == link->read) {
+    return NULL;
+  } else {
+    link->buffer[link->write] = datum;
+    link->write = next;
+    return datum;
+  }
+}
+
+static inline void *
+basic_receive(struct basic_link *link)
+{
+  if (link->read == link->write) {
+    return NULL;
+  } else {
+    void *datum = link->buffer[link->read];
+    link->read = NEXT(link->read);
+    return datum;
+  }
+}

--- a/src/linktest/basic.h
+++ b/src/linktest/basic.h
@@ -6,8 +6,8 @@
  */
 struct basic_link {
   void *buffer[LINK_RING_SIZE];
-  int32_t read;
-  int32_t write;
+  volatile int32_t read;
+  volatile int32_t write;
 };
 
 static inline void *

--- a/src/linktest/fan.c
+++ b/src/linktest/fan.c
@@ -1,0 +1,91 @@
+#include <inttypes.h>
+#include <pthread.h>
+#include <sys/time.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/signal.h>
+#include <sched.h>
+#include <assert.h>
+
+#include "linktest.h"
+
+void
+fan_test(int n)
+{
+  assert(n >= 3);
+  assert(n <= ncpus);
+  
+  int nthreads = n;
+  int nlinks = n - 1;
+  LINK **links;
+  
+  links = calloc(nlinks, sizeof(LINK *));
+  for (int i = 0; i < nlinks; i++) {
+    int error;
+
+    error = posix_memalign((void **)&links[i], CACHE_LINE_SIZE, sizeof(LINK));
+    if (error) fatal("posix_memalign");
+    memset(links[i], 0, sizeof(LINK));
+  }
+
+  pthread_t generator_thread;
+  pthread_t *discarder_threads;
+  int ndiscarders = nthreads - 1;
+  struct thread_params *params;
+
+  discarder_threads = calloc(ndiscarders, sizeof(pthread_t));
+  params = calloc(nthreads, sizeof(struct thread_params));
+
+  pthread_attr_t attrs;
+  cpu_set_t set;
+  int error;
+
+  pthread_attr_init(&attrs);
+
+  /* generator thread */
+  CPU_ZERO(&set);
+  CPU_SET(0, &set);
+  pthread_attr_setaffinity_np(&attrs, sizeof(set), &set);
+  for (int i = 0; i < nlinks; i++) {
+    params[0].outputs[i] = links[i];
+  }
+  params[0].noutputs = nlinks;
+  error = pthread_create(&generator_thread, &attrs, generate_round_robin,
+			 &params[0]);
+  errchk(error, "generator pthread_create");
+  pthread_detach(generator_thread);
+
+  for (int i = 0, threadno = 1; i < ndiscarders; i++, threadno++) {
+    CPU_ZERO(&set);
+    CPU_SET(threadno, &set);
+    pthread_attr_setaffinity_np(&attrs, sizeof(set), &set);
+    params[threadno].inputs[0] = links[i];
+    params[threadno].ninputs = 1;
+    error = pthread_create(&discarder_threads[i], &attrs, discard_single_input,
+			   &params[threadno]);
+    errchk(error, "discarder pthread_create");
+  }
+
+  struct timeval start, end, elapsed;
+  uintptr_t x;
+  uint64_t total_discarded = 0;
+  gettimeofday(&start, NULL);
+  for (int i = 0; i < ndiscarders; i++) {
+    pthread_join(discarder_threads[i], (void **)&x);
+    total_discarded += x;
+  }
+  gettimeofday(&end, NULL);
+  timersub(&end, &start, &elapsed);
+
+  double seconds = elapsed.tv_sec + elapsed.tv_usec/1000000.0;
+  printf("elapsed time for %" PRIu64 " elements: %f sec\n", total_discarded,
+	 seconds);
+  printf("dropped packets: %" PRIu64 " (%.1f%%)\n", total_dropped,
+	 (double)total_dropped/(double)total_packets);
+  printf("%7.2f Mpps\n", total_discarded/seconds/1e6);
+}
+
+
+			   
+

--- a/src/linktest/fan.c
+++ b/src/linktest/fan.c
@@ -81,8 +81,8 @@ fan_test(int n)
   double seconds = elapsed.tv_sec + elapsed.tv_usec/1000000.0;
   printf("elapsed time for %" PRIu64 " elements: %f sec\n", total_discarded,
 	 seconds);
-  printf("dropped packets: %" PRIu64 " (%.1f%%)\n", total_dropped,
-	 (double)total_dropped/(double)total_packets);
+  printf("dropped packets: %" PRIu64 " (%.2f%%)\n", total_dropped,
+	 100 * total_dropped/(double)total_packets);
   printf("%7.2f Mpps\n", total_discarded/seconds/1e6);
 }
 

--- a/src/linktest/ff.h
+++ b/src/linktest/ff.h
@@ -7,8 +7,8 @@
  */
 struct ff_link {
   void *buffer[LINK_RING_SIZE];
-  int32_t read __attribute__((aligned(CACHE_LINE_SIZE)));
-  int32_t write __attribute__((aligned(CACHE_LINE_SIZE)));
+  volatile int32_t read __attribute__((aligned(CACHE_LINE_SIZE)));
+  volatile int32_t write __attribute__((aligned(CACHE_LINE_SIZE)));
 };
 
 static inline void *

--- a/src/linktest/ff.h
+++ b/src/linktest/ff.h
@@ -1,0 +1,36 @@
+#define LINK_RING_SIZE 256
+#define NEXT(n) ((n + 1) & (LINK_RING_SIZE - 1))
+
+/*
+ * FastForward-style ring buffer. Note that read and write
+ * fields are on their own cache lines.
+ */
+struct ff_link {
+  void *buffer[LINK_RING_SIZE];
+  int32_t read __attribute__((aligned(CACHE_LINE_SIZE)));
+  int32_t write __attribute__((aligned(CACHE_LINE_SIZE)));
+};
+
+static inline void *
+ff_transmit(struct ff_link *link, void *datum)
+{
+  if (link->buffer[link->write] != NULL) {
+    return NULL;
+  } else {
+    link->buffer[link->write] = datum;
+    link->write = NEXT(link->write);
+    return datum;
+  }
+}
+
+static inline void *
+ff_receive(struct ff_link *link)
+{
+  void *datum = link->buffer[link->read];
+
+  if (datum != NULL) {
+    link->buffer[link->read] = NULL;
+    link->read = NEXT(link->read);
+  }
+  return datum;
+}

--- a/src/linktest/linktest.h
+++ b/src/linktest/linktest.h
@@ -33,6 +33,8 @@ struct thread_params {
 extern void errchk(int, char *);
 extern void fatal(char *fmt, ...) __attribute__ ((noreturn));
 
+extern int debug;
+
 extern int ncpus;
 extern int runflag;
 extern uint64_t total_packets;
@@ -54,5 +56,20 @@ enum {
 
 extern void pipeline_test(int);
 extern void fan_test(int);
+
+#include <inttypes.h>
+#include <x86intrin.h>
+
+#define copmiler_barrier() __asm__ __volatile__("" ::: "memory")
+
+static inline void
+rdtsc_spin(uint64_t ticks)
+{
+  uint64_t deadline = __rdtsc() + ticks;
+
+  while (__rdtsc() < deadline) {
+    compiler_barrier();
+  }
+}
 
 #endif

--- a/src/linktest/linktest.h
+++ b/src/linktest/linktest.h
@@ -1,0 +1,58 @@
+#ifndef LINKTEST_H
+#define LINKTEST_H
+
+#define CACHE_LINE_SIZE 64
+
+#if defined(BASIC_LINK) && !defined(FF_LINK)
+#include "basic.h"
+#define LINK struct basic_link
+#define TRANSMIT(l, d) basic_transmit(l, d)
+#define RECEIVE(l) basic_receive(l)
+#define LINKTYPE "basic"
+#elif defined(FF_LINK) && !defined(BASIC_LINK)
+#include "ff.h"
+#define LINK struct ff_link
+#define TRANSMIT(l, d) ff_transmit(l, d)
+#define RECEIVE(l) ff_receive(l)
+#define LINKTYPE "ff"
+#else
+#error "Must define one of BASIC_LINK or FF_LINK"
+#endif
+
+#define MAX_INPUT_LINKS 16
+#define MAX_OUTPUT_LINKS 16
+
+struct thread_params {
+  LINK *inputs[MAX_INPUT_LINKS];
+  uint32_t ninputs;
+  LINK *outputs[MAX_OUTPUT_LINKS];
+  uint32_t noutputs;
+  long delay;			/* in nanoseconds */
+};
+
+extern void errchk(int, char *);
+extern void fatal(char *fmt, ...) __attribute__ ((noreturn));
+
+extern int ncpus;
+extern int runflag;
+extern uint64_t total_packets;
+extern uint64_t total_dropped;
+extern long work_nanoseconds;
+
+/* start routines suitable for use in pthread_create() */
+extern void *relay_simple(void *);
+extern void *discard_single_input(void *);
+extern void *discard_inputs(void *);
+extern void *generate_single_output(void *);
+extern void *generate_broadcast(void *);
+extern void *generate_round_robin(void *);
+
+enum {
+  PIPELINE_TEST = 1,
+  FAN_TEST = 2
+};
+
+extern void pipeline_test(int);
+extern void fan_test(int);
+
+#endif

--- a/src/linktest/linktest.h
+++ b/src/linktest/linktest.h
@@ -60,7 +60,7 @@ extern void fan_test(int);
 #include <inttypes.h>
 #include <x86intrin.h>
 
-#define copmiler_barrier() __asm__ __volatile__("" ::: "memory")
+#define compiler_barrier() __asm__ __volatile__("" ::: "memory")
 
 static inline void
 rdtsc_spin(uint64_t ticks)

--- a/src/linktest/linktest.h
+++ b/src/linktest/linktest.h
@@ -36,7 +36,7 @@ extern void fatal(char *fmt, ...) __attribute__ ((noreturn));
 extern int debug;
 
 extern int ncpus;
-extern int runflag;
+extern volatile int runflag;
 extern uint64_t total_packets;
 extern uint64_t total_dropped;
 extern long work_nanoseconds;

--- a/src/linktest/main.c
+++ b/src/linktest/main.c
@@ -10,7 +10,7 @@
 int debug = 0;
 
 int ncpus;
-int runflag;
+volatile int runflag;
 uint64_t total_packets;
 uint64_t total_discarded;
 uint64_t total_dropped;

--- a/src/linktest/main.c
+++ b/src/linktest/main.c
@@ -1,0 +1,73 @@
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <getopt.h>
+
+#include "linktest.h"
+
+int ncpus;
+int runflag;
+uint64_t total_packets;
+uint64_t total_discarded;
+uint64_t total_dropped;
+long work_nanoseconds;
+
+static struct option longopts[] = {
+  { "mode", required_argument, NULL, 'm' },
+  { "threads", required_argument, NULL, 't' },
+  { NULL, 0, NULL, 0}
+};
+
+void
+usage(char *argv[])
+{
+  printf("usage: %s [options]\n", argv[0]);
+  printf(" -m, --mode: test to run: one of \"pipeline\", \"fan\".\n");
+  printf(" -t, --threads <n>: Use <n> threads. Must be <= number of cpus.\n");
+  exit(1);
+}
+
+int
+main(int argc, char *argv[])
+{
+  int ch;
+  int nthreads;
+  int test;
+
+  ncpus = sysconf(_SC_NPROCESSORS_ONLN);
+  runflag = 1;
+  total_packets = (uint64_t)100e6;
+  total_discarded = 0;
+  total_dropped = 0;
+
+  /* defaults */
+  test = PIPELINE_TEST;
+  nthreads = 2;
+
+  while ((ch = getopt_long(argc, argv, "m:t:", longopts, NULL)) != -1) {
+    switch (ch) {
+    case 'm':
+      break;
+    case 't':
+      break;
+    default:
+      usage(argv);
+      break;
+    }
+  }
+
+  if (nthreads > ncpus) {
+    fatal("can't have more threads (%d) than cpus (%d)\n", nthreads, ncpus);
+    exit(1);
+  }
+
+  printf("link type: %s\n", LINKTYPE);
+  if (test == PIPELINE_TEST) {
+    printf("pipeline test with %d stages\n", nthreads);
+    pipeline_test(nthreads);
+  } else if (test == FAN_TEST) {
+    printf("fanout test with generator and %d outputs\n", nthreads - 1);
+    fan_test(nthreads);
+  }
+}

--- a/src/linktest/main.c
+++ b/src/linktest/main.c
@@ -7,6 +7,8 @@
 
 #include "linktest.h"
 
+int debug = 0;
+
 int ncpus;
 int runflag;
 uint64_t total_packets;
@@ -17,6 +19,8 @@ long work_nanoseconds;
 static struct option longopts[] = {
   { "mode", required_argument, NULL, 'm' },
   { "threads", required_argument, NULL, 't' },
+  { "packets", required_argument, NULL, 'p' },
+  { "debug", no_argument, NULL, 'd' },
   { NULL, 0, NULL, 0}
 };
 
@@ -46,14 +50,24 @@ main(int argc, char *argv[])
   mode = PIPELINE_TEST;
   nthreads = 2;
 
-  while ((ch = getopt_long(argc, argv, "m:t:", longopts, NULL)) != -1) {
+  while ((ch = getopt_long(argc, argv, "m:p:t:", longopts, NULL)) != -1) {
     switch (ch) {
+    case 'd':
+      debug = 1;
+      break;
     case 'm':
       if (strcmp(optarg, "pipeline") == 0) {
 	mode = PIPELINE_TEST;
       } else if (strcmp(optarg, "fan") == 0) {
 	mode = FAN_TEST;
       } else {
+	usage(argv);
+      }
+      break;
+    case 'p':
+      total_packets = strtol(optarg, NULL, 10);
+      if (total_packets < 1) {
+	printf("the argument to -p/--packets must be an integer > 0\n");
 	usage(argv);
       }
       break;
@@ -80,6 +94,7 @@ main(int argc, char *argv[])
   }
 
   printf("link type: %s\n", LINKTYPE);
+  printf("sending %" PRIu64 " packets\n", total_packets);
   if (mode == PIPELINE_TEST) {
     printf("pipeline test with %d stages\n", nthreads);
     pipeline_test(nthreads);

--- a/src/linktest/pipeline.c
+++ b/src/linktest/pipeline.c
@@ -1,0 +1,99 @@
+#include <inttypes.h>
+#include <pthread.h>
+#include <sys/time.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/signal.h>
+#include <sched.h>
+#include <assert.h>
+
+#include "linktest.h"
+
+void
+pipeline_test(int n)
+{
+  assert(n >= 2);
+  assert(n <= ncpus);
+
+  int nthreads = n;
+  int nlinks = n - 1;
+  LINK **links;
+  
+  links = calloc(nlinks, sizeof(LINK *));
+  for (int i = 0; i < nlinks; i++) {
+    void *p;
+    int error;
+
+    error = posix_memalign(&p, CACHE_LINE_SIZE, sizeof(LINK));
+    if (error) fatal("posix_memalign");
+    links[i] = p;
+    memset(links[i], 0, sizeof(LINK));
+  }
+  
+  pthread_t generator_thread, discarder_thread;
+  pthread_t *relay_threads;
+  
+  int nrelayers = nlinks - 2;
+  
+  if (nrelayers > 0) {
+    relay_threads = calloc(nrelayers, sizeof(pthread_t));
+  }
+
+  struct thread_params *params;
+  
+  params = calloc(nthreads, sizeof(struct thread_params));
+  
+  pthread_attr_t attrs;
+  cpu_set_t set;
+  int error;
+  pthread_attr_init(&attrs);
+  
+  CPU_ZERO(&set);
+  CPU_SET(n - 1, &set);
+  pthread_attr_setaffinity_np(&attrs, sizeof(set), &set);
+  params[nthreads - 1].inputs[0] = links[nlinks - 1];
+  params[nthreads - 1].ninputs = 1;
+  error = pthread_create(&discarder_thread, &attrs, discard_single_input,
+			 &params[nthreads - 1]);
+  errchk(error, "discarder pthread_create");
+  
+  for (int i = 0, threadno = 1; i < nrelayers; i++, threadno++) {
+    CPU_ZERO(&set);
+    CPU_SET(threadno, &set);
+    pthread_attr_setaffinity_np(&attrs, sizeof(set), &set);
+    params[threadno].inputs[0] = links[threadno - 1];
+    params[threadno].ninputs = 1;
+    params[threadno].outputs[0] = links[threadno];
+    params[threadno].noutputs = 1;
+    error = pthread_create(&relay_threads[i], &attrs, relay_simple,
+			   &params[threadno]);
+    errchk(error, "relayerer pthread_create");
+    pthread_detach(relay_threads[i]);
+  }
+
+  CPU_ZERO(&set);
+  CPU_SET(0, &set);
+  pthread_attr_setaffinity_np(&attrs, sizeof(set), &set);
+  params[0].outputs[0] = links[0];
+  params[0].noutputs = 1;
+  error = pthread_create(&generator_thread, &attrs, generate_single_output,
+			 &params[0]);
+  errchk(error, "generator pthread_create");
+  pthread_detach(generator_thread);
+  
+  struct timeval start, end, elapsed;
+  uintptr_t total_discarded;
+  gettimeofday(&start, NULL);
+  pthread_join(discarder_thread, (void **)&total_discarded);
+  gettimeofday(&end, NULL);
+  timersub(&end, &start, &elapsed);
+
+  double seconds = elapsed.tv_sec + elapsed.tv_usec/1000000.0;
+  printf("elapsed time for %" PRIu64 " elements: %f sec\n", total_discarded,
+	 seconds);
+  printf("dropped packets: %" PRIu64 " (%.1f%%)\n", total_dropped,
+	 100*total_dropped/(double)total_packets);
+  printf("%7.2f Mpps\n", total_discarded/seconds/1e6);
+}
+  

--- a/src/linktest/threadprocs.c
+++ b/src/linktest/threadprocs.c
@@ -1,0 +1,164 @@
+#include <inttypes.h>
+#include <pthread.h>
+#include <sys/time.h>
+#include <time.h>
+#include <assert.h>
+
+#include "linktest.h"
+
+/*
+ * Receive values from a single input, and re-send them to a single output.
+ */
+void *
+relay_simple(void *arg)
+{
+  struct thread_params *params = arg;
+
+  assert(params->ninputs == 1);
+  assert(params->noutputs == 1);
+
+  LINK *input = params->inputs[0];
+  LINK *output = params->outputs[0];
+  struct timespec ts = { 0, params->delay };
+
+  while (runflag) {
+    void *datum = RECEIVE(input);
+    if (params->delay) nanosleep(&ts, NULL);
+    if (datum) {
+      void *sent = NULL;
+      while (sent == NULL) {
+	TRANSMIT(output, datum);
+      }
+    }
+  }
+  return NULL;
+}
+
+/*
+ * Receive and discard values from a single input link.
+ */
+void *
+discard_single_input(void *arg)
+{
+  struct thread_params *params = arg;
+  uintptr_t discarded = 0;
+
+  assert(params->ninputs == 1);
+
+  LINK *input = params->inputs[0];
+  struct timespec ts = { 0, params->delay };
+
+  while (runflag) {
+    void *datum = RECEIVE(input);
+    if (datum) {
+      if (params->delay) nanosleep(&ts, NULL);
+      discarded++;
+    }
+  }
+  pthread_exit((void *)discarded);
+  return NULL;
+}
+
+/*
+ * Receive and discard values from all input links.
+ */
+void *
+discard_inputs(void *arg)
+{
+  struct thread_params *params = arg;
+  uintptr_t discarded = 0;
+
+  assert(params->ninputs > 0);
+
+  LINK *input = params->inputs[0];
+  LINK *output = params->outputs[0];
+  struct timespec ts = { 0, params->delay };
+
+  while (runflag) {
+    for (int i = 0; i < params->ninputs; i++) {
+      void *datum = RECEIVE(params->inputs[i]);
+      if (datum) {
+	if (params->delay) nanosleep(&ts, NULL);
+	discarded++;
+      }
+    }
+  }
+  pthread_exit((void *)discarded);
+  return NULL;
+}
+
+/*
+ * Generate a value and send it to the single output link.
+ */
+void *
+generate_single_output(void *arg)
+{
+  struct thread_params *params = arg;
+
+  assert(params->ninputs == 0);
+  assert(params->noutputs == 1);
+
+  uint64_t n = 0;
+  void *datum;
+  struct timespec ts = {0, params->delay};
+
+  for (int i = 0; i < total_packets; i++) {
+    if (params->delay) nanosleep(&ts, NULL);
+    datum = TRANSMIT(params->outputs[0], (void *)++n);
+    if (datum == NULL) total_dropped++;
+  }
+  runflag = 0;
+  return NULL;
+}
+
+/*
+ * Generate a value and send it to all of the output links.
+ */
+void *
+generate_broadcast(void *arg)
+{
+  struct thread_params *params = arg;
+
+  assert(params->ninputs == 0);
+  assert(params->noutputs > 0);
+
+  uint64_t n = 0;
+  struct timespec ts = {0, params->delay};
+
+  for (int i = 0; i < total_packets; i++) {
+    if (params->delay) nanosleep(&ts, NULL);
+    n = n + 1;
+    for (int j = 0; j < params->noutputs; j++) {
+      TRANSMIT(params->outputs[0], (void *)n);
+    }
+  }
+  runflag = 0;
+  return NULL;
+}
+
+/*
+ * Generate a value and send it to one of the outputs, which is
+ * selected in round-robin fashion.
+ */
+void *
+generate_round_robin(void *arg)
+{
+  struct thread_params *params = arg;
+
+  assert(params->ninputs == 0);
+  assert(params->noutputs > 0);
+
+  uint64_t n = 0;
+  int dest = 0;
+  struct timespec ts = {0, params->delay};
+
+  for (int i = 0; i < total_packets; i++) {
+    if (params->delay) nanosleep(&ts, NULL);
+    n = n + 1;
+    TRANSMIT(params->outputs[dest], (void *)n);
+    dest = dest + 1;
+    if (dest == params->noutputs) dest = 0;
+  }
+  runflag = 0;
+  return NULL;
+}

--- a/src/linktest/utils.c
+++ b/src/linktest/utils.c
@@ -1,0 +1,24 @@
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+void
+errchk(int code, char *msg)
+{
+  if (code != 0) {
+    perror(msg);
+    exit(1);
+  }
+}
+
+void
+fatal(char *fmt, ...)
+{
+  va_list args;
+
+  va_start(args, fmt);
+  vfprintf(stderr, fmt, args);
+  va_end(args);
+  fflush(stderr);
+  exit(-1);
+}

--- a/src/program/snabbmark/mp.lua
+++ b/src/program/snabbmark/mp.lua
@@ -357,6 +357,7 @@ function mp_ring (args)
    end
    -- Spin until enough packets have been processed
    while counters[0] < c.packets do
+      C.usleep(100)
       core.lib.compiler_barrier()
    end
    local finish = C.get_time_ns()


### PR DESCRIPTION
I wrote this program (in C) to try to understand and measure the available performance of interprocess (well, inter-thread in this case) links.  It ended up getting bigger than I anticipated.

There are two modes.  One mode creates a pipeline.  That is, a thread generates "packets" as fast as it can, and it passes them on to zero or more relays, and thence to a thread that discards all its input.

```
lugano-4:linktest rme$ ./linktest -m pipeline -t 2
link type: basic
sending 100000000 packets
pipeline test with 2 stages
elapsed time for 99565351 elements: 1.411475 sec
dropped packets: 434565 (0.4%)
  70.54 Mpps
```

The other mode is a fan.  In this mode, a thread generates "packets" as fast as it can, and passes them on (in round-robin fashion) to a number of outputs.

```
lugano-4:linktest rme$ ./linktest -m fan -t 5
link type: basic
sending 100000000 packets
fanout test with generator and 4 outputs
elapsed time for 99999018 elements: 5.243559 sec
dropped packets: 982 (0.00%)
  19.07 Mpps
```

If you `make clean` and then do `make LINK=FF_LINK`, this will build a version of the program that uses a link structure that tries to be a little more cache-friendly by putting the read and write fields on their own cache lines.

The pipeline test:

```
lugano-4:linktest rme$ ./linktest -m pipeline -t 2
link type: ff
sending 100000000 packets
pipeline test with 2 stages
elapsed time for 99920585 elements: 0.601655 sec
dropped packets: 79405 (0.1%)
 166.08 Mpps
```

And the fan test:

```
lugano-4:linktest rme$ ./linktest -m fan -t 5
link type: ff
sending 100000000 packets
fanout test with generator and 4 outputs
elapsed time for 99999128 elements: 4.135264 sec
dropped packets: 872 (0.00%)
  24.18 Mpps
```

I have some more ideas about other kinds of links, but I wanted to get this out there in case anyone is interested.

I'm not sure what conclusions can be drawn yet.
