### PR TITLE
test_env.sh: set initrd and be able to append kernel params

### DIFF
--- a/src/program/snabbnfv/test_env/test_env.sh
+++ b/src/program/snabbnfv/test_env/test_env.sh
@@ -104,12 +104,15 @@ function launch_qemu {
     if [ ! -n $QUEUES ]; then
         export mqueues=",queues=$QUEUES"
     fi
+    if [ -e $assets/initrd ]; then
+        export QEMU_ARGS="-initrd $assets/initrd $QEMU_ARGS"
+    fi
     tmux_launch \
         "qemu$qemu_n" \
         "numactl --cpunodebind=$(pci_node $1) --membind=$(pci_node $1) \
-        $QEMU \
+        $QEMU $QEMU_ARGS \
         -kernel $assets/$4 \
-        -append \"earlyprintk root=/dev/vda rw console=ttyS0 ip=$(ip $qemu_n)\" \
+        -append \"earlyprintk root=/dev/vda $SNABB_KERNEL_PARAMS rw console=ttyS0 ip=$(ip $qemu_n)\" \
         -m $GUEST_MEM -numa node,memdev=mem -object memory-backend-file,id=mem,size=${GUEST_MEM}M,mem-path=$HUGETLBFS,share=on \
         -netdev type=vhost-user,id=net0,chardev=char0${mqueues} -chardev socket,id=char0,path=$2,server \
         -device virtio-net-pci,netdev=net0,mac=$(mac $qemu_n),mq=$qemu_mq,vectors=$qemu_vectors \


### PR DESCRIPTION
These two changes are necessary to use NixOS as a guest image for snabbnfv selftest.

- `$SNABB_KERNEL_PARAMS` shouldn't do any harm and it's needed to pass `init=` as it has to point to nix store
- NixOS uses initrd and needs to be passed to qemu

@eugeneia what do you think is best, should we pass initrd only when assets have the file?