### PR TITLE
Extended support for managing shared memory

### DIFF
--- a/src/apps/ipv6/nd_light.lua
+++ b/src/apps/ipv6/nd_light.lua
@@ -79,20 +79,9 @@ local function check_ip_address(ip, desc)
    return ip
 end
 
-local provided_counters = {
-   'type', 'dtime', 'status', 'rxerrors', 'txerrors', 'txdrop',
-   'ns_checksum_errors', 'ns_target_address_errors',
-   'na_duplicate_errors', 'na_target_address_errors',
-   'nd_protocol_errors'
-}
-
 function nd_light:new (arg)
-   local arg = arg and config.parse_app_arg(arg) or {}
    --copy the args to avoid changing the arg table so that it stays reusable.
-   local conf = {}
-   for k,v in pairs(arg) do
-      conf[k] = v
-   end
+   local conf = arg and lib.deepcopy(config.parse_app_arg(arg)) or {}
    local o = nd_light:superClass().new(self)
    conf.delay = conf.delay or 1000
    assert(conf.local_mac, "nd_light: missing local MAC address")
@@ -211,13 +200,15 @@ function nd_light:new (arg)
    o._logger = lib.logger_new({ module = 'nd_light' })
 
    -- Create counters
-   o.counters = {}
-   for _, name in ipairs(provided_counters) do
-      o.counters[name] = counter.open(name)
-   end
-   counter.set(o.counters.type, 0x1001) -- Virtual interface
-   counter.set(o.counters.dtime, C.get_unix_time())
-   counter.set(o.counters.status, 2) -- Link down
+   o.shm = { status                   = {counter, 2}, -- Link down
+             rxerrors                 = {counter},
+             txerrors                 = {counter},
+             txdrop                   = {counter},
+             ns_checksum_errors       = {counter},
+             ns_target_address_errors = {counter},
+             na_duplicate_errors      = {counter},
+             na_target_address_errors = {counter},
+             nd_protocol_errors       = {counter} }
 
    return o
 end
@@ -227,16 +218,16 @@ local function ns (self, dgram, eth, ipv6, icmp)
    local mem, length = self._cache.mem
    mem[0], length = dgram:payload()
    if not icmp:checksum_check(mem[0], length, ipv6) then
-      counter.add(self.counters.ns_checksum_errors)
-      counter.add(self.counters.rxerrors)
+      counter.add(self.shm.ns_checksum_errors)
+      counter.add(self.shm.rxerrors)
       return nil
    end
    -- Parse the neighbor solicitation and check if it contains our own
    -- address as target
    local ns = dgram:parse_match(nil, self._match_ns)
    if not ns then
-      counter.add(self.counters.ns_target_address_errors)
-      counter.add(self.counters.rxerrors)
+      counter.add(self.shm.ns_target_address_errors)
+      counter.add(self.shm.rxerrors)
       return nil
    end
    -- Ignore options as long as we don't implement a proper neighbor
@@ -257,21 +248,21 @@ end
 -- Process neighbor advertisement
 local function na (self, dgram, eth, ipv6, icmp)
    if self._eth_header then
-      counter.add(self.counters.na_duplicate_errors)
-      counter.add(self.counters.rxerrors)
+      counter.add(self.shm.na_duplicate_errors)
+      counter.add(self.shm.rxerrors)
       return nil
    end
    local na = dgram:parse_match(nil, self._match_na)
    if not na then
