### PR TITLE
snabbnfv: Update filter.ports config to allow iperf

### DIFF
--- a/src/program/snabbnfv/test_fixtures/nfvconfig/test_functions/filter.ports
+++ b/src/program/snabbnfv/test_fixtures/nfvconfig/test_functions/filter.ports
@@ -9,7 +9,8 @@ return {
   { vlan = 0,
     mac_address = "52:54:00:00:00:01",
     port_id = "B",
-    ingress_filter = "icmp6 or (ip6 and tcp and dst port 12345)",
+    -- NB: Allow iperf
+    ingress_filter = "icmp6 or (ip6 and tcp and dst port 12345) or arp or port 5001",
     gbps = nil,
     tunnel = nil
   },


### PR DESCRIPTION
This is to make the configuration file compatible with the "filter" benchmark configuration.

Expected to resolve the dramatic test failures seen here:
https://hydra.snabb.co/build/203152/download/2/report.html#success-and-failure