### PR TITLE
Fix genbook.sh

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -187,15 +187,15 @@ obj/doc/snabb.markdown: markdown Makefile doc/genbook.sh
 
 obj/doc/snabb.pdf: obj/doc/snabb.markdown
 	$(E) "PANDOC    $@"
-	$(Q) (cd doc; pandoc --template=template.latex --latex-engine=lualatex -V fontsize=10pt -V monofont=droidsansmono -V monoscale=.70 -V verbatimspacing=.85 -V mainfont=droidserif -V sansfont=droidsans -V documentclass:book -V geometry:top=1.0in -V geometry:bottom=0.75in -S --toc --chapters  -o ../$@ ../$<)
+	$(Q) (cd obj/doc; pandoc --template=template.latex --latex-engine=lualatex -V fontsize=10pt -V monofont=droidsansmono -V monoscale=.70 -V verbatimspacing=.85 -V mainfont=droidserif -V sansfont=droidsans -V documentclass:book -V geometry:top=1.0in -V geometry:bottom=0.75in -S --toc --chapters  -o ../../$@ ../../$<)
 
 obj/doc/snabb.html: obj/doc/snabb.markdown
 	$(E) "PANDOC    $@"
-	$(Q) (cd doc; pandoc --self-contained --css="style.css" -S -s --toc --chapters -o ../$@ ../$<)
+	$(Q) (cd obj/doc; pandoc --self-contained --css="../../doc/style.css" -S -s --toc --chapters -o ../../$@ ../../$<)
 
 obj/doc/snabb.epub: obj/doc/snabb.markdown
 	$(E) "PANDOC    $@"
-	$(Q) (cd doc; pandoc --self-contained --css="style.css" -S -s --toc --chapters -o ../$@ ../$<)
+	$(Q) (cd obj/doc; pandoc --self-contained --css="../../doc/style.css" -S -s --toc --chapters -o ../../$@ ../../$<)
 
 CLEAN = snabb obj bin testlog programs.inc
 

--- a/src/README.md
+++ b/src/README.md
@@ -17,7 +17,7 @@ ecosystem to match your requirements.
     
                  |     |     |
            +-----*-----*-----*-----+
-           |   Snabb Core   |
+           |      Snabb Core       |
            +-----------------------+
 
 The Snabb Core forms a runtime environment (*engine*) which

--- a/src/doc/genbook.sh
+++ b/src/doc/genbook.sh
@@ -6,13 +6,13 @@
 # The authors list is automatically generated from Git history,
 # ordered from most to least commits.
 
-# Link images in local .images/
-for png in $(find .. -name "*.png"); do
-    ln -f -s ../$png .images/
-done
-
 # Root directory for markdown files
 mdroot=../obj
+
+# Link images in local .images/
+for png in $(find .. -name "*.png"); do
+    ln -s ../../$png $mdroot/doc/.images/
+done
 
 cat <<EOF
 % Snabb Reference Manual

--- a/src/scripts/snabb_doc.sh
+++ b/src/scripts/snabb_doc.sh
@@ -82,6 +82,7 @@ function build_doc1 {
 }
 
 function build_doc {
+    (cd $(repo_path) && make clean)
     out=$(build_doc1 $1 $2 2>&1)
     if [ "$?" != 0 ]; then
         echo "$out" > $2


### PR DESCRIPTION
@lukego `genbook.sh`/`make obj/doc/snabb.*` were broken and never worked correctly, we missed that because SnabbDoc does not `make clean` before building. This PR rectifies that. I recommend merging this and making it into a bug fix release, in order to make valid PRs in this release cycle pass SnabbDoc.