-      counter.add(self.counters.na_target_address_errors)
-      counter.add(self.counters.rxerrors)
+      counter.add(self.shm.na_target_address_errors)
+      counter.add(self.shm.rxerrors)
       return nil
    end
    local option = na:options(dgram:payload())
    if not (#option == 1 and option[1]:type() == 2) then
       -- Invalid NS, ignore
-      counter.add(self.counters.nd_protocol_errors)
-      counter.add(self.counters.rxerrors)
+      counter.add(self.shm.nd_protocol_errors)
+      counter.add(self.shm.rxerrors)
       return nil
    end
    self._eth_header = ethernet:new({ src = self._config.local_mac,
@@ -279,7 +270,7 @@ local function na (self, dgram, eth, ipv6, icmp)
                                      type = 0x86dd })
    self._logger:log(string.format("Resolved next-hop %s to %s", ipv6:ntop(self._config.next_hop),
                                   ethernet:ntop(option[1]:option():addr())))
-   counter.set(self.counters.status, 1) -- Link up
+   counter.set(self.shm.status, 1) -- Link up
    return nil
 end
 
@@ -293,8 +284,8 @@ local function from_south (self, p)
    local eth, ipv6, icmp = unpack(dgram:stack())
    if ipv6:hop_limit() ~= 255 then
       -- Avoid off-link spoofing as per RFC
-      counter.add(self.counters.nd_protocol_errors)
-      counter.add(self.counters.rxerrors)
+      counter.add(self.shm.nd_protocol_errors)
+      counter.add(self.shm.rxerrors)
       return nil
    end
    local result
@@ -341,7 +332,7 @@ function nd_light:push ()
          -- Drop packets until ND for the next-hop
          -- has completed.
          packet.free(link.receive(l_in))
-         counter.add(self.counters.txdrop)
+         counter.add(self.shm.txdrop)
       else
          local p = cache.p
          p[0] = link.receive(l_in)
@@ -350,7 +341,7 @@ function nd_light:push ()
             link.transmit(l_out, p[0])
          else
             packet.free(p[0])
-            counter.add(self.counters.txerrors)
+            counter.add(self.shm.txerrors)
          end
       end
    end
@@ -362,8 +353,6 @@ function nd_light:stop ()
    self._next_hop.packet = nil
    packet.free(self._sna.packet)
    self._sna.packet = nil
-   -- delete counters
-   for name, _ in pairs(self.counters) do counter.delete(name) end
 end
 
 function selftest ()

--- a/src/core/app.lua
+++ b/src/core/app.lua
@@ -7,7 +7,7 @@ local lib       = require("core.lib")
 local link      = require("core.link")
 local config    = require("core.config")
 local timer     = require("core.timer")
-local shm     = require("core.shm")
+local shm       = require("core.shm")
 local histogram = require('core.histogram')
 local counter   = require("core.counter")
 local zone      = require("jit.zone")
@@ -30,11 +30,11 @@ link_table, link_array = {}, {}
 configuration = config.new()
 
 -- Counters for statistics.
-breaths   = counter.open("engine/breaths")   -- Total breaths taken
-frees     = counter.open("engine/frees")     -- Total packets freed
-freebits  = counter.open("engine/freebits")  -- Total packet bits freed (for 10GbE)
-freebytes = counter.open("engine/freebytes") -- Total packet bytes freed
-configs   = counter.open("engine/configs")   -- Total configurations loaded
+breaths   = counter.create("engine/breaths.counter")   -- Total breaths taken
+frees     = counter.create("engine/frees.counter")     -- Total packets freed
+freebits  = counter.create("engine/freebits.counter")  -- Total packet bits freed (for 10GbE)
+freebytes = counter.create("engine/freebytes.counter") -- Total packet bytes freed
+configs   = counter.create("engine/configs.counter")   -- Total configurations loaded
 
 -- Breathing regluation to reduce CPU usage when idle by calling usleep(3).
 --
@@ -70,8 +70,6 @@ end
 -- Run app:methodname() in protected mode (pcall). If it throws an
 -- error app will be marked as dead and restarted eventually.
 function with_restart (app, method)
-   local oldshm = shm.path
-   shm.path = app.shmpath
    local status, result
    if use_restart then
       -- Run fn in protected mode using pcall.
@@ -85,7 +83,6 @@ function with_restart (app, method)
    else
       status, result = true, method(app)
    end
-   shm.path = oldshm
    return status, result
 end
 
@@ -165,11 +162,10 @@ function apply_config_actions (actions, conf)
    local ops = {}
    function ops.stop (name)
       if app_table[name].stop then
-         local shmorig = shm.path
-         shm.path = app_table[name].shmpath
          app_table[name]:stop()
-         shm.path = shmorig
-         shm.unlink(app_table[name].shmpath)
+      end
+      if app_table[name].shm then
+         shm.delete_frame(app_table[name].shm)
       end
    end
    function ops.keep (name)
@@ -180,10 +176,7 @@ function apply_config_actions (actions, conf)
    function ops.start (name)
       local class = conf.apps[name].class
       local arg = conf.apps[name].arg
-      local shmpath, shmorig = "counters/"..name, shm.path
-      shm.path = shmpath
       local app = class:new(arg)
-      shm.path = shmorig
       if type(app) ~= 'table' then
          error(("bad return value from app '%s' start() method: %s"):format(
                   name, tostring(app)))
@@ -192,11 +185,14 @@ function apply_config_actions (actions, conf)
       app.appname = name
       app.output = {}
       app.input = {}
-      app.shmpath = shmpath
       new_app_table[name] = app
       table.insert(new_app_array, app)
       app_name_to_index[name] = #new_app_array
       app.zone = zone
+      if app.shm then
+         app.shm.dtime = {counter, C.get_unix_time()}
+         app.shm = shm.create_frame("apps/"..name, app.shm)
+      end
    end
    function ops.restart (name)
       ops.stop(name)
@@ -206,10 +202,7 @@ function apply_config_actions (actions, conf)
       if app_table[name].reconfig then
          local arg = conf.apps[name].arg
          local app = app_table[name]
-         local shmorig = shm.path
-         shm.path = app.shmpath
          app:reconfig(arg)
-         shm.path = shmorig
          new_app_table[name] = app
          table.insert(new_app_array, app)
          app_name_to_index[name] = #new_app_array
@@ -268,7 +261,7 @@ function main (options)
 
    local breathe = breathe
    if options.measure_latency or options.measure_latency == nil then
-      local latency = histogram.create('engine/latency', 1e-6, 1e0)
+      local latency = histogram.create('engine/latency.histogram', 1e-6, 1e0)
       breathe = latency:wrap_thunk(breathe, now)
    end
 
@@ -519,35 +512,6 @@ function selftest ()
    assert(app_table.app3 == orig_app3) -- should be the same
    main({duration = 4, report = {showapps = true}})
    assert(app_table.app3 ~= orig_app3) -- should be restarted
-   -- Test shm.path management
-   print("shm.path management")
-   local S = require("syscall")
-   local App4 = {zone="test"}
-   function App4:new ()
-      local c = counter.open('test')
-      counter.set(c, 42)
-      counter.commit()
-      return setmetatable({test_counter = c},
-                          {__index = App4})
-   end
-   function App4:pull ()
-      assert(counter.read(self.test_counter) == 42, "Invalid counter value")
-      counter.add(self.test_counter)
-   end
-   function App4:stop ()
-      assert(counter.read(self.test_counter) == 43, "Invalid counter value")
-      counter.delete('test')
-   end
-   local c_counter = config.new()
-   config.app(c_counter, "App4", App4)
-   configure(c_counter)
-   main({done = function () return app_table.App4.test_counter end})
-   assert(S.stat(shm.root.."/"..shm.resolve("counters/App4/test")),
-          "Missing : counters/App4/test")
-   configure(config.new())
-   assert(not S.stat(shm.root.."/"..shm.resolve("counters/App4")),
-          "Failed to unlink counters/App4")
-   print("OK")
 end
 
 -- XXX add graphviz() function back.

--- a/src/core/link.lua
+++ b/src/core/link.lua
@@ -15,6 +15,7 @@ local counter = require("core.counter")
 require("core.counter_h")
 
 require("core.link_h")
+local link_t = ffi.typeof("struct link")
 
 local band = require("bit").band
 
@@ -26,9 +27,9 @@ local provided_counters = {
 }
 
 function new (name)
-   local r = shm.create("links/"..name, "struct link")
+   local r = ffi.new(link_t)
    for _, c in ipairs(provided_counters) do
-      r.stats[c] = counter.open("counters/"..name.."/"..c)
+      r.stats[c] = counter.create("links/"..name.."/"..c..".counter")
    end
    counter.set(r.stats.dtime, C.get_unix_time())
    return r
@@ -36,9 +37,8 @@ end
 
 function free (r, name)
    for _, c in ipairs(provided_counters) do
-      counter.delete("counters/"..name.."/"..c)
+      counter.delete("links/"..name.."/"..c..".counter")
    end
-   shm.unmap(r)
    shm.unlink("links/"..name)
 end
 

--- a/src/core/main.lua
+++ b/src/core/main.lua
@@ -135,7 +135,7 @@ end
 -- Cleanup after Snabb process.
 function shutdown (pid)
    if not _G.developer_debug then
-      shm.unlink("//"..pid)
+      shm.unlink("/"..pid)
    end
 end
 

--- a/src/core/shm.lua
+++ b/src/core/shm.lua
@@ -2,66 +2,6 @@
 
 -- shm.lua -- shared memory alternative to ffi.new()
 
--- API:
---   shm.create(name, type) => ptr
---     Map a shared object into memory via a hierarchical name, creating it
---     if needed.
---   shm.open(name, type[, readonly]) => ptr
---     Map a shared object into memory via a hierarchical name.  Fail if
---     the shared object does not already exist.
---   shm.unmap(ptr)
---     Delete a memory mapping.
---   shm.unlink(path)
---     Unlink a subtree of objects from the filesystem.
---
--- (See NAME SYNTAX below for recognized name formats.)
--- 
--- Example:
---   local freelist = shm.map("engine/freelist/packet", "struct freelist")
--- 
--- This is like ffi.new() except that separate calls to map() for the
--- same name will each return a new mapping of the same shared
--- memory. Different processes can share memory by mapping an object
--- with the same name (and type). Each process can map any object any
--- number of times.
---
--- Mappings are deleted on process termination or with an explicit unmap:
---   shm.unmap(freelist)
---
--- Names are unlinked from objects that are no longer needed:
---   shm.unlink("engine/freelist/packet")
---   shm.unlink("engine")
---
--- Object memory is freed when the name is unlinked and all mappings
--- have been deleted.
---
--- Behind the scenes the objects are backed by files on ram disk:
---   /var/run/snabb/$pid/engine/freelist/packet
---
--- and accessed with the equivalent of POSIX shared memory (shm_overview(7)).
---
--- The practical limit on the number of objects that can be mapped
--- will depend on the operating system limit for memory mappings.
--- On Linux the default limit is 65,530 mappings:
---     $ sysctl vm.max_map_count
---     vm.max_map_count = 65530
-
--- NAME SYNTAX:
--- 
--- Names can be fully qualified, abbreviated to be within the current
--- process, or further abbreviated to be relative to the current value
--- of the 'path' variable. Here are examples of names and how they are
--- resolved:
---   Fully qualified:
---     //1234/foo/bar => /var/run/snabb/1234/foo/bar
---   Path qualified:
---     /foo/bar       => /var/run/snabb/$pid/foo/bar
---   Local:
---     bar            => /var/run/snabb/$pid/$path/bar
--- .. where $pid is the PID of this process and $path is the current
--- value of the 'path' variable in this module.
-
-
 module(..., package.seeall)
 
 local ffi = require("ffi")
@@ -71,7 +11,6 @@ local const = require("syscall.linux.constants")
 
 -- Root directory where the object tree is created.
 root = "/var/run/snabb"
-path = ""
 
 -- Table (address->size) of all currently mapped objects.
 mappings = {}
@@ -117,10 +56,9 @@ function open (name, type, readonly)
 end
 
 function resolve (name)
-   local q, p = name:match("^(/*)(.*)") -- split qualifier (/ or //)
+   local q, p = name:match("^(/*)(.*)") -- split qualifier (/)
    local result = p
-   if q == '' and path ~= '' then result = path.."/"..result end
-   if q ~= '//'              then result = tostring(S.getpid()).."/"..result end
+   if q ~= '/' then result = tostring(S.getpid()).."/"..result end
    return result
 end
 
@@ -170,53 +108,102 @@ function children (name)
    return S.util.dirtable(root.."/"..resolve(name), true) or {}
 end
 
--- Create an additional name for an existing object.
-function alias (toname, fromname)
-   assert(S.symlink(root.."/"..resolve(toname), root.."/"..resolve(fromname)),
-          "alias symlink failed")
+-- Type registry for modules that implement abstract shm objects.
+types = {}
+function register (type, module)
+   assert(module, "Must supply module")
+   assert(not types[type], "Duplicate shm type: "..type)
+   types[type] = module
+   return type
 end
+
+-- Create a directory of shm objects defined by specs under path.
+function create_frame (path, specs)
+   local frame = {}
+   frame.specs = specs
+   frame.path = path.."/"
+   for name, spec in pairs(specs) do
+      assert(frame[name] == nil, "shm: duplicate name: "..name)
+      local module = spec[1]
+      local initargs = lib.array_copy(spec)
+      table.remove(initargs, 1) -- strip type name from spec
+      frame[name] = module.create(frame.path..name.."."..module.type,
+                                  unpack(initargs))
+   end
+   return frame
+end
+
+-- Open a directory of shm objects for reading, determine their types by file
+-- extension.
+function open_frame (path)
+   local frame = {}
+   frame.specs = {}
+   frame.path = path.."/"
+   frame.readonly = true
+   for _, file in ipairs(children(path)) do
+      local name, type = file:match("(.*)[.](.*)$")
+      local module = types[type]
+      if module then
+         assert(frame[name] == nil, "shm: duplicate name: "..name)
+         frame[name] = module.open(frame.path..file)
+         frame.specs[name] = {module}
+      end
+   end
+   return frame
+end
+
+-- Delete/unmap a frame of shm objects. The frame's directory is unlinked if
+-- the frame was created by create_frame.
+function delete_frame (frame)
+   for name, spec in pairs(frame.specs) do
+      local module = spec[1]
+      if rawget(module, 'delete') then
+         module.delete(frame.path..name.."."..module.type)
+      else
+         unmap(frame[name])
+      end
+   end
+   if not frame.readonly then
+      unlink(frame.path)
+   end
+end
+
 
 function selftest ()
    print("selftest: shm")
-   print("checking paths..")
-   path = 'foo/bar'
+
+   print("checking resolve..")
    pid = tostring(S.getpid())
-   local p1 = resolve("//"..pid.."/foo/bar/baz/beer")
-   local p2 = resolve("/foo/bar/baz/beer")
-   local p3 = resolve("baz/beer")
+   local p1 = resolve("/"..pid.."/foo/bar/baz/beer")
+   local p2 = resolve("foo/bar/baz/beer")
    assert(p1 == p2, p1.." ~= "..p2)
-   assert(p1 == p3, p1.." ~= "..p3)
 
    print("checking shared memory..")
-   path = 'shm/selftest'
-   local name = "obj"
+   local name = "shm/selftest/obj"
    print("create "..name)
    local p1 = create(name, "struct { int x, y, z; }")
    local p2 = create(name, "struct { int x, y, z; }")
-   alias(name, name..".alias")
-   local p3 = create(name..".alias", "struct { int x, y, z; }")
    assert(p1 ~= p2)
    assert(p1.x == p2.x)
    p1.x = 42
    assert(p1.x == p2.x)
-   assert(p1.x == p3.x)
    assert(unlink(name))
    unmap(p1)
    unmap(p2)
 
    -- Test that we can open and cleanup many objects
    print("checking many objects..")
-   path = 'shm/selftest/manyobj'
+   local path = 'shm/selftest/manyobj'
    local n = 10000
    local objs = {}
    for i = 1, n do
-      table.insert(objs, create("obj/"..i, "uint64_t[1]"))
+      table.insert(objs, create(path.."/"..i, "uint64_t[1]"))
    end
    print(n.." objects created")
    for i = 1, n do unmap(objs[i]) end
    print(n.." objects unmapped")
-   assert((#children("/shm/selftest/manyobj/obj")) == n, "child count mismatch")
-   assert(unlink("/"))
+   assert((#children(path)) == n, "child count mismatch")
+   assert(unlink("shm"))
    print("selftest ok")
 end
 

--- a/src/lib/virtio/net_device.lua
+++ b/src/lib/virtio/net_device.lua
@@ -153,7 +153,7 @@ end
 
 function VirtioNetDevice:rx_packet_end(header_id, total_size, rx_p)
    local l = self.owner.output.tx
-   local counters = self.owner.counters
+   local counters = self.owner.shm
    if l then
       if band(self.rx_hdr_flags, C.VIO_NET_HDR_F_NEEDS_CSUM) ~= 0 and
          -- Bounds-check the checksum area
@@ -264,7 +264,7 @@ function VirtioNetDevice:tx_buffer_add(tx_p, addr, len)
 end
 
 function VirtioNetDevice:tx_packet_end(header_id, total_size, tx_p)
-   local counters = self.owner.counters
+   local counters = self.owner.shm
    counter.add(counters.txbytes, tx_p.length)
    counter.add(counters.txpackets)
    if ethernet:is_mcast(tx_p.data) then
@@ -340,7 +340,7 @@ function VirtioNetDevice:tx_buffer_add_mrg_rxbuf(tx_p, addr, len)
 end
 
 function VirtioNetDevice:tx_packet_end_mrg_rxbuf(header_id, total_size, tx_p)
-   local counters = self.owner.counters
+   local counters = self.owner.shm
    -- free the packet only when all its data is processed
    if self.tx.finished then
       counter.add(counters.txbytes, tx_p.length)

--- a/src/program/top/README
+++ b/src/program/top/README
@@ -3,8 +3,11 @@ Usage:
 
   -h, --help
                              Print usage information.
-  -c, --counters <name>
-                             Print counters of object by <name> and exit.
+  -l, --list <path>
+                             List shared memory objects in <path> and exit.
+                             Examples: snabb top -l engine
+                                       snabb top -l apps/foo
+                                       snabb top -l "links/foo.tx -> bar.rx"
 
 Display realtime performance statistics for a running Snabb instance with
 <pid>. If <pid> is not supplied and there is only one Snabb instance, top will

--- a/src/program/top/top.lua
+++ b/src/program/top/top.lua
@@ -12,7 +12,7 @@ local histogram = require("core.histogram")
 local usage = require("program.top.README_inc")
 
 local long_opts = {
-   help = "h", counters = "c"
+   help = "h", list = "l"
 }
 
 function clearterm () io.write('\027[2J') end
@@ -21,19 +21,19 @@ function run (args)
    local opt = {}
    local object = nil
    function opt.h (arg) print(usage) main.exit(1) end
-   function opt.c (arg) object = arg              end
-   args = lib.dogetopt(args, opt, "hc:", long_opts)
+   function opt.l (arg) object = arg              end
+   args = lib.dogetopt(args, opt, "hl:", long_opts)
 
    if #args > 1 then print(usage) main.exit(1) end
    local target_pid = select_snabb_instance(args[1])
 
-   if     object then list_counters(target_pid, object)
+   if     object then list_shm(target_pid, object)
    else               top(target_pid) end
    ordered_exit(0)
 end
 
 function select_snabb_instance (pid)
-   local instances = shm.children("//")
+   local instances = shm.children("/")
    if pid then
       -- Try to use given pid
       for _, instance in ipairs(instances) do
@@ -51,33 +51,30 @@ function select_snabb_instance (pid)
 end
 
 function ordered_exit (value)
-   shm.unlink("//"..S.getpid()) -- Unlink own shm tree to avoid clutter
+   shm.unlink("/"..S.getpid()) -- Unlink own shm tree to avoid clutter
    os.exit(value)
 end
 
-function read_counter (name, path)
-   if path then name = path.."/"..name end
-   local value = counter.read(counter.open(name, 'readonly'))
-   counter.delete(name)
-   return value
-end
-
-function list_counters (pid, object)
-   local path = "//"..pid.."/counters/"..object
-   local cnames = shm.children(path)
-   table.sort(cnames, function (a, b) return a < b end)
-   for _, cname in ipairs(cnames) do
-      print_row({30, 30}, {cname, lib.comma_value(read_counter(cname, path))})
+function list_shm (pid, object)
+   local frame = shm.open_frame("/"..pid.."/"..object)
+   local sorted = {}
+   for name, _ in pairs(frame) do table.insert(sorted, name) end
+   table.sort(sorted)
+   for _, name in ipairs(sorted) do
+      if name ~= 'path' and name ~= 'specs' and  name ~= 'readonly' then
+         print_row({30, 30}, {name, tostring(frame[name])})
+      end
    end
+   shm.delete_frame(frame)
 end
 
 function top (instance_pid)
-   local instance_tree = "//"..instance_pid
+   local instance_tree = "/"..instance_pid
    local counters = open_counters(instance_tree)
    local configs = 0
    local last_stats = nil
    while (true) do
-      if configs < counter.read(counters.configs) then
+      if configs < counter.read(counters.engine.configs) then
          -- If a (new) config is loaded we (re)open the link counters.
          open_link_counters(counters, instance_tree)
       end
@@ -97,41 +94,31 @@ end
 
 function open_counters (tree)
    local counters = {}
-   for _, name in ipairs({"configs", "breaths", "frees", "freebytes"}) do
-      counters[name] = counter.open(tree.."/engine/"..name, 'readonly')
-   end
-   local success, latency = pcall(histogram.open, tree..'/engine/latency')
-   if success then counters.latency = latency end
+   counters.engine = shm.open_frame(tree.."/engine")
    counters.links = {} -- These will be populated on demand.
    return counters
 end
 
 function open_link_counters (counters, tree)
    -- Unmap and clear existing link counters.
-   for linkspec, _ in pairs(counters.links) do
-      for _, name
-      in ipairs({"rxpackets", "txpackets", "rxbytes", "txbytes", "txdrop"}) do
-         counter.delete(tree.."/counters/"..linkspec.."/"..name)
-      end
+   for _, link_frame in pairs(counters.links) do
+      shm.delete_frame(link_frame)
    end
    counters.links = {}
    -- Open current link counters.
    for _, linkspec in ipairs(shm.children(tree.."/links")) do
-      counters.links[linkspec] = {}
-      for _, name
-      in ipairs({"rxpackets", "txpackets", "rxbytes", "txbytes", "txdrop"}) do
-         counters.links[linkspec][name] =
-            counter.open(tree.."/counters/"..linkspec.."/"..name, 'readonly')
-      end
+      counters.links[linkspec] = shm.open_frame(tree.."/links/"..linkspec)
    end
 end
 
 function get_stats (counters)
    local new_stats = {}
    for _, name in ipairs({"configs", "breaths", "frees", "freebytes"}) do
-      new_stats[name] = counter.read(counters[name])
+      new_stats[name] = counter.read(counters.engine[name])
    end
-   if counters.latency then new_stats.latency = counters.latency:snapshot() end
+   if counters.engine.latency then
+      new_stats.latency = counters.engine.latency:snapshot()
+   end
    new_stats.links = {}
    for linkspec, link in pairs(counters.links) do
       new_stats.links[linkspec] = {}
@@ -153,7 +140,7 @@ function print_global_metrics (new_stats, last_stats)
              {float_s(frees / 1000), float_s(bytes / (1000^3)), tostring(breaths)})
 end
 
-function summarize_latency(histogram, prev)
+function summarize_latency (histogram, prev)
    local total = histogram.total
    if prev then total = total - prev.total end
    if total == 0 then return 0, 0, 0 end
@@ -174,7 +161,6 @@ function print_latency_metrics (new_stats, last_stats)
    local min, avg, max = summarize_latency(cur, prev)
    print_row(global_metrics_row,
              {"Min breath (us)", "Average", "Maximum"})
-   
    print_row(global_metrics_row,
              {float_s(min*1e6), float_s(avg*1e6), float_s(max*1e6)})
    print("\n")

--- a/src/program/top/top.lua
+++ b/src/program/top/top.lua
@@ -29,7 +29,6 @@ function run (args)
 
    if     object then list_shm(target_pid, object)
    else               top(target_pid) end
-   ordered_exit(0)
 end
 
 function select_snabb_instance (pid)
@@ -47,12 +46,7 @@ function select_snabb_instance (pid)
       else                            return instances[1] end
    elseif #instances == 1 then print("No Snabb instance found.")
    else print("Multple Snabb instances found. Select one.") end
-   ordered_exit(1)
-end
-
-function ordered_exit (value)
-   shm.unlink("/"..S.getpid()) -- Unlink own shm tree to avoid clutter
-   os.exit(value)
+   os.exit(1)
 end
 
 function list_shm (pid, object)


### PR DESCRIPTION
This changes quite a few things around `core.shm`, mainly to remove statistics counter boilerplate, and to conveniently support multiple types of shared memory objects (as opposed to just counters). I am not super happy with the `shm.{create,open,delete}_frame` abstraction but it does the job. Summary of changes:

- changes the runtime directory layout: there are now directories for `apps/`, `links/`, `engine/`, `pci/`. Link structs are no longer exposed. All memory mapped files now have extensions that designate their type, for e.g. `snabb top` to determine how to open them.
- snabb top now has `-l` instead of `-a`, which supports dumping engine/link counters as well
- apps no longer create/delete their shared memory directly but use the field `myapp.shm` to declare objects.
- documentation of shared memory libraries was moved from inline to markdown (and updated)
- per-PCI-address shared memory is created under `pci/<pciaddr>` using `shm.create_frame`
- Some unused functions from`core.shm` were removed for simplicity: `alias` was unused, the whole `path` relative logic was removed (a single `/` now means fully qualified, I found the path qualified logic to be error prone and unnecessary)
- modules that implement share memory types (`core.counter`, `core.histogram`) now use the new `shm.register` to register themselves as types with `core.shm`. Its a bit magical but enables convenient use in apps and e.g. lets them implement `tonumber` so they can be printed by `snabb top -l`
- to facilitate uniform treatment of shared memory types, `core.counter` and `core.histogram` now implement a common interface: `create`, `open` and optionally `delete`

Cc @alexandergall @lukego 