### PR TITLE
Add method 'exists' to core/shm

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -469,6 +469,10 @@ If *readonly* is non-nil the shared object is mapped in read-only mode.
 *Readonly* defaults to nil. Fails if the shared object does not already exist.
 Returns a pointer to the mapped object.
 
+— Function **shm.exists** *name*
+
+Checks whether shared object *name* exists.
+
 — Function **shm.unmap** *pointer*
 
 Deletes the memory mapping for *pointer*.

--- a/src/core/shm.lua
+++ b/src/core/shm.lua
@@ -55,6 +55,12 @@ function open (name, type, readonly)
    return map(name, type, readonly, false)
 end
 
+function exists (name)
+   local path = resolve(name)
+   local fd = S.open(root..'/'..path, "rdonly")
+   return fd and fd:close()
+end
+
 function resolve (name)
    local q, p = name:match("^(/*)(.*)") -- split qualifier (/)
    local result = p
@@ -190,6 +196,14 @@ function selftest ()
    assert(unlink(name))
    unmap(p1)
    unmap(p2)
+
+   print("checking exists..")
+   assert(not exists(name))
+   local p1 = create(name, "struct { int x, y, z; }")
+   assert(exists(name))
+   assert(unlink(name))
+   unmap(p1)
+   assert(not exists(name))
 
    -- Test that we can open and cleanup many objects
    print("checking many objects..")


### PR DESCRIPTION
Trying to open a shared memory object which has not been mapped yet results in an error. For instance:

```
core/shm.lua:37: shm open error (26039/shm/selftest/obj):No such file or directory
```

I think it would be useful to have an `exists` method which could be used to check whether an object exists before trying to open it.