### PR TITLE
snabb_bot: Dirty fix for GitHub API pagination

### DIFF
--- a/src/scripts/snabb_bot.sh
+++ b/src/scripts/snabb_bot.sh
@@ -33,7 +33,8 @@ function init {
 function clean { rm -rf "$tmpdir"; }
 
 function fetch_pull_requests {
-    curl "https://api.github.com/repos/$REPO/pulls" > "$tmpdir/pulls"
+    curl "https://api.github.com/repos/$REPO/pulls?per_page=100" \
+        > "$tmpdir/pulls"
 }
 
 function pull_request_ids { "$JQ" ".[].number" "$tmpdir/pulls"; }

--- a/src/scripts/snabb_doc.sh
+++ b/src/scripts/snabb_doc.sh
@@ -30,7 +30,8 @@ function init {
 function clean { rm -rf "$tmpdir"; }
 
 function fetch_pull_requests {
-    curl "https://api.github.com/repos/$REPO/pulls" > "$tmpdir/pulls"
+    curl "https://api.github.com/repos/$REPO/pulls?per_page=100" \
+        > "$tmpdir/pulls"
 }
 
 function pull_request_ids { "$JQ" ".[].number" "$tmpdir/pulls"; }


### PR DESCRIPTION
I noticed only yesterday that SnabbBot ignored some PRs. The issue is that SnabbBot is not aware of [GitHub’s paginated API responses](https://developer.github.com/v3/#pagination). This is only a dirty fix that should give us some leeway until we have more than 100 open PRs. SnabbBot really needs to parse the Link headers and traverse over the pages somehow.

Note to self:
```
awk '/^Link: <(.*)>; rel="next".*$/ { print gensub(/^Link: <(.*)>; rel="next".*$/, "\\1", 1) }'
```