### PR TITLE
Add bits and bytes methods to Register

### DIFF
--- a/src/lib/hardware/README.md
+++ b/src/lib/hardware/README.md
@@ -191,6 +191,19 @@ in read-write mode.
 Clears bits of register according to *bitmask*. Only available on
 registers in read-write mode.
 
+- Method **Register:bits** *start*, *length*, *bits*
+
+Get / set *length* bits of the register at offset *start*
+if bits == nil then return *length* bits from the register at offset *start*
+if bits ~= nil then set *length* bits in the register at offset *start* to
+*bits*
+
+- Method **Register:byte** *start*, *byte*
+
+Get / set a byte offset by *start* into the register
+if *byte* == nil then return byte offset by *start*
+if *byte* ~= nil then set byte offset by *start* to *byte*
+
 — Method **Register:wait**  *bitmask*, *value*
 
 Blocks until applying *bitmask* to the register equals *value*. If

--- a/src/lib/hardware/register.lua
+++ b/src/lib/hardware/register.lua
@@ -37,6 +37,29 @@ end
 function Register:set (bitmask) self(bit.bor(self(), bitmask)) end
 function Register:clr (bitmask) self(bit.band(self(), bit.bnot(bitmask))) end
 
+-- Get / set length bits of the register at offset start
+-- if bits == nil then return length bits from the register at offset start
+-- if bits ~= nil then set length bits in the register at offset start
+function Register:bits (start, length, bits)
+  if bits == nil then
+    return bit.band(bit.rshift(self(), start), 2^length - 1)
+  else
+    local tmp = self()
+    local offmask = bit.bnot(bit.lshift(2^length - 1, start))
+    tmp = bit.band(tmp, offmask)
+    tmp = bit.bor(tmp, bit.lshift(bits, start))
+    self(tmp)
+  end
+end
+-- Get / set a byte length bytes from an offset of start bytes
+function Register:byte (start, byte)
+  if bits == nil then
+    return self:bits(start * 8, 8)
+  else
+    return self:bits(start * 8, 8, byte)
+  end
+end
+
 --- Block until applying `bitmask` to the register value gives `value`.
 --- If `value` is not given then until all bits in the mask are set.
 function Register:wait (bitmask, value)
@@ -81,8 +104,8 @@ local mt = {
                     reset=Register.noop, print=Register.print},
         __call = Register.read, __tostring = Register.__tostring},
   RW = {__index = { read=Register.read, write=Register.write, wait=Register.wait,
-                    set=Register.set, clr=Register.clr, reset=Register.noop,
-                    print=Register.print},
+                    set=Register.set, clr=Register.clr, reset=Register.noop, bits=Register.bits,
+                    bytes=Register.bytes, print=Register.print},
         __call = Register.__call, __tostring = Register.__tostring},
   RC = {__index = { read=Register.readrc, reset=Register.reset,
                     print=Register.printrc},

--- a/src/lib/hardware/register.lua
+++ b/src/lib/hardware/register.lua
@@ -37,12 +37,16 @@ end
 function Register:set (bitmask) self(bit.bor(self(), bitmask)) end
 function Register:clr (bitmask) self(bit.band(self(), bit.bnot(bitmask))) end
 
+function ro_bits(register, start, length)
+    return bit.band(bit.rshift(register(), start), 2^length - 1)
+end
+
 -- Get / set length bits of the register at offset start
 -- if bits == nil then return length bits from the register at offset start
 -- if bits ~= nil then set length bits in the register at offset start
 function Register:bits (start, length, bits)
   if bits == nil then
-    return bit.band(bit.rshift(self(), start), 2^length - 1)
+    return ro_bits(self, start, length)
   else
     local tmp = self()
     local offmask = bit.bnot(bit.lshift(2^length - 1, start))
@@ -51,10 +55,13 @@ function Register:bits (start, length, bits)
     self(tmp)
   end
 end
+function ro_byte(register, start, byte)
+  return register:bits(start * 8, 8)
+end
 -- Get / set a byte length bytes from an offset of start bytes
 function Register:byte (start, byte)
-  if bits == nil then
-    return self:bits(start * 8, 8)
+  if byte == nil then
+    return ro_byte(self, start, byte)
   else
     return self:bits(start * 8, 8, byte)
   end
@@ -102,12 +109,14 @@ end
 local mt = {
   RO = {__index = { read=Register.read, wait=Register.wait,
                     reset=Register.noop, print=Register.print},
+                    bits=ro_bits, byte=ro_byte,
         __call = Register.read, __tostring = Register.__tostring},
   RW = {__index = { read=Register.read, write=Register.write, wait=Register.wait,
-                    set=Register.set, clr=Register.clr, reset=Register.noop, bits=Register.bits,
-                    bytes=Register.bytes, print=Register.print},
+                    set=Register.set, clr=Register.clr, reset=Register.noop,
+                    bits=Register.bits, byte=Register.byte, print=Register.print},
         __call = Register.__call, __tostring = Register.__tostring},
   RC = {__index = { read=Register.readrc, reset=Register.reset,
+                    bits=ro_bits, byte=ro_byte,
                     print=Register.printrc},
         __call = Register.readrc, __tostring = Register.__tostring},
   RC64 = {__index = { read=Register.readrc, reset=Register.reset,


### PR DESCRIPTION
Setting the 3rd byte in a register to 45 or bits 0:3 to 5 is currently quite awkward.
This provide 2 helper methods to the Register objects to make life easier.