### PR TITLE
Allow opening counters multiple times

### DIFF
--- a/src/core/counter.lua
+++ b/src/core/counter.lua
@@ -42,7 +42,7 @@ local private = {}
 local numbers = {} -- name -> number
 
 function open (name, readonly)
-   if numbers[name] then error("counter already opened: " .. name) end
+   if numbers[name] then return private[numbers[name]] end
    local n = #public+1
    numbers[name] = n
    public[n] = shm.map(name, counter_t, readonly)


### PR DESCRIPTION
Sometimes, for instance when running tests, it is useful being able to open the same private counter multiple times in the same program.

The underlying memory is not mapped multiple times: the already existing counter is returned.