### PR TITLE
Use LuaJIT-fu to optimized virtio-net device

### DIFF
--- a/src/apps/vhost/vhost_user.lua
+++ b/src/apps/vhost/vhost_user.lua
@@ -279,6 +279,8 @@ function VhostUser:set_vring_kick (msg, fds, nfds)
 
    -- Kick enables processing in vhost-user protocol
    self.vhost_ready = true
+   -- Compile a new optimized fast-path for the vring processing
+   self.dev:rejit()
 
    assert(idx < 42)
    if validfd then

--- a/src/lib/virtio/net_device.lua
+++ b/src/lib/virtio/net_device.lua
@@ -271,7 +271,11 @@ function VirtioNetDevice:tx_packet_start_mrg_rxbuf(addr, len)
       if link.empty(l) then return end
       tx_p = link.receive(l)
 
-      tx_mrg_hdr.hdr.flags = validflags(tx_p.data+14, tx_p.length-14)
+      if band(self.features, C.VIRTIO_NET_F_CSUM) == 0 then
+         tx_mrg_hdr.hdr.flags = 0
+      else
+         tx_mrg_hdr.hdr.flags = validflags(tx_p.data+14, tx_p.length-14)
+      end
 
       self.tx.tx_mrg_hdr[0] = tx_mrg_hdr
       self.tx.data_sent = 0

--- a/src/lib/virtio/net_device.lua
+++ b/src/lib/virtio/net_device.lua
@@ -10,12 +10,11 @@ local link      = require("core.link")
 local memory    = require("core.memory")
 local packet    = require("core.packet")
 local timer     = require("core.timer")
-local vq        = require("lib.virtio.virtq_device")
+local VirtioVirtq = require("lib.virtio.virtq_device")
 local checksum  = require("lib.checksum")
 local ffi       = require("ffi")
 local C         = ffi.C
 local band      = bit.band
-local get_buffers = vq.VirtioVirtq.get_buffers
 
 require("lib.virtio.virtio.h")
 require("lib.virtio.virtio_vring_h")
@@ -88,10 +87,10 @@ function VirtioNetDevice:new(owner, disable_mrg_rxbuf, disable_indirect_desc)
 
    for i = 0, max_virtq_pairs-1 do
       -- TXQ
-      o.virtq[2*i] = vq.VirtioVirtq:new()
+      o.virtq[2*i] = VirtioVirtq:new()
       o.virtq[2*i].device = o
       -- RXQ
-      o.virtq[2*i+1] = vq.VirtioVirtq:new()
+      o.virtq[2*i+1] = VirtioVirtq:new()
       o.virtq[2*i+1].device = o
    end
 
@@ -129,7 +128,7 @@ function VirtioNetDevice:receive_packets_from_vm ()
    for i = 0, self.virtq_pairs-1 do
       self.ring_id = 2*i+1
       local virtq = self.virtq[self.ring_id]
-      get_buffers(virtq, 'rx', ops, self.hdr_size)
+      virtq:get_buffers('rx', ops, self.hdr_size)
    end
 end
 
@@ -206,7 +205,7 @@ function VirtioNetDevice:transmit_packets_to_vm ()
    for i = 0, self.virtq_pairs-1 do
       self.ring_id = 2*i
       local virtq = self.virtq[self.ring_id]
-      get_buffers(virtq, 'tx', ops, self.hdr_size)
+      virtq:get_buffers('tx', ops, self.hdr_size)
    end
 end
 
@@ -494,6 +493,28 @@ feature_names = {
 
    [C.VIRTIO_NET_F_MQ]                          = "VIRTIO_NET_F_MQ"
 }
