### PR TITLE
Intel1g fixes

### DIFF
--- a/src/apps/intel/intel1g.lua
+++ b/src/apps/intel/intel1g.lua
@@ -63,46 +63,46 @@ function Intel1g:new(conf)
 
    -- 8.1.3 Register Summary, p.359
    local r = {}
-   r.CTRL = 	0x00000		-- Device Control - RW
-   --r.CTRL = 	0x00004		-- alias: Device Control - RW
-   r.STATUS = 	0x00008		-- Device Status - RO
-   r.CTRL_EXT =	0x00018		-- Extended Device Control - RW
-   r.MDIC = 	0x00020		-- MDI Control - RW
-   r.RCTL = 	0x00100		-- RX Control - RW
-   r.TCTL = 	0x00400		-- TX Control - RW
-   r.TCTL_EXT =	0x00404		-- Extended TX Control - RW
-   r.MDICNFG = 	0x00E04		-- MDI Configuration - RW
-   r.EEER = 	0x00E30		-- Energy Efficient Ethernet (EEE) Register
-   r.EIMC = 	0x01528		-- 
-   --r.RXDCTL =	0x02828		-- legacy alias: RX Descriptor Control queue 0 - RW
-   --r.TXDCTL =	0x03828		-- legacy alias: TX Descriptor Control queue 0 - RW
-   r.GPRC = 	0x04074		-- Good Packets Receive Count - R/clr
-   r.RNBC = 	0x040A0		-- Receive No Buffers Count - R/clr
-   r.TORL = 	0x040C0		-- Total Octets Received - R/clr
-   r.TORH = 	0x040C4		-- Total Octets Received - R/clr
-   r.TOTL = 	0x040C8		-- Total Octets Transmitted - R/clr
-   r.TOTH = 	0x040CC		-- Total Octets Transmitted - R/clr
-   r.TPR = 	0x040D0		-- Total Packets Received - R/clr
-   r.TPT = 	0x040D4		-- Total Packets Transmitted - R/clr
-   r.RPTHC = 	0x04104		-- Rx Packets to Host Count - R/clr
-   r.MANC =	0x05820		-- 
-   r.SWSM =	0x05b50		-- 
-   r.SW_FW_SYNC=0x05b5c		-- Software Firmware Synchronization
-   r.EEMNGCTL=	0x12030		-- Management EEPROM Control Register
+   r.CTRL =     0x00000         -- Device Control - RW
+   --r.CTRL =   0x00004         -- alias: Device Control - RW
+   r.STATUS =   0x00008         -- Device Status - RO
+   r.CTRL_EXT = 0x00018         -- Extended Device Control - RW
+   r.MDIC =     0x00020         -- MDI Control - RW
+   r.RCTL =     0x00100         -- RX Control - RW
+   r.TCTL =     0x00400         -- TX Control - RW
+   r.TCTL_EXT = 0x00404         -- Extended TX Control - RW
+   r.MDICNFG =  0x00E04         -- MDI Configuration - RW
+   r.EEER =     0x00E30         -- Energy Efficient Ethernet (EEE) Register
+   r.EIMC =     0x01528         -- 
+   --r.RXDCTL = 0x02828         -- legacy alias: RX Descriptor Control queue 0 - RW
+   --r.TXDCTL = 0x03828         -- legacy alias: TX Descriptor Control queue 0 - RW
+   r.GPRC =     0x04074         -- Good Packets Receive Count - R/clr
+   r.RNBC =     0x040A0         -- Receive No Buffers Count - R/clr
+   r.TORL =     0x040C0         -- Total Octets Received - R/clr
+   r.TORH =     0x040C4         -- Total Octets Received - R/clr
+   r.TOTL =     0x040C8         -- Total Octets Transmitted - R/clr
+   r.TOTH =     0x040CC         -- Total Octets Transmitted - R/clr
+   r.TPR =      0x040D0         -- Total Packets Received - R/clr
+   r.TPT =      0x040D4         -- Total Packets Transmitted - R/clr
+   r.RPTHC =    0x04104         -- Rx Packets to Host Count - R/clr
+   r.MANC =     0x05820         -- 
+   r.SWSM =     0x05b50         -- 
+   r.SW_FW_SYNC=0x05b5c         -- Software Firmware Synchronization
+   r.EEMNGCTL=  0x12030         -- Management EEPROM Control Register
 
    -- checks
    local deviceInfo= pci.device_info(pciaddress)
    assert(pci.is_usable(deviceInfo), "NIC is in use")
    assert(deviceInfo.driver == 'apps.intel.intel1g', "intel1g does not support this NIC")
    local ringSize= 1
-   if deviceInfo.device == "0x1521" then		-- i350
+   if deviceInfo.device == "0x1521" then                -- i350
     ringSize= 8
-   elseif deviceInfo.device == "0x157b" then		-- i210
+   elseif deviceInfo.device == "0x157b" then            -- i210
     ringSize= 4
    end
    assert((txq >=0) and (txq <ringSize), "txqueue must be in 0.." .. ringSize-1 .. " for " .. deviceInfo.model)
    assert((rxq >=0) and (rxq <ringSize), "rxqueue must be in 0.." .. ringSize-1 .. " for " .. deviceInfo.model)
-   assert((ndesc %128) ==0, "ndesc must be a multiple of 128 (for Rx only)")	-- see 7.1.4.5
+   assert((ndesc %128) ==0, "ndesc must be a multiple of 128 (for Rx only)")    -- see 7.1.4.5
 
    -- Setup device access
    pci.unbind_device_from_linux(pciaddress)
@@ -146,15 +146,15 @@ function Intel1g:new(conf)
    end
 
    -- 3.7.4.4.4 Using PHY Registers, 
