### PR TITLE
vhost_user: Enable/disable vring processing on kick/get_base

### DIFF
--- a/src/apps/vhost/vhost_user.lua
+++ b/src/apps/vhost/vhost_user.lua
@@ -277,6 +277,9 @@ function VhostUser:set_vring_kick (msg, fds, nfds)
    local idx = tonumber(bit.band(msg.u64, C.VHOST_USER_VRING_IDX_MASK))
    local validfd = bit.band(msg.u64, C.VHOST_USER_VRING_NOFD_MASK) == 0
 
+   -- Kick enables processing in vhost-user protocol
+   self.vhost_ready = true
+
    assert(idx < 42)
    if validfd then
       assert(nfds == 1)
@@ -312,6 +315,10 @@ end
 function VhostUser:get_vring_base (msg)
    msg.state.num = self.dev:get_vring_base(msg.state.index)
    msg.size = ffi.sizeof("struct vhost_vring_state")
+
+   -- get_vring_base disables vring processing in vhost-user protocol
+   self.vhost_ready = false
+
    self:reply(msg)
 end
 


### PR DESCRIPTION
Follow the rules for the vhost-user protocol to enable and disable processing. Particularly, avoid processing DMA requests when the guest driver is offline because they will contain garbage.

This fix should resolve all QEMU-related failures in the test matrix for the l2fwd benchmark. Compare [new results](http://rpubs.com/lukego/200128) and [old results](https://github.com/snabbco/snabb/issues/976#issuecomment-236838883). Highlights that there are still a couple of DPDK-related interop problems to resolve afterwards.