### PR TITLE
Packet.lua: add clone_to_memory

### DIFF
--- a/src/core/packet.lua
+++ b/src/core/packet.lua
@@ -71,12 +71,17 @@ function new_packet ()
    return p
 end
 
+-- Create an exact copy of srcp at memory pointed to by dstp.
+function clone_to_memory(dstp, srcp)
+   ffi.copy(dstp, srcp, srcp.length)
+   dstp.length = srcp.length
+   return dstp
+end
+
 -- Create an exact copy of a packet.
 function clone (p)
    local p2 = allocate()
-   ffi.copy(p2, p, p.length)
-   p2.length = p.length
-   return p2
+   return clone_to_memory(p2, p)
 end
 
 -- Append data to the end of a packet.


### PR DESCRIPTION
It's useful to be able to clone packets to arbitrary memory, not just freshly allocated packets. In the lwaftr, we need this facility for cloning packets to within ctables that embed, rather than point to, packets.

@eugeneia 