### PR TITLE
Skip SnabbNFV test if cannot find QEMU image

### DIFF
--- a/src/program/snabbnfv/test_env/test_env.sh
+++ b/src/program/snabbnfv/test_env/test_env.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+SKIPPED_CODE=43
+
 if [ -z "$MAC" ]; then
     export MAC=52:54:00:00:00:
     echo "Defaulting to MAC=$MAC"
@@ -95,7 +97,7 @@ function qemu_log {
 
 function qemu_image {
     image=$assets/$1${qemu_n}.img
-    [ -f $image ] || cp $assets/$1.img $image
+    [ -f $image ] || cp $assets/$1.img $image 2> /dev/null
     echo $image
 }
 
@@ -134,6 +136,11 @@ function launch_qemu {
 }
 
 function qemu {
+    local image=$(qemu_image "qemu")
+    if [ ! -f "$image" ]; then
+        echo "Couldn't find QEMU image: ${image}"
+        exit $SKIPPED_CODE
+    fi
     launch_qemu $1 $2 $3 bzImage qemu
 }
 


### PR DESCRIPTION
In master, the SnabbNFV selftest always tries to run a QEMU image regardless whether an image file exists or not. In case it doesn't exist, the process which tries to log into the VM keeps waiting until it times out with an exit error.

```
src $ sudo ./program/snabbnfv/selftest.sh
Defaulting to SNABB_TELNET0=5000
Defaulting to SNABB_TELNET1=5001
Defaulting to SNABB_IPERF_BENCH_CONF=program/snabbnfv/test_fixtures/nfvconfig/test_functions/same_vlan.ports
USING program/snabbnfv/test_fixtures/nfvconfig/test_functions/other_vlan.ports
Defaulting to MAC=52:54:00:00:00:
Defaulting to IP=fe80::5054:ff:fe00:
Defaulting to GUEST_MEM=512
Defaulting to HUGETLBFS=/hugetlbfs
Defaulting to QUEUES=1
Defaulting to QEMU=/usr/bin/qemu-system-x86_64
cp: cannot stat ‘/home/dpino/.test_env/qemu.img’: No such file or directory
cp: cannot stat ‘/home/dpino/.test_env/qemu.img’: No such file or directory
Waiting for VM listening on telnet port 5000 to get ready...
```

In an earlier version the test was skipped if SNABB_PCI0 was not defined. But now SNABB_PCI0 is always defined. In my opinion, the test should be skipped if there's not QEMU file image available.