### PR TITLE
Getter/setter for Intel10g's ring_buffer_size

### DIFF
--- a/src/apps/intel/intel10g.lua
+++ b/src/apps/intel/intel10g.lua
@@ -23,7 +23,18 @@ local timer = require("core.timer")
 local bits, bitset = lib.bits, lib.bitset
 local band, bor, lshift = bit.band, bit.bor, bit.lshift
 
-num_descriptors = 1024
+local num_descriptors = 1024
+function ring_buffer_size (arg)
+   if not arg then return num_descriptors end
+   local ring_size = assert(tonumber(arg), "bad ring size: " .. arg)
+   if ring_size > 32*1024 then
+      error("ring size too large for hardware: " .. ring_size)
+   end
+   if math.log(ring_size)/math.log(2) % 1 ~= 0 then
+      error("ring size is not a power of two: " .. arg)
+   end
+   num_descriptors = assert(tonumber(arg))
+end
 
 -- Defaults for configurable items
 local default = {

--- a/src/program/firehose/firehose.lua
+++ b/src/program/firehose/firehose.lua
@@ -39,13 +39,6 @@ function run (args)
    end
    function opt.r (arg)
       ring_size = tonumber(arg)
-      if type(ring_size) ~= 'number' then fatal("bad ring size: " .. arg) end
-      if ring_size > 32*1024 then
-         fatal("ring size too large for hardware: " .. ring_size)
-      end
-      if math.log(ring_size)/math.log(2) % 1 ~= 0 then
-         fatal("ring size is not a power of two: " .. arg)
-      end
    end
    args = lib.dogetopt(args, opt, "hHet:i:r:", long_opts)
    if #pciaddresses == 0 then
@@ -79,7 +72,7 @@ int firehose_callback_v1(const char *pciaddr, char **packets, void *rxring,
 
       local intel10g = require("apps.intel.intel10g")
       -- Maximum buffers to avoid packet drops
-      intel10g.num_descriptors = ring_size
+      intel10g.ring_buffer_size(ring_size)
       local nic = intel10g.new_sf({pciaddr=pciaddr})
       nic:open()
 


### PR DESCRIPTION
Intel10g's ring buffer has to comply several restrictions (power of two and not larger than 32*1024). Currently these constraints are implemented independently in several apps (firehose, lwaftr). The PR adds a single entry point for getting/setting intel10g's ring buffer. 