### PR TITLE
Monitor ingress packet drops and jit flush if threshold exceeded

### DIFF
--- a/src/apps/intel/intel10g.lua
+++ b/src/apps/intel/intel10g.lua
@@ -187,6 +187,10 @@ do
    end
 end
 
+function M_sf:ingress_packet_drops ()
+   return self.qs.QPRDC[0]()
+end
+
 function M_sf:init_snmp ()
    -- Rudimentary population of a row in the ifTable MIB.  Allocation
    -- of the ifIndex is delegated to the SNMP agent via the name of
@@ -717,6 +721,7 @@ M_pf.set_promiscuous_mode = M_sf.set_promiscuous_mode
 M_pf.init_receive = M_sf.init_receive
 M_pf.init_transmit = M_sf.init_transmit
 M_pf.wait_linkup = M_sf.wait_linkup
+M_pf.ingress_packet_drops = M_sf.ingress_packet_drops
 
 function M_pf:set_vmdq_mode ()
    self.r.RTTDCS(bits{VMPAC=1,ARBDIS=6,BDPM=22})       -- clear TDPAC,TDRM=4, BPBFSM
@@ -1171,6 +1176,9 @@ function M_vf:set_tx_rate (limit, priority)
    return self
 end
 
+function M_vf:ingress_packet_drops ()
+   return self.pf:ingress_packet_drops()
+end
 
 rxdesc_t = ffi.typeof [[
    union {

--- a/src/apps/intel/intel_app.lua
+++ b/src/apps/intel/intel_app.lua
@@ -98,6 +98,10 @@ function Intel82599:pull ()
    self:add_receive_buffers()
 end
 
+function Intel82599:ingress_packet_drops ()
+   return self.dev:ingress_packet_drops()
+end
+
 function Intel82599:add_receive_buffers ()
    -- Generic buffers
    while self.dev:can_add_receive_buffer() do

--- a/src/core/app.lua
+++ b/src/core/app.lua
@@ -99,7 +99,7 @@ end
 
 -- Run app:methodname() in protected mode (pcall). If it throws an
 -- error app will be marked as dead and restarted eventually.
-local function with_restart (app, method)
+function with_restart (app, method)
    if use_restart then
       -- Run fn in protected mode using pcall.
       local status, result_or_error = pcall(method, app)

--- a/src/core/app.lua
+++ b/src/core/app.lua
@@ -28,37 +28,6 @@ link_table, link_array = {}, {}
 
 configuration = config.new()
 
--- Ingress packet drop monitor.
-ingress_drop_monitor = {
-   threshold = 100000,
-   wait = 20,
-   last_flush = 0,
-   last_value = ffi.new('uint64_t[1]'),
-   current_value = ffi.new('uint64_t[1]')
-}
-
-function ingress_drop_monitor:sample()
-   local sum = self.current_value
-   sum[0] = 0
-   for i = 1, #app_array do
-      local app = app_array[i]
-      if app.ingress_packet_drops and not app.dead then
-         local status, value = with_restart(app, app.ingress_packet_drops)
-         if status then sum[0] = sum[0] + value end
-      end
-   end
-end
-
-function ingress_drop_monitor:jit_flush_if_needed()
-   if self.current_value[0] - self.last_value[0] < self.threshold then return end
-   if now() - self.last_flush < self.wait then return end
-   self.last_flush = now()
-   self.last_value[0] = self.current_value[0]
-   jit.flush()
-   print("jit.flush")
-   --- TODO: Change last_flush, last_value and current_value fields to be counters.
-end
-
 -- Counters for statistics.
 breaths   = counter.open("engine/breaths")   -- Total breaths taken
 frees     = counter.open("engine/frees")     -- Total packets freed
@@ -113,6 +82,37 @@ local function with_restart (app, method)
    else
       return true, method(app)
    end
+end
+
+-- Ingress packet drop monitor.
+ingress_drop_monitor = {
+   threshold = 100000,
+   wait = 20,
+   last_flush = 0,
+   last_value = ffi.new('uint64_t[1]'),
+   current_value = ffi.new('uint64_t[1]')
+}
+
+function ingress_drop_monitor:sample()
+   local sum = self.current_value
+   sum[0] = 0
+   for i = 1, #app_array do
+      local app = app_array[i]
+      if app.ingress_packet_drops and not app.dead then
+         local status, value = with_restart(app, app.ingress_packet_drops)
+         if status then sum[0] = sum[0] + value end
+      end
+   end
+end
+
+function ingress_drop_monitor:jit_flush_if_needed()
+   if self.current_value[0] - self.last_value[0] < self.threshold then return end
+   if now() - self.last_flush < self.wait then return end
+   self.last_flush = now()
+   self.last_value[0] = self.current_value[0]
+   jit.flush()
+   print("jit.flush")
+   --- TODO: Change last_flush, last_value and current_value fields to be counters.
 end
 
 -- Restart dead apps.

--- a/src/core/app.lua
+++ b/src/core/app.lua
@@ -27,6 +27,36 @@ link_table, link_array = {}, {}
 
 configuration = config.new()
 
+-- Ingress packet drop monitor.
+ingress_drop_monitor = {
+   threshold = 100000,
+   wait = 20,
+   last_flush = 0,
+   last_value = ffi.new('uint64_t[1]'),
+   current_value = ffi.new('uint64_t[1]')
+}
+
+function ingress_drop_monitor:sample()
+   local sum = self.current_value
+   sum[0] = 0
+   for i = 1, #app_array do
+      local app = app_array[i]
+      if app.ingress_packet_drops and not app.dead then
+         sum[0] = sum[0] + app:ingress_packet_drops()
+      end
+   end
+end
+
+function ingress_drop_monitor:jit_flush_if_needed()
+   if self.current_value[0] - self.last_value[0] < self.threshold then return end
+   if app.now() - self.last_flush < self.wait then return end
+   self.last_flush = app.now()
+   self.last_value[0] = self.current_value[0]
+   jit.flush()
+   print("jit.flush")
+   --- TODO: Change last_flush, last_value and current_value fields to be counters.
+end
+
 -- Counters for statistics.
 breaths   = counter.open("engine/breaths")   -- Total breaths taken
 frees     = counter.open("engine/frees")     -- Total packets freed
@@ -244,6 +274,16 @@ function main (options)
    if options.measure_latency or options.measure_latency == nil then
       local latency = histogram.create('engine/latency', 1e-6, 1e0)
       breathe = latency:wrap_thunk(breathe, now)
+   end
+
+   if options.ingress_drop_monitor or options.ingress_drop_monitor == nil then
+      local interval = 1e8   -- Every 100 milliseconds.
+      local function fn()
+         ingress_drop_monitor:sample()
+         ingress_drop_monitor:jit_flush_if_needed()
+      end
+      local t = timer.new("ingress drop monitor", fn, interval, "repeating")
+      timer.activate(t)
    end
 
    monotonic_now = C.get_monotonic_time()

--- a/src/core/app.lua
+++ b/src/core/app.lua
@@ -99,7 +99,7 @@ end
 
 -- Run app:methodname() in protected mode (pcall). If it throws an
 -- error app will be marked as dead and restarted eventually.
-function with_restart (app, method)
+local function with_restart (app, method)
    if use_restart then
       -- Run fn in protected mode using pcall.
       local status, result_or_error = pcall(method, app)

--- a/src/core/app.lua
+++ b/src/core/app.lua
@@ -10,6 +10,7 @@ local timer     = require("core.timer")
 local histogram = require('core.histogram')
 local counter   = require("core.counter")
 local zone      = require("jit.zone")
+local jit       = require("jit")
 local ffi       = require("ffi")
 local C         = ffi.C
 require("core.packet_h")
@@ -49,8 +50,8 @@ end
 
 function ingress_drop_monitor:jit_flush_if_needed()
    if self.current_value[0] - self.last_value[0] < self.threshold then return end
-   if app.now() - self.last_flush < self.wait then return end
-   self.last_flush = app.now()
+   if now() - self.last_flush < self.wait then return end
+   self.last_flush = now()
    self.last_value[0] = self.current_value[0]
    jit.flush()
    print("jit.flush")


### PR DESCRIPTION
This PR adds a method to Intel10g app to fetch ingress packet drops value (QPRDC register). A timer in `core/app.lua` monitors this value periodically (100ms) and runs `jit.flush()` if a certain threshold is reached. There's a grace period of 20 seconds between jit flushes.

The monitor runs by default but it can be disabled on `engine.main(c, { ingress_monitor_drops = false })`