-   local MDIOpage= -1		-- 8.27.3.21 HW resets to 0, but persists with SW reset!
-   poke32(r.MDICNFG, 0)		-- 8.2.5 MDC/MDIO Config: 0x0000 = internal PHY
+   local MDIOpage= -1           -- 8.27.3.21 HW resets to 0, but persists with SW reset!
+   poke32(r.MDICNFG, 0)         -- 8.2.5 MDC/MDIO Config: 0x0000 = internal PHY
 
-   local function writePHY(page, register, data)	-- 8.2.4 Media Dependent Interface Control
+   local function writePHY(page, register, data)        -- 8.2.4 Media Dependent Interface Control
     if page ~= MDIOpage then
      MDIOpage= page
-     writePHY(page, 22, (page %256))	-- select page by writing page to register 22 (from any page)
+     writePHY(page, 22, (page %256))    -- select page by writing page to register 22 (from any page)
     end
-    poke32(r.MDIC, 1 *2^26 + (register %2^5)*2^16  + (data %2^16))	-- OpCode 01b = MDI write
+    poke32(r.MDIC, 1 *2^26 + (register %2^5)*2^16  + (data %2^16))      -- OpCode 01b = MDI write
     wait32(r.MDIC, {Ready=28})
     assert(band(peek32(r.MDIC), bitvalue({Error=30})) ==0, "writePHY(): error")
    end
@@ -162,9 +162,9 @@ function Intel1g:new(conf)
    local function readPHY(page, register)
     if page ~= MDIOpage then
      MDIOpage= page
-     writePHY(page, 22, (page %256))	-- select page by writing page to register 22 (from any page)
+     writePHY(page, 22, (page %256))    -- select page by writing page to register 22 (from any page)
     end
-    poke32(r.MDIC, 2 *2^26 + (register %2^5)*2^16)	-- OpCode 10b = MDI read
+    poke32(r.MDIC, 2 *2^26 + (register %2^5)*2^16)      -- OpCode 10b = MDI read
     wait32(r.MDIC, {Ready=28})
     assert(band(peek32(r.MDIC), bitvalue({Error=30})) ==0, "readPHY(): error")
     return peek32(r.MDIC) %2^16
@@ -176,7 +176,7 @@ function Intel1g:new(conf)
 
    local function printMACstatus()
     print("MAC Status:")
-    local status= peek32(r.STATUS)				-- p.372, 8.2.2
+    local status= peek32(r.STATUS)                              -- p.372, 8.2.2
     print("  STATUS       = " .. bit.tohex(status))
     print("  Full Duplex  = " .. yesno(status, 0))
     print("  Link Up      = " .. yesno(status, 1))
@@ -184,21 +184,21 @@ function Intel1g:new(conf)
     local speed = (({10,100,1000,1000})[1+bit.band(bit.rshift(status, 6),3)])
     print("  Speed        = " .. speed .. ' Mb/s')
     local autoSpeed = (({10,100,1000,1000})[1+bit.band(bit.rshift(status, 8),3)])
-    print("  Auto Speed   = " .. autoSpeed .. ' Mb/s')	-- Auto-Speed Detection Value (ASDV), result after setting CTRL_EXT.ASDCHK
+    print("  Auto Speed   = " .. autoSpeed .. ' Mb/s')  -- Auto-Speed Detection Value (ASDV), result after setting CTRL_EXT.ASDCHK
     print("  PHY Reset    = " .. yesno(status, 10))
-    print("  RxFlowCtrl   = " .. yesno(status, 27))		-- should be set by SW driver to auto-neg. from PHY
-    print("  TxFlowCtrl   = " .. yesno(status, 28))		-- should be set by SW driver to auto-neg. from PHY
+    print("  RxFlowCtrl   = " .. yesno(status, 27))             -- should be set by SW driver to auto-neg. from PHY
+    print("  TxFlowCtrl   = " .. yesno(status, 28))             -- should be set by SW driver to auto-neg. from PHY
    end
 
    local function printPHYstatus()
     print("PHY Status:")
-    print("  PHYREG(0,0)  = " .. bit.tohex(readPHY(0,0)) .. " Copper Control")	-- p.545, 
-    print("  PHYREG(0,1)  = " .. bit.tohex(readPHY(0,1)) .. " Copper Status")	-- p.546, 
+    print("  PHYREG(0,0)  = " .. bit.tohex(readPHY(0,0)) .. " Copper Control")  -- p.545, 
+    print("  PHYREG(0,1)  = " .. bit.tohex(readPHY(0,1)) .. " Copper Status")   -- p.546, 
     local phyID1= readPHY(0,2)
-    print("  PHYREG(0,2)  = " .. bit.tohex(phyID1) .. " PHY ID 1")		-- p.547, 8.27.3.3 PHY Identifier 1
+    print("  PHYREG(0,2)  = " .. bit.tohex(phyID1) .. " PHY ID 1")              -- p.547, 8.27.3.3 PHY Identifier 1
     assert((phyID1 == 0x0141) or (phyID1 == 0x0154), "PHY ID1 is not 0x0141 (i210) or 0x0154 (i350)")
-    print("  PHYREG(0,4)  = " .. bit.tohex(readPHY(0,4)) .. " Copper Auto-Neg Adv")	-- p.548, p.114, auto-neg. flow control (bits 10, 11)
-    print("  PHYREG(0,5)  = " .. bit.tohex(readPHY(0,5)) .. " Copper Link Partner Ability")	-- p.549, p.115, auto-neg. flow control (bits 10, 11) of partner
+    print("  PHYREG(0,4)  = " .. bit.tohex(readPHY(0,4)) .. " Copper Auto-Neg Adv")     -- p.548, p.114, auto-neg. flow control (bits 10, 11)
+    print("  PHYREG(0,5)  = " .. bit.tohex(readPHY(0,5)) .. " Copper Link Partner Ability")     -- p.549, p.115, auto-neg. flow control (bits 10, 11) of partner
     print("  PHYREG(0,6)  = " .. bit.tohex(readPHY(0,6)) .. " Copper Auto-Neg Expansion")  -- p.550
     print("  PHYREG(0,9)  = " .. bit.tohex(readPHY(0,9)) .. " 1000BASE-T Control")  -- p.552
     print("  PHYREG(0,10) = " .. bit.tohex(readPHY(0,10)) .. " 1000BASE-T Status")  -- p.553
