### PR TITLE
Print out multiple snabb instance pids

### DIFF
--- a/src/program/top/top.lua
+++ b/src/program/top/top.lua
@@ -39,14 +39,20 @@ function select_snabb_instance (pid)
          if instance == pid then return pid end
       end
       print("No such Snabb instance: "..pid)
-   elseif #instances == 2 then
-      -- Two means one is us, so we pick the other.
-      local own_pid = tostring(S.getpid())
-      if instances[1] == own_pid then return instances[2]
-      else                            return instances[1] end
    elseif #instances == 1 then print("No Snabb instance found.")
-   else print("Multple Snabb instances found. Select one.") end
-   os.exit(1)
+   else
+      local own_pid = tostring(S.getpid())
+      if #instances == 2 then
+         -- Two means one is us, so we pick the other.
+         return instances[1] == own_pid and instances[2] or instances[1]
+      else
+         print("Multiple Snabb instances found. Select one:")
+         for _, instance in ipairs(instances) do
+            if instance ~= own_pid then print(instance) end
+         end
+      end
+   end
+   main.exit(1)
 end
 
 function list_shm (pid, object)


### PR DESCRIPTION
When running top, if there are multiple snabb instances, instead of printing out "Multiple Snabb instances found. Select one", print out the list of pids as well (except current one).