### PR TITLE
Delayed_start, stall snabb so that peer NIC drivers can fully initialize

### DIFF
--- a/src/apps/test/delayed_start.lua
+++ b/src/apps/test/delayed_start.lua
@@ -1,0 +1,24 @@
+module(...,package.seeall)
+
+local ffi = require("ffi")
+local C = ffi.C
+Delayed_start = { }
+
+--[[
+An app that delays packet forwarding for a configurable period of time.
+Useful when feeding pcaps into a physical nic. The delay lets the peer
+NIC completely initialize before sending packets so none are dropped.
+]]
+function Delayed_start:new(delay)
+   return setmetatable({ delay = delay }, { __index = Delayed_start})
+end
+
+function Delayed_start:push()
+   if self.delay then
+      C.usleep(self.delay)
+      self.delay = nil
+   end
+   for _ = 1, link.nreadable(self.input.input) do
+      link.transmit(self.output.output, link.receive(self.input.input))
+   end
+end

--- a/src/apps/test/delayed_start.lua
+++ b/src/apps/test/delayed_start.lua
@@ -10,14 +10,12 @@ Useful when feeding pcaps into a physical nic. The delay lets the peer
 NIC completely initialize before sending packets so none are dropped.
 ]]
 function Delayed_start:new(delay)
-   return setmetatable({ delay = delay }, { __index = Delayed_start})
+   return setmetatable({ start = engine.now() + delay },
+					  { __index = Delayed_start })
 end
 
 function Delayed_start:push()
-   if self.delay then
-      C.usleep(self.delay)
-      self.delay = nil
-   end
+   if engine.now() < self.start then return end
    for _ = 1, link.nreadable(self.input.input) do
       link.transmit(self.output.output, link.receive(self.input.input))
    end


### PR DESCRIPTION
An app that delays packet forwarding for a configurable period of time.
Useful when feeding pcaps into a physical nic. The delay lets the peer
NIC the link to come up before sending packets so none are dropped.

Waiting for a linkup in the NicDriver:new() delays the whole process
in every situation and is even worse when a port doesn't link as all the 
timers need to expire.