### PR TITLE
hardware.pci: Fix to recognize hex digits in addresses

### DIFF
--- a/src/lib/hardware/pci.lua
+++ b/src/lib/hardware/pci.lua
@@ -163,7 +163,7 @@ end
 --
 -- example: qualified("01:00.0") -> "0000:01:00.0"
 function qualified (address)
-   return address:gsub("^%d%d:%d%d[.]%d+$", "0000:%1")
+   return address:gsub("^%x%x:%x%x[.]%x+$", "0000:%1")
 end
 
 --- ### Selftest


### PR DESCRIPTION
Fix a bug where translating between "qualified" and "canonical" PCI addresses was broken because PCI addresses were expected to have decimal digits when in reality they are hexadecimal.