### PR TITLE
SnabbBot: use PR base as moving target instead of master

### DIFF
--- a/src/doc/testing.md
+++ b/src/doc/testing.md
@@ -134,8 +134,5 @@ SnabbBot is configured through the following environment variables:
 * `REPO`—Optional. Target GitHub repository. Default is
   `snabbco/snabb` (upstream).
 
-* `CURRENT`—Optional. The branch to merge pull requests with. Default is
-  `master`.
-
 * `SNABBBOTDIR`—Optional. SnabbBot cache directory. Default is
   `/tmp/snabb_bot`.


### PR DESCRIPTION
This updates @SnabbBot to merge and compare PRs to their base branches instead of master. My motivation is that given our new work flow it is useful for contributors and maintainers to “get what you see”. E.g. if I open a PR targeting the `ipsec` branch SnabbBot will no longer merge `master` (but `ipsec` instead) into that PR head before testing it.

Maintainers need to watch out for the following: an affirmative SnabbBot result no longer means that a given PR is mergable or tested with `master` *unless* that PRs target is `master`. On the upside, if you open a PR targeting `next` it will actually be tested against `next` and the SnabbBot results will be more realistic.

I have already deployed this version and it is already in effect. (Sorry if I irritated anyone with the live testing.) I am assuming this is a non-controversial change, but please let me know if you have any gripes with this, it can easily be reverted.

Cc @lukego @kbara @wingo @capr @alexandergall @domenkozar 