### PR TITLE
test_env.sh: prefer $SNABB_TEST_FIXTURES over ~/.test_env

### DIFF
--- a/src/program/snabbnfv/test_env/test_env.sh
+++ b/src/program/snabbnfv/test_env/test_env.sh
@@ -32,7 +32,11 @@ export qemu_smp=$QUEUES
 export qemu_vectors=$((2*$QUEUES + 1))
 
 export sockets=""
-export assets=$HOME/.test_env
+if [ -z "$SNABB_TEST_FIXTURES" ]; then
+    export assets=$HOME/.test_env
+else
+    export assets=$SNABB_TEST_FIXTURES
+fi
 export qemu=qemu/obj/x86_64-softmmu/qemu-system-x86_64
 export host_qemu=$(which qemu-system-x86_64)
 


### PR DESCRIPTION
This is the last missing piece for https://github.com/snabblab/snabblab-nixos/issues/13

Motivation: on snabblab servers it's too stateful to modify home directories of all users, so we'd like snabb to pick up a specific bash environment variable to discover test fixtures needed for `make test`.

cc @lukego @eugeneia 