### PR TITLE
src/Makefile: silence grep

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -39,7 +39,7 @@ EXE    := bin/snabb $(patsubst %,bin/%,$(PROGRAM))
 #   core.memory core.lib ...
 # for each module that has a top-level selftest () function.
 TESTMODS = $(shell find . -regex '[^\#]*\.lua' -printf '%P ' | \
-             xargs grep -l '^function selftest *[[:punct:]]' | \
+             xargs grep -s -l '^function selftest *[[:punct:]]' | \
              sed -e 's_\.lua__' -e 's_/_._g')
 
 # TESTSCRIPTS expands to:


### PR DESCRIPTION
Otherwise it prints misleading errors:

```
grep: jit/vmdef.lua: No such file or directory
grep: program/lisper/dev-env/syscall.lua: No such file or directory
grep: program/lisper/dev-env-docker/syscall.lua: No such file or
directory
grep: jit/vmdef.lua: No such file or directory
grep: program/lisper/dev-env/syscall.lua: No such file or directory
grep: program/lisper/dev-env-docker/syscall.lua: No such file or
directory
grep: jit/vmdef.lua: No such file or directory
grep: program/lisper/dev-env/syscall.lua: No such file or directory
grep: program/lisper/dev-env-docker/syscall.lua: No such file or
directory
grep: jit/vmdef.lua: No such file or directory
grep: program/lisper/dev-env/syscall.lua: No such file or directory
grep: program/lisper/dev-env-docker/syscall.lua: No such file or
directory
```

cc @eugeneia 