@@ -206,7 +206,7 @@ function Intel1g:new(conf)
     print("  PHYREG(0,16) = " .. bit.tohex(readPHY(0,16)) .. " Copper Specific Control 1")  -- p.554
 
     local phyStatus= readPHY(0, 17)
-    print("  PHYREG(0,17) = " .. bit.tohex(phyStatus) .. " Copper Specific Status 1")	-- p.556, 8.27.3.16
+    print("  PHYREG(0,17) = " .. bit.tohex(phyStatus) .. " Copper Specific Status 1")   -- p.556, 8.27.3.16
     local speed = (({10,100,1000,1000})[1+bit.band(bit.rshift(phyStatus, 14),3)])
     print("  Speed        = " .. speed .. ' Mb/s')
     print("  Full Duplex  = " .. yesno(phyStatus, 13))
@@ -217,18 +217,18 @@ function Intel1g:new(conf)
     print("  Rx Pause     = " .. yesno(phyStatus, 8))
     print("  MDI-X        = " .. yesno(phyStatus, 6))
     print("  Downshift    = " .. yesno(phyStatus, 5))
-    print("  Copper Sleep = " .. yesno(phyStatus, 4))	-- Copper Energy Detect Status
+    print("  Copper Sleep = " .. yesno(phyStatus, 4))   -- Copper Energy Detect Status
     print("  Glabal Link  = " .. yesno(phyStatus, 3))
     print("  Polarity Rev = " .. yesno(phyStatus, 1))
     print("  Jabber       = " .. yesno(phyStatus, 0))
 
     print("  PHYREG(0,20) = " .. bit.tohex(readPHY(0,20)) .. " Copper Specific Control 2")  -- p.559
-    print("  PHYREG(0,21) = " .. bit.tohex(readPHY(0,21)) .. " Copper Specific Rx Errors")	-- p.559
-    print("  PHYREG(0,22) = " .. bit.tohex(readPHY(0,22)) .. " Page Addres")	-- p.559
-    print("  PHYREG(0,23) = " .. bit.tohex(readPHY(0,23)) .. " Copper Specific Control 3")	-- p.560
-    print("  PHYREG(2,16) = " .. bit.tohex(readPHY(2,16)) .. " MAC Specific Control 1")	-- p.561
-    print("  PHYREG(2,19) = " .. bit.tohex(readPHY(2,19)) .. " MAC Specific Status")	-- p.561
-    print("  PHYREG(2,21) = " .. bit.tohex(readPHY(2,21)) .. " MAC Specific Control 2")	-- p.563         
+    print("  PHYREG(0,21) = " .. bit.tohex(readPHY(0,21)) .. " Copper Specific Rx Errors")      -- p.559
+    print("  PHYREG(0,22) = " .. bit.tohex(readPHY(0,22)) .. " Page Addres")    -- p.559
+    print("  PHYREG(0,23) = " .. bit.tohex(readPHY(0,23)) .. " Copper Specific Control 3")      -- p.560
+    print("  PHYREG(2,16) = " .. bit.tohex(readPHY(2,16)) .. " MAC Specific Control 1") -- p.561
+    print("  PHYREG(2,19) = " .. bit.tohex(readPHY(2,19)) .. " MAC Specific Status")    -- p.561
+    print("  PHYREG(2,21) = " .. bit.tohex(readPHY(2,21)) .. " MAC Specific Control 2") -- p.563         
    end
 
    local function printTxStatus()
@@ -280,96 +280,96 @@ function Intel1g:new(conf)
 
    local function initPHY()
      -- 4.3.1.4 PHY Reset, p.131
-     wait32(r.MANC, {BLK_Phy_Rst_On_IDE=18}, 0)	-- wait untill IDE link stable
+     wait32(r.MANC, {BLK_Phy_Rst_On_IDE=18}, 0) -- wait untill IDE link stable
      -- 4.6.1 Acquiring Ownership over a Shared Resource, p.147
      -- and 4.6.2 Releasing Ownership
      -- XXX to do: write wrappers for both software/software (SWSM.SMBI) 
      -- software/firmware (SWSM.SWESMBI) semamphores, then apply them...
-     set32(r.SWSM, {SWESMBI= 1})		-- a. get software/firmware semaphore
+     set32(r.SWSM, {SWESMBI= 1})                -- a. get software/firmware semaphore
      while band(peek32(r.SWSM), 0x02) ==0 do
        set32(r.SWSM, {SWESMBI= 1})
      end
-     wait32(r.SW_FW_SYNC, {SW_PHY_SM=1}, 0)	-- b. wait until firmware releases PHY
-     set32(r.SW_FW_SYNC, {SW_PHY_SM=1})		-- set semaphore bit to own PHY
-     clear32(r.SWSM, {SWESMBI= 1})		-- c. release software/firmware semaphore
-     set32(r.CTRL, {PHYreset= 31})		-- 3. set PHY reset
-     C.usleep(1*100)				-- 4. wait 100 us
-     clear32(r.CTRL, {PHYreset= 31})		-- 5. release PHY reset
-     set32(r.SWSM, {SWESMBI= 1})		-- 6. release ownership
+     wait32(r.SW_FW_SYNC, {SW_PHY_SM=1}, 0)     -- b. wait until firmware releases PHY
+     set32(r.SW_FW_SYNC, {SW_PHY_SM=1})         -- set semaphore bit to own PHY
+     clear32(r.SWSM, {SWESMBI= 1})              -- c. release software/firmware semaphore
+     set32(r.CTRL, {PHYreset= 31})              -- 3. set PHY reset
+     C.usleep(1*100)                            -- 4. wait 100 us
+     clear32(r.CTRL, {PHYreset= 31})            -- 5. release PHY reset
+     set32(r.SWSM, {SWESMBI= 1})                -- 6. release ownership
      while band(peek32(r.SWSM), 0x02) ==0 do
        set32(r.SWSM, {SWESMBI= 1})
      end
