### PR TITLE
branches.md: Add branch 'timeline'

### DIFF
--- a/src/doc/branches.md
+++ b/src/doc/branches.md
@@ -146,3 +146,9 @@ The current state of each branch with respect to master is visible here:
 
     Maintainer: Domen Kožar <domen@dev.si>
 
+#### timeline
+
+    BRANCH: timeline git://github.com/lukego/snabb
+    Timeline (core.timeline) logging feature development branch.
+
+    Maintainer: Luke Gorrie <luke@snabb.co>


### PR DESCRIPTION
Adding the `timeline` branch as a subsystem, initially maintained by me.

This feature is ready for early adopters to try out! Just do `git merge timeline` onto the branch where you want to use it.

Once we are happy with the feature and have some experience using it then we can open a PR to upstream this branch to master and join the normal upstreaming flow.
