### PR TITLE
core/packet.lua: Enable overflow check when allocating packets

### DIFF
--- a/src/core/packet.lua
+++ b/src/core/packet.lua
@@ -107,9 +107,7 @@ function data (p) return p.data end
 function length (p) return p.length end
 
 function preallocate_step()
-   if _G.developer_debug then
-      assert(packets_allocated + packet_allocation_step <= max_packets)
-   end
+   assert(packets_allocated + packet_allocation_step <= max_packets)
 
    for i=1, packet_allocation_step do
       free_internal(new_packet(), true)


### PR DESCRIPTION
Enable a really important assertion that the packet freelist does not overflow when we allocate a new batch of packets.

This should not be a performance issue: the check is on a slow-path where we are allocating a thousand new packets.

This is actually very important. I found a bug that packetblaster would crash with heap corruption / segfault when you run it with more than 3 network interfaces at the same time. This is because it allocated too many packets for transmit/receive buffers and that error was not caught unless "developer debug" mode was enabled.

(That problem is separately alleviated by #883 that reduces the descriptor queues from 32K packets to 2K packets each.)