### PR TITLE
core.timer: Inhibit debug messages

### DIFF
--- a/src/core/timer.lua
+++ b/src/core/timer.lua
@@ -7,7 +7,8 @@ local C = ffi.C
 
 local lib = require("core.lib")
 
-debug = _G.developer_debug
+-- Enable only when debugging this module. Can be very verbose.
+local debug = false
 
 ticks = false     -- current time, in ticks
 ns_per_tick = 1e6 -- tick resolution (millisecond)


### PR DESCRIPTION
Print debug messages only when enabled by editing the `core/timer.lua` source file, not when _G.developer_debug is enabled.

The debug mode prints a message every time a timer is executed. This could easily produce thousands of messages per second in reasonable applications. This seems appropriate when specifically debugging the timer module but not when enabling a more general debug mode.