### PR TITLE
Disable ingress_drop_monitor by default

### DIFF
--- a/src/core/app.lua
+++ b/src/core/app.lua
@@ -281,7 +281,7 @@ function main (options)
       breathe = latency:wrap_thunk(breathe, now)
    end
 
-   if options.ingress_drop_monitor or options.ingress_drop_monitor == nil then
+   if options.ingress_drop_monitor then
       local interval = 1e8   -- Every 100 milliseconds.
       local function fn ()
          ingress_drop_monitor:sample()


### PR DESCRIPTION
As commented in #917, the ingress drop monitor feature needs further testing before turning it on by default. The feature is only run now if requested explicitly with an options parameter.

I made this PR rebased to `next` as #909 is already merged.