+
+-- Request fresh Just-In-Time compilation of the vring processing code.
+-- 
+-- This should be called when the expected workload has changed
+-- significantly, for example when a virtual machine loads a new
+-- device driver or renegotiates features. This will cause LuaJIT to
+-- generate fresh machine code for the traffic processing fast-path.
+--
+-- See background motivation here:
+--   https://github.com/LuaJIT/LuaJIT/issues/208#issuecomment-236423732
+function VirtioNetDevice:rejit ()
+   local mod = "lib.virtio.virtq_device"
+   -- Load fresh copies of the virtq module: one for tx, one for rx.
+   local txvirtq = package.loaders[1](mod)(mod)
+   local rxvirtq = package.loaders[1](mod)(mod)
+   local tx_mt = {__index = txvirtq}
+   local rx_mt = {__index = rxvirtq}
+   for i = 0, max_virtq_pairs-1 do
+      setmetatable(self.virtq[2*i],   tx_mt)
+      setmetatable(self.virtq[2*i+1], rx_mt)
+   end
+end
 
 function get_feature_names(bits)
 local string = ""

--- a/src/lib/virtio/virtq_device.lua
+++ b/src/lib/virtio/virtq_device.lua
@@ -3,8 +3,6 @@
 -- Implements virtio virtq
 
 
-module(...,package.seeall)
-
 local lib       = require("core.lib")
 local memory    = require("core.memory")
 local ffi       = require("ffi")
@@ -111,3 +109,5 @@ function VirtioVirtq:signal_used ()
       end
    end
 end
+
+return VirtioVirtq


### PR DESCRIPTION
This branch improves virito-net performance substantially by fixing bad cases in the performance test matrix.

### Test results

- [iperf and l2fwd benchmarks](https://hydra.snabb.co/build/438946/download/2/report.html#split-by-benchmark) show more consistently high scores (dramatically so for l2fwd).
- [l2fwd by configuration benchmarks](https://hydra.snabb.co/build/438946/download/2/report.html#configuration-1) shows that the benefit comes mostly from fixing performance problems that affect specific virtio-net configuration options. This includes a big improvement for the base options negotiated by recent DPDK releases.

### LuaJIT-fu

The vhost_user app now JITs separate machine code for each connection. The transmit and receive paths are also JITed separately.

This improves performance and consistency for many workloads, especially for dealing with different combinations of virtio-net options and with virtual machines that switch device drivers (e.g. from Linux to DPDK or Snabb).

The root problem was that our vring processing code is written in a style that performs badly with LuaJIT. The code is implemented in one central loop, [VirtioVirtq:get_buffers()](https://github.com/snabbco/snabb/blob/master/src/lib/virtio/virtq_device.lua#L52-L93), which has many different behaviors depending on its arguments (callback functions, negotiated virtio features, etc). LuaJIT compiles all of these different options into a growing network of "side traces" and this degrades performance.

To make the code perform efficiently we need to make its control flow more consistent from the point of view of the JIT.

One solution to this problem would be to write specialized versions of the vring processing code for all different combinations of situations:

- Separately for transmit and receive;
- Separately for mergeable RX buffers and without;
- Separately for indirect decsriptors and without;
- etc...

However doing this by hand would be a lot of work. We would have to rewrite the vring processing code and the new version would be much more code.

Instead we make the JIT do this work for us automatically. We just have one copy of the source code but we load a fresh copy of the object code for each vring. This means that each vring is JITed separately in a way that suits its specific behavior. So the machine code for a vring that supports mergeable RX buffers will automatically optimize for that case, and so on.

You can think of it as creating many different vring processing loops that each inline a different set of subroutines.

If you want to know more about doing this kind of optimization with LuaJIT then there is some background information here:

  LuaJIT/LuaJIT#208 (comment)

Note that the callback-driven nature of the vring processing code is not a problem directly. Callback indirection compiles very efficiently when the same callback function is used every time. However, performance degrades when the JIT is sharing machine code between multiple calls that provide different callback functions. (The same thing happens if you pass different parameter values that cause 'if' statements to switch from 'then' to 'else'.)

Quoth the LuaJIT masters all too innocently:

> Avoid unbiased branches.
