### PR TITLE
core.packet: make packet_t public accoding to documentation

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -323,7 +323,7 @@ Returns a structure holding ring statistics for the *link*:
 
 ## Packet (core.packet)
 
-A *packet* is an FFI object of type `packet.packet_t` representing a network
+A *packet* is an FFI object of type `struct packet` representing a network
 packet that is currently being processed. The packet is used to explicitly
 manage the life cycle of the packet. Packets are explicitly allocated and freed
 by using `packet.allocate` and `packet.free`. When a packet is received using
@@ -335,7 +335,7 @@ freed. The number of allocatable packets is limited by the size of the
 underlying “freelist”, e.g. a pool of unused packet objects from and to which
 packets are allocated and freed.
 
-— Ctype **packet.packet_t**
+— Type **struct packet**
 
 ```
 struct packet {

--- a/src/core/packet.lua
+++ b/src/core/packet.lua
@@ -13,8 +13,8 @@ local counter  = require("core.counter")
 
 require("core.packet_h")
 
-local packet_t = ffi.typeof("struct packet")
-local packet_ptr_t = ffi.typeof("struct packet *")
+packet_t = ffi.typeof("struct packet")
+local packet_ptr_t = ffi.typeof("$ *", packet_t)
 local packet_size = ffi.sizeof(packet_t)
 local header_size = 8
 max_payload = tonumber(C.PACKET_PAYLOAD_SIZE)

--- a/src/core/packet.lua
+++ b/src/core/packet.lua
@@ -13,8 +13,8 @@ local counter  = require("core.counter")
 
 require("core.packet_h")
 
-packet_t = ffi.typeof("struct packet")
-local packet_ptr_t = ffi.typeof("$ *", packet_t)
+local packet_t = ffi.typeof("struct packet")
+local packet_ptr_t = ffi.typeof("struct packet *")
 local packet_size = ffi.sizeof(packet_t)
 local header_size = 8
 max_payload = tonumber(C.PACKET_PAYLOAD_SIZE)


### PR DESCRIPTION
#913 made the packet ctype public in documentation, but actually failed to make it publicly accessible by other code, this commit revises that.