-     clear32(r.SW_FW_SYNC, {SW_PHY_SM=1})	-- release PHY
-     clear32(r.SWSM, {SWESMBI= 1})		-- release software/firmware semaphore
-     wait32(r.EEMNGCTL, {CFG_DONE0=18})		-- 7. wait for CFG_DONE
+     clear32(r.SW_FW_SYNC, {SW_PHY_SM=1})       -- release PHY
+     clear32(r.SWSM, {SWESMBI= 1})              -- release software/firmware semaphore
+     wait32(r.EEMNGCTL, {CFG_DONE0=18})         -- 7. wait for CFG_DONE
 
-     set32(r.SWSM, {SWESMBI= 1})		-- 8. a. get software/firmware semaphore
+     set32(r.SWSM, {SWESMBI= 1})                -- 8. a. get software/firmware semaphore
      while band(peek32(r.SWSM), 0x02) ==0 do
        set32(r.SWSM, {SWESMBI= 1})
      end
-     wait32(r.SW_FW_SYNC, {SW_PHY_SM=1}, 0)	-- b. wait until firmware releases PHY
-     clear32(r.SWSM, {SWESMBI= 1})		-- c. release software/firmware semaphore
-     --XXX to do...				-- 9. configure PHY
-     --XXX to do...				-- 10. release ownership, see 4.6.2, p.148
-     clear32(r.SW_FW_SYNC, {SW_PHY_SM=1})	-- release PHY
-     clear32(r.SWSM, {SWESMBI= 1})		-- release software/firmware semaphore
+     wait32(r.SW_FW_SYNC, {SW_PHY_SM=1}, 0)     -- b. wait until firmware releases PHY
+     clear32(r.SWSM, {SWESMBI= 1})              -- c. release software/firmware semaphore
+     --XXX to do...                             -- 9. configure PHY
+     --XXX to do...                             -- 10. release ownership, see 4.6.2, p.148
+     clear32(r.SW_FW_SYNC, {SW_PHY_SM=1})       -- release PHY
+     clear32(r.SWSM, {SWESMBI= 1})              -- release software/firmware semaphore
    end
 
    -- Device setup and initialization
    --printNICstatus(r, "Status before Init: ")
    --printStats(r)
-   if not attach then				-- Initialize device
-      poke32(r.EIMC, 0xffffffff)		-- disable interrupts
-      poke32(r.CTRL, {RST = 26})		-- software / global reset, self clearing
-      --poke32(r.CTRL, {DEV_RST = 29})		-- device reset (incl. DMA), self clearing
-      C.usleep(4*1000)				-- wait at least 3 ms before reading, see 7.6.1.1
-      wait32(r.CTRL, {RST = 26}, 0)		-- wait port reset complete
-      --wait32(r.CTRL, {DEV_RST = 29}, 0)	-- wait device reset complete
-      poke32(r.EIMC, 0xffffffff)		-- re-disable interrupts
-      if conf.loopback == "MAC" then		-- 3.7.6.2.1 Setting the I210 to MAC Loopback Mode
-         set32(r.CTRL, {SETLINKUP = 6})		-- Set CTRL.SLU (bit 6, should be set by default)
-         set32(r.RCTL, {LOOPBACKMODE0 = 6})	-- Set RCTL.LBM to 01b (bits 7:6)
-	 set32(r.CTRL, {FRCSPD=11, FRCDPLX=12})	-- Set CTRL.FRCSPD and FRCDPLX (bits 11 and 12)
-	 set32(r.CTRL, {FD=0, SPEED1=9})	-- Set the CTRL.FD bit and program the CTRL.SPEED field to 10b (1 GbE)
-	 set32(r.EEER, {EEE_FRC_AN=24})		-- Set EEER.EEE_FRC_AN to 1b to enable checking EEE operation in MAC loopback mode
+   if not attach then                           -- Initialize device
+      poke32(r.EIMC, 0xffffffff)                -- disable interrupts
+      poke32(r.CTRL, {RST = 26})                -- software / global reset, self clearing
+      --poke32(r.CTRL, {DEV_RST = 29})          -- device reset (incl. DMA), self clearing
+      C.usleep(4*1000)                          -- wait at least 3 ms before reading, see 7.6.1.1
+      wait32(r.CTRL, {RST = 26}, 0)             -- wait port reset complete
+      --wait32(r.CTRL, {DEV_RST = 29}, 0)       -- wait device reset complete
+      poke32(r.EIMC, 0xffffffff)                -- re-disable interrupts
+      if conf.loopback == "MAC" then            -- 3.7.6.2.1 Setting the I210 to MAC Loopback Mode
+         set32(r.CTRL, {SETLINKUP = 6})         -- Set CTRL.SLU (bit 6, should be set by default)
+         set32(r.RCTL, {LOOPBACKMODE0 = 6})     -- Set RCTL.LBM to 01b (bits 7:6)
+         set32(r.CTRL, {FRCSPD=11, FRCDPLX=12}) -- Set CTRL.FRCSPD and FRCDPLX (bits 11 and 12)
+         set32(r.CTRL, {FD=0, SPEED1=9})        -- Set the CTRL.FD bit and program the CTRL.SPEED field to 10b (1 GbE)
+         set32(r.EEER, {EEE_FRC_AN=24})         -- Set EEER.EEE_FRC_AN to 1b to enable checking EEE operation in MAC loopback mode
          print("MAC Loopback set")
