### PR TITLE
Add SNABB_SHM_ROOT and SNABB_SHM_KEEP

### DIFF
--- a/src/core/main.lua
+++ b/src/core/main.lua
@@ -134,7 +134,7 @@ end
 
 -- Cleanup after Snabb process.
 function shutdown (pid)
-   if not _G.developer_debug then
+   if not _G.developer_debug and not lib.getenv("SNABB_SHM_KEEP") then
       shm.unlink("//"..pid)
    end
 end

--- a/src/core/shm.lua
+++ b/src/core/shm.lua
@@ -70,7 +70,7 @@ local S = require("syscall")
 local const = require("syscall.linux.constants")
 
 -- Root directory where the object tree is created.
-root = "/var/run/snabb"
+root = os.getenv("SNABB_SHM_ROOT") or "/var/run/snabb"
 path = ""
 
 -- Table (address->size) of all currently mapped objects.


### PR DESCRIPTION
This PR adds environment variables for telling Snabb to preserve process shm objects after termination. This is particularly intended to make it possible for CI to preserve shm directories of test runs so that relevant information can be extracted post-moretem e.g. timeline logs, histograms, counters, etc.

I know that we already have too many undocumented environment variables. Sorry. I see cleaning this up as a separate matter and for now I am focused on improving CI.

- `SNABB_SHM_ROOT` can be used to override the default location of shm files (`/var/run/snabb`).
- `SNABB_SHM_KEEP` can be set to prevent removal of the shm folder when the process terminates. (The existing variable `SNABB_DEBUG` has this effect already but that also has other consequences that may not always be desirable e.g. additional debug printouts and assertion checks.)

I would quite like to sneak this into `v2016.08` if there is a willing upstream but it would not be the end of the world to take it in the next release.