### PR TITLE
scripts/dock.sh: use eugeneia/snabb-nfv-test-vanilla by default

### DIFF
--- a/src/scripts/dock.sh
+++ b/src/scripts/dock.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-export SNABB_TEST_IMAGE=${SNABB_TEST_IMAGE:=eugeneia/snabb-nfv-test}
+export SNABB_TEST_IMAGE=${SNABB_TEST_IMAGE:=eugeneia/snabb-nfv-test-vanilla}
 
 # Snabb Docker environment
 


### PR DESCRIPTION
Switch to using `eugeneia/snabb-nfv-test-vanilla` by default in `scripts/dock.sh`. Should have done that way earlier, but doing this now finally since #944 triggers a bug in QEMU 2.4.0. This will most likely trigger a performance regression, so it might be wise to merge this as the very end of the release cycle to avoid the regression cascading onto other PRs.

Cc @lukego 