-      elseif conf.loopback == "PHY" then	-- 3.7.6.3.1 Setting the I210 to Internal PHY Loopback Mode
-         set32(r.CTRL, {SETLINKUP = 6})		-- Set CTRL.SLU (bit 6, should be set by default)
-	 clear32(r.CTRL_EXT, {LinkMode1=23,LinkMode0=22})	-- set Link mode to internal PHY
-         writePHY(0, 0, bitvalue({Duplex=8, SpeedMSB=6}))	-- PHYREG 8.27.3 Copper Control
-         writePHY(2, 21, 0x06)					-- MAC interface speed 1GE, 8.27.3.27 MAC Specific Control 2, p.563
+      elseif conf.loopback == "PHY" then        -- 3.7.6.3.1 Setting the I210 to Internal PHY Loopback Mode
+         set32(r.CTRL, {SETLINKUP = 6})         -- Set CTRL.SLU (bit 6, should be set by default)
+         clear32(r.CTRL_EXT, {LinkMode1=23,LinkMode0=22})       -- set Link mode to internal PHY
+         writePHY(0, 0, bitvalue({Duplex=8, SpeedMSB=6}))       -- PHYREG 8.27.3 Copper Control
+         writePHY(2, 21, 0x06)                                  -- MAC interface speed 1GE, 8.27.3.27 MAC Specific Control 2, p.563
          --writePHY(0, 0, bitvalue({Duplex=8, SpeedMSB=6, CopperReset=15})) -- Copper Reset: not required, so don't!
-         writePHY(0, 0, bitvalue({Duplex=8, SpeedMSB=6, Loopback=14}))	-- Loopback
+         writePHY(0, 0, bitvalue({Duplex=8, SpeedMSB=6, Loopback=14}))  -- Loopback
          print("PHY Loopback set")
