### PR TITLE
core.memory: Add 'align' argument to dma_alloc()

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -370,9 +370,12 @@ can be accessed directly by network cards. The important
 characteristic of DMA memory is being located in contiguous physical
 memory at a stable address.
 
-— Function **memory.dma_alloc** *bytes*
+— Function **memory.dma_alloc** *bytes*, *[alignment]*
 
 Returns a pointer to *bytes* of new DMA memory.
+
+Optionally a specific *alignment* requirement can be provided (in
+bytes). The default alignment is 128.
 
 — Function **memory.virtual_to_physical** *pointer*
 


### PR DESCRIPTION
Now it is possible to request specific alignment for DMA memory.

This is practical. For example, Mellanox ConnectX-4 requires specific alignments (e.g. 4KB).

(cherry picked from commit f349c41973af27fbbab431736b7fb4ddc512aa8e)