### PR TITLE
lib.ipsec.esp: update API and fix sanitation bug

### DIFF
--- a/src/lib/ipsec/README.md
+++ b/src/lib/ipsec/README.md
@@ -41,12 +41,10 @@ be a table with the following keys:
 
 — Method **esp_v6_encrypt:encapsulate** *packet*
 
-Returns a freshly allocated packet that is the encrypted and encapsulated
-version of *packet* or `nil` if header parsing failed. The contents of *packet*
-are destructively modified in the process.
+Encapsulates *packet* and encrypts its payload. Returns `true` on success and
+`false` otherwise.
 
 — Method **esp_v6_decrypt:decapsulate** *packet*
 
-Returns a freshly allocated packet that is the decrypted and decapsulated
-version of *packet* or `nil` if header parsing or authentication failed. The
-contents of *packet* are destructively modified in the process.
+Decapsulates *packet* and decrypts its payload. Returns `true` on success and
+`false` otherwise.

--- a/src/lib/ipsec/esp.lua
+++ b/src/lib/ipsec/esp.lua
@@ -87,6 +87,7 @@ local function padding (a, l) return (a - l%a) % a end
 function esp_v6_encrypt:encapsulate (p)
    local gcm = self.aes_128_gcm
    local data, length = packet.data(p), packet.length(p)
+   if length < PAYLOAD_OFFSET then return false end
    local payload = data + PAYLOAD_OFFSET
    local payload_length = length - PAYLOAD_OFFSET
    -- Padding, see https://tools.ietf.org/html/rfc4303#section-2.4
@@ -190,6 +191,11 @@ ABCDEFGHIJKLMNOPQRSTUVWXYZ
    assert(packet.length(p2) == packet.length(p)
           and C.memcmp(p, p2, packet.length(p)) == 0,
           "integrity check failed")
+   -- Check invalid packets.
+   local p_invalid = packet.from_string("invalid")
+   assert(not enc:encapsulate(p_invalid), "encapsulated invalid packet")
+   local p_invalid = packet.from_string("invalid")
+   assert(not dec:decapsulate(p_invalid), "decapsulated invalid packet")
    -- Check transmitted Sequence Number wrap around
    enc.seq:low(0)
    enc.seq:high(1)

--- a/src/program/snabbmark/snabbmark.lua
+++ b/src/program/snabbmark/snabbmark.lua
@@ -362,7 +362,8 @@ function esp (npackets, packet_size, mode, profile)
       local start = C.get_monotonic_time()
       local encapsulated
       for i = 1, npackets do
-         encapsulated = enc:encapsulate(packet.clone(plain))
+         encapsulated = packet.clone(plain)
+         enc:encapsulate(encapsulated)
          packet.free(encapsulated)
       end
       local finish = C.get_monotonic_time()
@@ -371,12 +372,14 @@ function esp (npackets, packet_size, mode, profile)
       print(("Encapsulation (packet size = %d): %.2f Gbit/s")
             :format(packet_size, gbits(bps)))
    else
-      local encapsulated = enc:encapsulate(plain)
+      local encapsulated = packet.clone(plain)
+      enc:encapsulate(encapsulated)
       if profile then profiler.start(profile) end
       local start = C.get_monotonic_time()
       local plain
       for i = 1, npackets do
-         plain = dec:decapsulate(packet.clone(encapsulated))
+         plain = packet.clone(encapsulated)
+         dec:decapsulate(plain)
          packet.free(plain)
       end
       local finish = C.get_monotonic_time()


### PR DESCRIPTION
Updates API for #845 and fixes a bug in `lib.ipsec.esp.encapsulate` where input packet length was unchecked.