### PR TITLE
Set image format as raw

### DIFF
--- a/src/program/snabbnfv/test_env/test_env.sh
+++ b/src/program/snabbnfv/test_env/test_env.sh
@@ -115,7 +115,7 @@ function launch_qemu {
         -device virtio-net-pci,netdev=net0,mac=$(mac $qemu_n),mq=$qemu_mq,vectors=$qemu_vectors \
         -M pc -smp $qemu_smp -cpu host --enable-kvm \
         -serial telnet:localhost:$3,server,nowait \
-        -drive if=virtio,file=$(qemu_image $5) \
+        -drive if=virtio,format=raw,file=$(qemu_image $5) \
         -nographic" \
         $(qemu_log)
     qemu_n=$(expr $qemu_n + 1)


### PR DESCRIPTION
Removes the following warning in `qemu0.log`:

```
WARNING: Image format was not specified for '/root/.test_env/qemu-dpdk0.img' 
and probing guessed raw. 
Automatically detecting the format is dangerous for raw images, write operations
on block 0 will be restricted. 
Specify the 'raw' format explicitly to remove the restrictions.
```

This assumes all images used for benchmarking are in raw format.
