### PR TITLE
Make ingress drop monitor a timer and enable it only in lwAFTR

### DIFF
--- a/src/core/app.lua
+++ b/src/core/app.lua
@@ -68,7 +68,7 @@ end
 
 -- Run app:methodname() in protected mode (pcall). If it throws an
 -- error app will be marked as dead and restarted eventually.
-local function with_restart (app, method)
+function with_restart (app, method)
    if use_restart then
       -- Run fn in protected mode using pcall.
       local status, result_or_error = pcall(method, app)
@@ -82,37 +82,6 @@ local function with_restart (app, method)
    else
       return true, method(app)
    end
-end
-
--- Ingress packet drop monitor.
-ingress_drop_monitor = {
-   threshold = 100000,
-   wait = 20,
-   last_flush = 0,
-   last_value = ffi.new('uint64_t[1]'),
-   current_value = ffi.new('uint64_t[1]')
-}
-
-function ingress_drop_monitor:sample ()
-   local sum = self.current_value
-   sum[0] = 0
-   for i = 1, #app_array do
-      local app = app_array[i]
-      if app.ingress_packet_drops and not app.dead then
-         local status, value = with_restart(app, app.ingress_packet_drops)
-         if status then sum[0] = sum[0] + value end
-      end
-   end
-end
-
-function ingress_drop_monitor:jit_flush_if_needed ()
-   if self.current_value[0] - self.last_value[0] < self.threshold then return end
-   if now() - self.last_flush < self.wait then return end
-   self.last_flush = now()
-   self.last_value[0] = self.current_value[0]
-   jit.flush()
-   print("jit.flush")
-   --- TODO: Change last_flush, last_value and current_value fields to be counters.
 end
 
 -- Restart dead apps.
@@ -279,16 +248,6 @@ function main (options)
    if options.measure_latency or options.measure_latency == nil then
       local latency = histogram.create('engine/latency', 1e-6, 1e0)
       breathe = latency:wrap_thunk(breathe, now)
-   end
-
-   if options.ingress_drop_monitor or options.ingress_drop_monitor == nil then
-      local interval = 1e8   -- Every 100 milliseconds.
-      local function fn ()
-         ingress_drop_monitor:sample()
-         ingress_drop_monitor:jit_flush_if_needed()
-      end
-      local t = timer.new("ingress drop monitor", fn, interval, "repeating")
-      timer.activate(t)
    end
 
    monotonic_now = C.get_monotonic_time()

--- a/src/lib/timers/ingress_drop_monitor.lua
+++ b/src/lib/timers/ingress_drop_monitor.lua
@@ -1,0 +1,49 @@
+module(...,package.seeall)
+
+-- Ingress packet drop monitor timer.
+
+local ffi = require("ffi")
+
+-- Every 100 milliseconds.
+local interval = 1e8
+
+local with_restart = core.app.with_restart
+local now = core.app.now
+
+ingress_drop_monitor = {
+   threshold = 100000,
+   wait = 20,
+   last_flush = 0,
+   last_value = ffi.new('uint64_t[1]'),
+   current_value = ffi.new('uint64_t[1]'),
+}
+
+function ingress_drop_monitor:sample ()
+   local app_array = engine.app_array
+   local sum = self.current_value
+   sum[0] = 0
+   for i = 1, #app_array do
+      local app = app_array[i]
+      if app.ingress_packet_drops and not app.dead then
+         local status, value = with_restart(app, app.ingress_packet_drops)
+         if status then sum[0] = sum[0] + value end
+      end
+   end
+end
+
+function ingress_drop_monitor:jit_flush_if_needed ()
+   if self.current_value[0] - self.last_value[0] < self.threshold then return end
+   if now() - self.last_flush < self.wait then return end
+   self.last_flush = now()
+   self.last_value[0] = self.current_value[0]
+   jit.flush()
+   print("jit.flush")
+   --- TODO: Change last_flush, last_value and current_value fields to be counters.
+end
+
+local function fn ()
+   ingress_drop_monitor:sample()
+   ingress_drop_monitor:jit_flush_if_needed()
+end
+
+return timer.new("ingress drop monitor", fn, interval, "repeating")


### PR DESCRIPTION
Moves ingress-drop-monitor out of engine and puts it on its own file as a timer. Applications can use the timer to activate packet-drop monitoring on applications that implement `ingress_packet_drops` method. In this case, ingress-drop-monitor is activated by default for the lwAFTR application.