-      else					-- 3.7.4.4 Copper (Internal) PHY Link Config
-	 -- PHY tells MAC after auto-neg. (PCS and 802.3 clauses 28 (extensions) & 40 (.3ab)
-	 -- config generally determined by PHY auto-neg. (speed, duplex, flow control)
-	 -- PHY asserts link indication (LINK) to MAC
-	 -- SW driver must Set Link Up (CTRL.SLU) before MAC recognizes LINK from PHY and consider link up
-         initPHY()						-- 4.5.7.2.1 Full Duplx, Speed auto neg. by PHY
-         C.usleep(1*1000*1000)					-- wait 1s for init to settle
+      else                                      -- 3.7.4.4 Copper (Internal) PHY Link Config
+         -- PHY tells MAC after auto-neg. (PCS and 802.3 clauses 28 (extensions) & 40 (.3ab)
+         -- config generally determined by PHY auto-neg. (speed, duplex, flow control)
+         -- PHY asserts link indication (LINK) to MAC
+         -- SW driver must Set Link Up (CTRL.SLU) before MAC recognizes LINK from PHY and consider link up
+         initPHY()                                              -- 4.5.7.2.1 Full Duplx, Speed auto neg. by PHY
+         C.usleep(1*1000*1000)                                  -- wait 1s for init to settle
          print("initPHY() done")
-         clear32(r.STATUS, {PHYReset=10})			-- p.373
-         set32(r.CTRL, {SETLINKUP = 6})				-- Set CTRL.SLU (bit 6, should be set by default)
-         clear32(r.CTRL_EXT, {LinkMode1=23,LinkMode0=22})	-- set Link mode to direct copper / internal PHY
-         clear32(r.CTRL_EXT, {PowerDown=20})			-- disable power down
-         set32(r.CTRL_EXT, {AutoSpeedDetect = 12})		-- p.373
-         --set32(r.CTRL_EXT, {DriverLoaded = 28})		-- signal Device Driver Loaded
+         clear32(r.STATUS, {PHYReset=10})                       -- p.373
+         set32(r.CTRL, {SETLINKUP = 6})                         -- Set CTRL.SLU (bit 6, should be set by default)
+         clear32(r.CTRL_EXT, {LinkMode1=23,LinkMode0=22})       -- set Link mode to direct copper / internal PHY
+         clear32(r.CTRL_EXT, {PowerDown=20})                    -- disable power down
+         set32(r.CTRL_EXT, {AutoSpeedDetect = 12})              -- p.373
+         --set32(r.CTRL_EXT, {DriverLoaded = 28})               -- signal Device Driver Loaded
 
          io.write("Waiting for link...")
          io.flush()
-         wait32(r.STATUS, {LinkUp=1})				-- wait for auto-neg. to complete
+         wait32(r.STATUS, {LinkUp=1})                           -- wait for auto-neg. to complete
          print(" We have link-up!")
          --printMACstatus()
       end
 
       stop_nic = function ()
          -- XXX Are these the right actions?
-         clear32(r.CTRL, {SETLINKUP = 6})		-- take the link down
-         pci.set_bus_master(pciaddress, false)		-- disable DMA
+         clear32(r.CTRL, {SETLINKUP = 6})               -- take the link down
+         pci.set_bus_master(pciaddress, false)          -- disable DMA
       end
 
-      function self:report()				-- from SolarFlareNic:report() for snabbmark, etc.
+      function self:report()                            -- from SolarFlareNic:report() for snabbmark, etc.
        io.write("Intel1g device " .. pciaddress .. ":  ")
        for name,value in pairs(counters) do
         io.write(string.format('%s: %d ', name, value))
@@ -379,13 +379,13 @@ function Intel1g:new(conf)
 
    end  -- if not attach then
 
-   if txq then						-- Transmitter
+   if txq then                                          -- Transmitter
       -- Define registers for the transmit queue that we are using
       r.TDBAL  = 0xe000 + txq*0x40
       r.TDBAH  = 0xe004 + txq*0x40
       r.TDLEN  = 0xe008 + txq*0x40
-      r.TDH    = 0xe010 + txq*0x40			-- Tx Descriptor Head - RO!
-      r.TDT    = 0xe018 + txq*0x40			-- Tx Descriptor Head - RW
+      r.TDH    = 0xe010 + txq*0x40                      -- Tx Descriptor Head - RO!
+      r.TDT    = 0xe018 + txq*0x40                      -- Tx Descriptor Head - RW
       r.TXDCTL = 0xe028 + txq*0x40
       r.TXCTL  = 0xe014 + txq*0x40
 
@@ -422,15 +422,15 @@ function Intel1g:new(conf)
          txdesc[tdt].flags = bor(p.length, txdesc_flags, lshift(p.length+0ULL, 46))
          txpackets[tdt] = p
          tdt = ringnext(tdt)
-	 counters.txPackets= counters.txPackets +1
-	 counters.txBytes= counters.txBytes +p.length
+         counters.txPackets= counters.txPackets +1
+         counters.txBytes= counters.txBytes +p.length
       end
 
       -- Synchronize DMA ring state with hardware
       -- Free packets that have been transmitted
       local function sync_transmit ()
          local cursor = tdh
-         tdh = peek32(r.TDH)			-- possible race condition, see 7.1.4.4, 7.2.3 
+         tdh = peek32(r.TDH)                    -- possible race condition, see 7.1.4.4, 7.2.3 
          while cursor ~= tdh do
             if txpackets[cursor] then
                packet.free(txpackets[cursor])
@@ -441,12 +441,12 @@ function Intel1g:new(conf)
          poke32(r.TDT, tdt)
       end
 
-      function self:push ()				-- move frames from link.rx to NIC.txQueue for transmission
+      function self:push ()                             -- move frames from link.rx to NIC.txQueue for transmission
          counters.push= counters.push +1
          --local li = self.input[1]
-         local li = self.input["rx"]			-- same-same as [1]
+         local li = self.input["rx"]                    -- same-same as [1]
          assert(li, "intel1g:push: no input link")
-         if link.empty(li) then				-- from SolarFlareNic:push()
+         if link.empty(li) then                         -- from SolarFlareNic:push()
           counters.pushRxLinkEmpty= counters.pushRxLinkEmpty +1
          elseif not can_transmit() then
           counters.pushTxRingFull= counters.pushTxRingFull +1
@@ -469,15 +469,15 @@ function Intel1g:new(conf)
       end
    end  -- if txq then
 
-   if rxq then				-- Receiver
+   if rxq then                          -- Receiver
       r.RDBAL  = 0xc000 + rxq*0x40
       r.RDBAH  = 0xc004 + rxq*0x40
       r.RDLEN  = 0xc008 + rxq*0x40
-      r.SRRCTL = 0xc00c + rxq*0x40	-- Split and Replication Receive Control
-      r.RDH    = 0xc010 + rxq*0x40	-- Rx Descriptor Head - RO
-      r.RXCTL  = 0xc014 + rxq*0x40	-- Rx DCA Control Registers
-      r.RDT    = 0xc018 + rxq*0x40	-- Rx Descriptor Tail - RW
-      r.RXDCTL = 0xc028 + rxq*0x40	-- Receive Descriptor Control
+      r.SRRCTL = 0xc00c + rxq*0x40      -- Split and Replication Receive Control
+      r.RDH    = 0xc010 + rxq*0x40      -- Rx Descriptor Head - RO
+      r.RXCTL  = 0xc014 + rxq*0x40      -- Rx DCA Control Registers
+      r.RDT    = 0xc018 + rxq*0x40      -- Rx Descriptor Tail - RW
+      r.RXDCTL = 0xc028 + rxq*0x40      -- Receive Descriptor Control
 
       local rxdesc_t = ffi.typeof([[
         struct { 
@@ -498,64 +498,64 @@ function Intel1g:new(conf)
 
       -- Initialize receive queue
       -- see em_initialize_receive_unit() in http://cvsweb.openbsd.org/cgi-bin/cvsweb/src/sys/dev/pci/if_em.c
-      clear32(r.RCTL, {rxen = 1})	-- disable receiver while setting up descriptor ring
-      --poke32(r.RDTR, )		-- set Receive Delay Timer Register (only for interrupt ops?)
+      clear32(r.RCTL, {rxen = 1})       -- disable receiver while setting up descriptor ring
+      --poke32(r.RDTR, )                -- set Receive Delay Timer Register (only for interrupt ops?)
       poke32(r.RDBAL, tophysical(rxdesc) % 2^32)
       poke32(r.RDBAH, tophysical(rxdesc) / 2^32)
       poke32(r.RDLEN, ndesc * ffi.sizeof(rxdesc_t))
 
       for i = 0, ndesc-1 do
-	local p= packet.allocate()
-	rxpackets[i]= p
+        local p= packet.allocate()
+        rxpackets[i]= p
         rxdesc[i].address= tophysical(p.data)
         rxdesc[i].status= 0
       end
 
       local rctl= {}
-      rctl.RXEN= 1			-- enable receiver
-      rctl.SBP= 2			-- store bad packet
-      rctl.RCTL_UPE= 3			-- unicast promiscuous enable
-      rctl.RCTL_MPE= 4			-- multicast promiscuous enable
-      rctl.LPE= 5			-- Long Packet Enable
-      rctl.BAM= 15			-- broadcast enable
-      --rctl.SZ_512= 17			-- buffer size: use SRRCTL for larger buffer sizes
-      --rctl.RCTL_RDMTS_HALF=		-- rx desc min threshold size
-      rctl.SECRC= 26			-- i350 has a bug where it always strips the CRC, so strip CRC and cope in rxeof
+      rctl.RXEN= 1                      -- enable receiver
+      rctl.SBP= 2                       -- store bad packet
+      rctl.RCTL_UPE= 3                  -- unicast promiscuous enable
+      rctl.RCTL_MPE= 4                  -- multicast promiscuous enable
+      rctl.LPE= 5                       -- Long Packet Enable
+      rctl.BAM= 15                      -- broadcast enable
+      --rctl.SZ_512= 17                 -- buffer size: use SRRCTL for larger buffer sizes
+      --rctl.RCTL_RDMTS_HALF=           -- rx desc min threshold size
+      rctl.SECRC= 26                    -- i350 has a bug where it always strips the CRC, so strip CRC and cope in rxeof
 
-      poke32(r.SRRCTL, 10)		-- buffer size in 1 KB increments
-      set32(r.SRRCTL, {Drop_En= 31})	-- drop packets when no descriptors available
-      set32(r.RXDCTL, {ENABLE= 25})	-- enable the RX queue
-      wait32(r.RXDCTL, {ENABLE=25})	-- wait until enabled
+      poke32(r.SRRCTL, 10)              -- buffer size in 1 KB increments
+      set32(r.SRRCTL, {Drop_En= 31})    -- drop packets when no descriptors available
+      set32(r.RXDCTL, {ENABLE= 25})     -- enable the RX queue
+      wait32(r.RXDCTL, {ENABLE=25})     -- wait until enabled
 
-      --poke32(r.RCTL, rctl)		-- enable receiver only once Rx queue/descriptors are setup
-      set32(r.RCTL, rctl)		-- enable receiver only once Rx queue/descriptors are setup
+      --poke32(r.RCTL, rctl)            -- enable receiver only once Rx queue/descriptors are setup
+      set32(r.RCTL, rctl)               -- enable receiver only once Rx queue/descriptors are setup
 
-      --poke32(r.RDH, 0)		-- Rx descriptor Head (RO)
-      --poke32(r.RDT, 0)		-- Rx descriptor Tail
-      poke32(r.RDT, ndesc-1)		-- Rx descriptor Tail, trigger NIC to cache descriptors with index ~=0
+      --poke32(r.RDH, 0)                -- Rx descriptor Head (RO)
+      --poke32(r.RDT, 0)                -- Rx descriptor Tail
+      poke32(r.RDT, ndesc-1)            -- Rx descriptor Tail, trigger NIC to cache descriptors with index ~=0
 
       --printNICstatus(r, "Status after init receive: ")
 
       -- Return true if there is a DMA-completed packet ready to be received.
       local function can_receive ()
          local r= (rdt ~= rdh) and (band(rxdesc[rdt].status, 0x01) ~= 0)
-	 --print("can_receive():  r=",r, "  rdh=",rdh, "  rdt=",rdt)
+         --print("can_receive():  r=",r, "  rdh=",rdh, "  rdt=",rdt)
          return r
       end
 
       local lostSeq, lastSeqNo = 0, -1
 
-      local function receive ()		-- Receive a packet
-         assert(can_receive())		-- precondition
+      local function receive ()         -- Receive a packet
+         assert(can_receive())          -- precondition
          local desc = rxdesc[rdt]
          local p = rxpackets[rdt]
          p.length = desc.length
-	 counters.rxPackets= counters.rxPackets +1
-	 counters.rxBytes= counters.rxBytes +p.length
-         local np= packet.allocate()	-- get empty packet buffer
-         rxpackets[rdt] = np		-- disconnect received packet, connect new buffer
+         counters.rxPackets= counters.rxPackets +1
+         counters.rxBytes= counters.rxBytes +p.length
+         local np= packet.allocate()    -- get empty packet buffer
+         rxpackets[rdt] = np            -- disconnect received packet, connect new buffer
          rxdesc[rdt].address= tophysical(np.data)
-	 rxdesc[rdt].status= 0		-- see 7.1.4.5: zero status before bumping tail pointer
+         rxdesc[rdt].status= 0          -- see 7.1.4.5: zero status before bumping tail pointer
          rdt = ringnext(rdt)
          --print("receive(): p.length= ", p.length)
          rxSeqNo= p.data[3] *2^24 + p.data[2] *2^16 + p.data[1] *2^8 + p.data[0]
@@ -563,33 +563,33 @@ function Intel1g:new(conf)
          lastSeqNo= lastSeqNo +1
          while lastSeqNo < rxSeqNo do
           --print("receive(): lastSeqNo , rxSeqNo= ", lastSeqNo, rxSeqNo)
-	  --print("receive(): missing ", lastSeqNo)
+          --print("receive(): missing ", lastSeqNo)
           lostSeq= lostSeq +1
           lastSeqNo= lastSeqNo +1
          end
          return p
       end
 
-      local function sync_receive ()			-- Synchronize receive registers with hardware
-         rdh = peek32(r.RDH)				-- possible race condition, see 7.1.4.4, 7.2.3
-         --rdh = band(peek32(r.RDH), ndesc-1)		-- from intel1g: Luke observed (RDH == ndesc) !?
-         --rdh = math.min(peek32(r.RDH), ndesc-1)	-- from intel10g
-         assert(rdh <ndesc)				-- from intel1g: Luke observed (RDH == ndesc) !?
-         --C.full_memory_barrier()			-- from intel10g, why???
+      local function sync_receive ()                    -- Synchronize receive registers with hardware
+         rdh = peek32(r.RDH)                            -- possible race condition, see 7.1.4.4, 7.2.3
+         --rdh = band(peek32(r.RDH), ndesc-1)           -- from intel1g: Luke observed (RDH == ndesc) !?
+         --rdh = math.min(peek32(r.RDH), ndesc-1)       -- from intel10g
+         assert(rdh <ndesc)                             -- from intel1g: Luke observed (RDH == ndesc) !?
+         --C.full_memory_barrier()                      -- from intel10g, why???
          poke32(r.RDT, rdt)
-	 --print("sync_receive():  rdh=",rdh, "  rdt=",rdt)
+         --print("sync_receive():  rdh=",rdh, "  rdt=",rdt)
       end
       
-      function self:pull ()				-- move received frames from NIC.rxQueue to link.tx
+      function self:pull ()                             -- move received frames from NIC.rxQueue to link.tx
          counters.pull= counters.pull +1
          --local lo = self.output[1]
-         local lo = self.output["tx"]			-- same-same as [1]
+         local lo = self.output["tx"]                   -- same-same as [1]
          --assert(lo, "intel1g: no output link")
          local limit = rxburst
          while limit > 0 and can_receive() do
           limit = limit - 1
-          if lo then					-- a link connects NIC to a sink
-           if not link.full(lo) then			-- from SolarFlareNic:pull()
+          if lo then                                    -- a link connects NIC to a sink
+           if not link.full(lo) then                    -- from SolarFlareNic:pull()
             link.transmit(lo, receive())
            else
             counters.pullTxLinkFull= counters.pullTxLinkFull +1
@@ -603,7 +603,7 @@ function Intel1g:new(conf)
          sync_receive()
       end
 
-      stop_receive = function ()			-- stop receiver, see 4.5.9.2
+      stop_receive = function ()                        -- stop receiver, see 4.5.9.2
          --poke32(r.RXDCTL, 0)
          clear32(r.RXDCTL, {ENABLE=25})
          wait32(r.RXDCTL, {ENABLE=25}, 0)
@@ -614,11 +614,11 @@ function Intel1g:new(conf)
             end
          end
          -- XXX return dma memory of Rx descriptor ring
-	print("stop_receive(): lostSeq ", lostSeq)
+        print("stop_receive(): lostSeq ", lostSeq)
       end
    end  -- if rxq then
 
-   function self:stop ()				-- Stop all functions that are running
+   function self:stop ()                                -- Stop all functions that are running
       if stop_receive  then stop_receive()  end
       if stop_transmit then stop_transmit() end
       if stop_nic      then stop_nic()      end
@@ -662,7 +662,7 @@ function selftest ()
    print("selftest: ok")
 
    local runtime = endTime - startTime
-   engine.app_table.nic.stop()				-- outputs :report()
+   engine.app_table.nic.stop()                          -- outputs :report()
 
    local source= engine.app_table.source.output.tx
    assert(source, "Intel1g: no source?")
@@ -671,13 +671,13 @@ function selftest ()
    local txpackets= s.txpackets
 
    --local li = engine.app_table.nic.input[1]
-   local li = engine.app_table.nic.input["rx"]		-- same-same as [1]
+   local li = engine.app_table.nic.input["rx"]          -- same-same as [1]
    assert(li, "Intel1g: no input link?")
    local s= link.stats(li)
    print("input link:  txpackets= ", s.txpackets, "  rxpackets= ", s.rxpackets, "  txdrop= ", s.txdrop)
 
    --local lo = engine.app_table.nic.output[1]
-   local lo = engine.app_table.nic.output["tx"]		-- same-same as [1]
+   local lo = engine.app_table.nic.output["tx"]         -- same-same as [1]
    assert(lo, "Intel1g: no output link?")
    local s= link.stats(lo)
    print("output link: txpackets= ", s.txpackets, "  rxpackets= ", s.rxpackets, "  txdrop= ", s.txdrop)

--- a/src/apps/intel/intel1g.lua
+++ b/src/apps/intel/intel1g.lua
@@ -95,9 +95,9 @@ function Intel1g:new(conf)
    assert(pci.is_usable(deviceInfo), "NIC is in use")
    assert(deviceInfo.driver == 'apps.intel.intel1g', "intel1g does not support this NIC")
    local ringSize= 1
-   if deviceInfo.device == "0x1521" then                -- i350
+   if deviceInfo.model == "Intel 350" then
     ringSize= 8
-   elseif deviceInfo.device == "0x157b" then            -- i210
+   elseif deviceInfo.model == "Intel 210" then
     ringSize= 4
    end
    assert((txq >=0) and (txq <ringSize), "txqueue must be in 0.." .. ringSize-1 .. " for " .. deviceInfo.model)

--- a/src/apps/intel/intel1g.lua
+++ b/src/apps/intel/intel1g.lua
@@ -107,7 +107,7 @@ function Intel1g:new(conf)
    -- Setup device access
    pci.unbind_device_from_linux(pciaddress)
    pci.set_bus_master(pciaddress, true)
-   local regs, mmiofd = pci.map_pci_memory(pciaddress, 0)
+   local regs, mmiofd = pci.map_pci_memory(pciaddress, 0, true)
 
    -- Common utilities, see snabb/src/lib/hardware/register.lua
    local function bitvalue (value)

--- a/src/lib/hardware/pci.lua
+++ b/src/lib/hardware/pci.lua
@@ -75,6 +75,7 @@ local cards = {
       ["0x1528"] = {model = model["X540"],      driver = 'apps.intel.intel_app'},
       ["0x154d"] = {model = model["X520"],      driver = 'apps.intel.intel_app'},
       ["0x1521"] = {model = model["i350"],      driver = 'apps.intel.intel1g'},
+      ["0x1533"] = {model = model["i210"],      driver = 'apps.intel.intel1g'},
       ["0x157b"] = {model = model["i210"],      driver = 'apps.intel.intel1g'},
    },
    ["0x1924"] =  {


### PR DESCRIPTION
Commits     acc3595,    1024ea1 and 93d1c53 should be no-brainers. I'm not sure why the author has used local functions to manipulate registers instead of the standard utilities of `lib/hardware/register.lua`.  I have stuck to that method but believe that this should eventually be changed to have more uniformity in drivers. Also, this driver should probably be included in the `apps/intel/intel_app` framework, I guess. 

Commit 05565fe adds MTU-handling similar to what's already in `intel10g`, but this time I have enforced egress drops of oversized frames. Drop counters are only exposed through SNMP via 1ccd4d7. Note that the functionality relies on the assumption that all VLAN-handling by the NIC is disabled. This might require some discussion (also in the context of `intel10g` and future drivers).

Commit 1ccd4d7 implements "old-style" SNMP support like in the current `intel10g` driver. This will be removed once #931 (or something similar) is on master, I suppose. I wouldn't mind if this commit is excluded from this PR (i.e. I would maintain it on the `l2vpn` branch until it becomes obsolete unless other people want to use SNMP). Note that I reverted to the utilities from `lib/hardware/register.lua` for the statistics registers to make use of the accumulator functionality.
