### PR TITLE
Skip intel1g selftest if SNABB_PCI_INTEL1G0 is empty

### DIFF
--- a/src/apps/intel/intel1g.lua
+++ b/src/apps/intel/intel1g.lua
@@ -633,7 +633,7 @@ end  -- function Intel1g:new()
 function selftest ()
    print("selftest: Intel1g")
    local pciaddr = os.getenv("SNABB_PCI_INTEL1G0")
-   if not pciaddr then
+   if not pciaddr or pciaddr == "" then
       print("SNABB_PCI_INTEL1G0 not set")
       os.exit(engine.test_skipped_code)
    end

--- a/src/apps/intel/intel1g.lua
+++ b/src/apps/intel/intel1g.lua
@@ -632,8 +632,8 @@ end  -- function Intel1g:new()
 
 function selftest ()
    print("selftest: Intel1g")
-   local pciaddr = os.getenv("SNABB_PCI_INTEL1G0")
-   if not pciaddr or pciaddr == "" then
+   local pciaddr = lib.getenv("SNABB_PCI_INTEL1G0")
+   if not pciaddr then
       print("SNABB_PCI_INTEL1G0 not set")
       os.exit(engine.test_skipped_code)
    end


### PR DESCRIPTION
Recently we updated our lwaftr branch with Snabb master. Since then snabb-bot CI tests are failing on intel1g selftest. Example: https://gist.github.com/lwaftr-igalia/8d3a39922142575d10dae99027e108fd

The reason is that snabb-bot runs the tests as:

```bash
nix/store/zjvf7la6my2pqshyaz71h1n9icx3bvw8-docker-1.8.1/libexec/docker/docker run \
--rm --privileged -i -v /tmp/snabb_bot/tmp/repo:/snabb -e SNABB_PCI0=0000:83:00.0 \
 -e SNABB_PCI1=0000:83:00.1 -e SNABB_PCI_INTEL0= -e SNABB_PCI_INTEL1= \
 -e SNABB_PCI_INTEL1G0= -e SNABB_PCI_INTEL1G1= -e \
SNABB_PCI_SOLARFLARE0= -e SNABB_PCI_SOLARFLARE1= -e \
SNABB_TELNET0= -e SNABB_TELNET1= -e SNABB_PCAP= -e \
SNABB_PERF_SAMPLESIZE=5 lwaftr/snabb-test \
bash -c mount -t hugetlbfs none /hugetlbfs && (cd snabb/src; make benchmarks)
```

`SNABB_PCI_INTEL1G0` is set but its value is empty. The test is only skipped if `SNABB_PCI_INTEL1G0` doesn't exist.

The failing test is reproducible in master:

```bash
$ sudo SNABB_PCI_INTEL1G0= ./snabb snsh -t apps.intel.intel1g
selftest: Intel1g
core/lib.lua:60: Unable to open file: /sys/bus/pci/devices//vendor
stack traceback:
        core/main.lua:130: in function <core/main.lua:128>
        [C]: in function 'error'
        core/lib.lua:60: in function 'firstline'
        lib/hardware/pci.lua:40: in function 'device_info'
        apps/intel/intel1g.lua:94: in function 'new'
```

The test should be skipped too when the variable exists and its value is empty.