### PR TITLE
fix 2 race conditions

### DIFF
--- a/src/core/memory.lua
+++ b/src/core/memory.lua
@@ -50,9 +50,18 @@ end
 --- ### HugeTLB: Allocate contiguous memory in bulk from Linux
 
 function allocate_hugetlb_chunk ()
+   local fd, err = syscall.open("/proc/sys/vm/nr_hugepages","rdonly")
+   assert(fd, tostring(err))
+   fd:flock("ex")
    for i =1, 3 do
       local page = C.allocate_huge_page(huge_page_size)
-      if page ~= nil then return page else reserve_new_page() end
+      if page ~= nil then
+         fd:flock("un")
+         fd:close()
+         return page
+      else
+         reserve_new_page()
+      end
    end
 end
 

--- a/src/core/memory.lua
+++ b/src/core/memory.lua
@@ -78,7 +78,6 @@ function reserve_new_page ()
       local have = tonumber(lib.firstline("/proc/sys/vm/nr_hugepages"))
       local want = have + 1
       lib.writefile("/proc/sys/vm/nr_hugepages", tostring(want))
-      syscall.sysctl("vm.nr_hugepages", tostring(want))
       io.write("[memory: Provisioned a huge page: sysctl vm.nr_hugepages ", have, " -> ", want, "]\n")
    end
 end

--- a/src/core/memory.lua
+++ b/src/core/memory.lua
@@ -69,15 +69,15 @@ function reserve_new_page ()
    -- Check that we have permission
    lib.root_check("error: must run as root to allocate memory for DMA")
    -- Is the kernel shm limit too low for huge pages?
-   if huge_page_size > tonumber(syscall.sysctl("kernel.shmmax")) then
+   if huge_page_size > tonumber(lib.firstline("/proc/sys/kernel/shmmax")) then
       -- Yes: fix that
-      local old = syscall.sysctl("kernel.shmmax", tostring(huge_page_size))
+      local old = lib.writefile("/proc/sys/kernel/shmmax", tostring(huge_page_size))
       io.write("[memory: Enabling huge pages for shm: ",
                "sysctl kernel.shmmax ", old, " -> ", huge_page_size, "]\n")
    else
-      -- No: try provisioning an additional page
-      local have = tonumber(syscall.sysctl("vm.nr_hugepages"))
+      local have = tonumber(lib.firstline("/proc/sys/vm/nr_hugepages"))
       local want = have + 1
+      lib.writefile("/proc/sys/vm/nr_hugepages", tostring(want))
       syscall.sysctl("vm.nr_hugepages", tostring(want))
       io.write("[memory: Provisioned a huge page: sysctl vm.nr_hugepages ", have, " -> ", want, "]\n")
    end

--- a/src/core/shm.lua
+++ b/src/core/shm.lua
@@ -67,6 +67,7 @@ module(..., package.seeall)
 local ffi = require("ffi")
 local lib = require("core.lib")
 local S = require("syscall")
+local const = require("syscall.linux.constants")
 
 -- Root directory where the object tree is created.
 root = "/var/run/snabb"
@@ -131,7 +132,7 @@ function mkdir (name)
    if not S.stat(root) then
       local mask = S.umask(0)
       local status, err = S.mkdir(root, "01777")
-      assert(status, ("Unable to create %s: %s"):format(
+      assert(status or err.errno == const.E.EXIST, ("Unable to create %s: %s"):format(
                 root, tostring(err or "unspecified error")))
       S.umask(mask)
    end


### PR DESCRIPTION
When starting multiple snabb processes in quick succession, in for example an RSS enabled driver 2 race conditions can cause abnormal termination.