### PR TITLE
Add 'start' method to apps

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -126,6 +126,14 @@ implemented the app instance is discarded and a new instance is created.
 *Optional*. Print a report of the current app status.
 
 
+— Method **myapp:start**
+
+*Optional*. Starts the app.
+
+At this point links and app name are set. The app has a chance to do
+additional initialization if needed.
+
+
 — Method **myapp:stop**
 
 *Optional*. Stop the app and release associated external resources.

--- a/src/core/app.lua
+++ b/src/core/app.lua
@@ -178,7 +178,6 @@ function apply_config_actions (actions, conf)
       table.insert(new_app_array, app)
       app_name_to_index[name] = #new_app_array
       app.zone = zone
-      if app.start then app:start() end
    end
    function ops.restart (name)
       ops.stop(name)
@@ -226,9 +225,13 @@ function apply_config_actions (actions, conf)
    for linkspec, r in pairs(link_table) do
       if not new_link_table[linkspec] then link.free(r, linkspec) end
    end
-   -- commit changes
+   -- Commit changes.
    app_table, link_table = new_app_table, new_link_table
    app_array, link_array = new_app_array, new_link_array
+   -- Trigger start event for each app.
+   for _, app in ipairs(app_array) do
+      app:start()
+   end
 end
 
 -- Call this to "run snabb switch".

--- a/src/core/app.lua
+++ b/src/core/app.lua
@@ -178,6 +178,7 @@ function apply_config_actions (actions, conf)
       table.insert(new_app_array, app)
       app_name_to_index[name] = #new_app_array
       app.zone = zone
+      if app_table[name].start then app_table[name]:start() end
    end
    function ops.restart (name)
       ops.stop(name)

--- a/src/core/app.lua
+++ b/src/core/app.lua
@@ -178,7 +178,7 @@ function apply_config_actions (actions, conf)
       table.insert(new_app_array, app)
       app_name_to_index[name] = #new_app_array
       app.zone = zone
-      if app_table[name].start then app_table[name]:start() end
+      if app.start then app:start() end
    end
    function ops.restart (name)
       ops.stop(name)

--- a/src/core/app.lua
+++ b/src/core/app.lua
@@ -230,7 +230,7 @@ function apply_config_actions (actions, conf)
    app_array, link_array = new_app_array, new_link_array
    -- Trigger start event for each app.
    for _, app in ipairs(app_array) do
-      app:start()
+      if app.start then app:start() end
    end
 end
 

--- a/src/core/app.lua
+++ b/src/core/app.lua
@@ -148,8 +148,8 @@ end
 -- Update the active app network by applying the necessary actions.
 function apply_config_actions (actions, conf)
    -- The purpose of this function is to populate these tables:
-   local new_app_table,  new_app_array  = {}, {}, {}
-   local new_link_table, new_link_array = {}, {}, {}
+   local new_app_table,  new_app_array  = {}, {}
+   local new_link_table, new_link_array = {}, {}
    -- Temporary name->index table for use in link renumbering
    local app_name_to_index = {}
    -- Table of functions that execute config actions


### PR DESCRIPTION
I think apps should have a 'start' method. 

The event will be emitted by `ops.start` (in `core/app.lua`). This _start_ method will give a chance to apps to additionally initialize themselves. For instance, right now apps can only access their links or even their own name in `push` and  `pull`methods. The reason is that these properties are setup by `ops.start` but it doesn't emit a _start_ event to their apps. Interestingly, `ops.stop` do emit a stop event to the apps :)

The background for this change is that we want to add counters per app in the lwAFTR and the only chance we have to do that is in their `push` or `pull` methods or doing other hacks that modify the engine https://github.com/Igalia/snabb/pull/299 I think the _start_ method solution is consistent with the current design.