### PR TITLE
Add no-loop switch to 'packetblaster replay'

### DIFF
--- a/src/program/packetblaster/packetblaster.lua
+++ b/src/program/packetblaster/packetblaster.lua
@@ -45,16 +45,18 @@ function run_loadgen (c, patterns, opts)
    engine.busywait = true
    engine.configure(c)
 
-   if opts.loop then
+   local report = {}
+   if use_loadgen then
       local fn = function ()
          print("Transmissions (last 1 sec):")
          engine.report_apps()
       end
       local t = timer.new("report", fn, 1e9, 'repeating')
       timer.activate(t)
+   else
+      report = {showlinks = true}
    end
 
-   local report = not opts.loop and {showlinks = true} or {}
    if opts.duration then engine.main({duration=opts.duration, report=report})
    else             engine.main() end
 end

--- a/src/program/packetblaster/packetblaster.lua
+++ b/src/program/packetblaster/packetblaster.lua
@@ -24,7 +24,7 @@ local function is_device_suitable (pcidev, patterns)
 end
 
 function run_loadgen (c, patterns, opts)
-   if opts.loop == nil then opts.loop = true end
+   assert(type(opts) == "table")
    local nics = 0
    pci.scan_devices()
    for _,device in ipairs(pci.devices) do

--- a/src/program/packetblaster/packetblaster.lua
+++ b/src/program/packetblaster/packetblaster.lua
@@ -7,6 +7,7 @@ local timer     = require("core.timer")
 local lib       = require("core.lib")
 local pci       = require("lib.hardware.pci")
 local LoadGen   = require("apps.intel.loadgen").LoadGen
+local Intel82599 = require("apps.intel.intel_app").Intel82599
 
 local function is_device_suitable (pcidev, patterns)
    if not pcidev.usable or pcidev.driver ~= 'apps.intel.intel_app' then
@@ -23,28 +24,39 @@ local function is_device_suitable (pcidev, patterns)
 end
 
 function run_loadgen (c, patterns, opts)
+   if opts.loop == nil then opts.loop = true end
    local nics = 0
    pci.scan_devices()
    for _,device in ipairs(pci.devices) do
       if is_device_suitable(device, patterns) then
          nics = nics + 1
          local name = "nic"..nics
-         config.app(c, name, LoadGen, device.pciaddress)
+         if opts.loop then
+            config.app(c, name, LoadGen, device.pciaddress)
+         else
+            config.app(c, name, Intel82599, {pciaddr = device.pciaddress})
+         end
          config.link(c, "source."..tostring(nics).."->"..name..".input")
       end
    end
    assert(nics > 0, "<PCI> matches no suitable devices.")
    engine.busywait = true
    engine.configure(c)
-   local fn = function ()
-      print("Transmissions (last 1 sec):")
-      engine.report_apps()
+
+   if opts.loop then
+      local fn = function ()
+         print("Transmissions (last 1 sec):")
+         engine.report_apps()
+      end
+      local t = timer.new("report", fn, 1e9, 'repeating')
+      timer.activate(t)
    end
-   local t = timer.new("report", fn, 1e9, 'repeating')
-   timer.activate(t)
-   if opts.duration then engine.main({duration=opts.duration})
+
+   local report = not opts.loop and {showlinks = true} or {}
+   if opts.duration then engine.main({duration=opts.duration, report=report})
    else             engine.main() end
 end
+
 local function show_usage(exit_code)
    print(require("program.packetblaster.README_inc"))
    main.exit(exit_code)

--- a/src/program/packetblaster/packetblaster.lua
+++ b/src/program/packetblaster/packetblaster.lua
@@ -4,7 +4,6 @@ module(..., package.seeall)
 
 local engine    = require("core.app")
 local timer     = require("core.timer")
-local intel10g  = require("apps.intel.intel10g")
 local lib       = require("core.lib")
 local pci       = require("lib.hardware.pci")
 local LoadGen   = require("apps.intel.loadgen").LoadGen
@@ -24,39 +23,39 @@ local function is_device_suitable (pcidev, patterns)
 end
 
 function run_loadgen (c, patterns, duration)
-  local nics = 0
-  pci.scan_devices()
-  for _,device in ipairs(pci.devices) do
-    if is_device_suitable(device, patterns) then
-      nics = nics + 1
-      local name = "nic"..nics
-      config.app(c, name, LoadGen, device.pciaddress)
-      config.link(c, "source."..tostring(nics).."->"..name..".input")
-    end
-  end
-  assert(nics > 0, "<PCI> matches no suitable devices.")
-  engine.busywait = true
-  engine.configure(c)
-  local fn = function ()
-                print("Transmissions (last 1 sec):")
-                engine.report_apps()
-             end
-  local t = timer.new("report", fn, 1e9, 'repeating')
-  timer.activate(t)
-  if duration then engine.main({duration=duration})
-  else             engine.main() end
+   local nics = 0
+   pci.scan_devices()
+   for _,device in ipairs(pci.devices) do
+      if is_device_suitable(device, patterns) then
+         nics = nics + 1
+         local name = "nic"..nics
+         config.app(c, name, LoadGen, device.pciaddress)
+         config.link(c, "source."..tostring(nics).."->"..name..".input")
+      end
+   end
+   assert(nics > 0, "<PCI> matches no suitable devices.")
+   engine.busywait = true
+   engine.configure(c)
+   local fn = function ()
+      print("Transmissions (last 1 sec):")
+      engine.report_apps()
+   end
+   local t = timer.new("report", fn, 1e9, 'repeating')
+   timer.activate(t)
+   if duration then engine.main({duration=duration})
+   else             engine.main() end
 end
 local function show_usage(exit_code)
-  print(require("program.packetblaster.README_inc"))
-  main.exit(exit_code)
+   print(require("program.packetblaster.README_inc"))
+   main.exit(exit_code)
 end
 
 function run(args)
-  if #args == 0 then show_usage(1) end
-  local command = string.gsub(table.remove(args, 1), "-", "_")
-  local modname = ("program.packetblaster.%s.%s"):format(command, command)
-  if not lib.have_module(modname) then
-    show_usage(1)
-  end
-  require(modname).run(args)
+   if #args == 0 then show_usage(1) end
+   local command = string.gsub(table.remove(args, 1), "-", "_")
+   local modname = ("program.packetblaster.%s.%s"):format(command, command)
+   if not lib.have_module(modname) then
+      show_usage(1)
+   end
+   require(modname).run(args)
 end

--- a/src/program/packetblaster/packetblaster.lua
+++ b/src/program/packetblaster/packetblaster.lua
@@ -34,10 +34,11 @@ function run_loadgen (c, patterns, opts)
          local name = "nic"..nics
          if use_loadgen then
             config.app(c, name, LoadGen, device.pciaddress)
+            config.link(c, "source."..tostring(nics).."->"..name..".input")
          else
             config.app(c, name, Intel82599, {pciaddr = device.pciaddress})
+            config.link(c, "source."..tostring(nics).."->"..name..".rx")
          end
-         config.link(c, "source."..tostring(nics).."->"..name..".input")
       end
    end
    assert(nics > 0, "<PCI> matches no suitable devices.")

--- a/src/program/packetblaster/packetblaster.lua
+++ b/src/program/packetblaster/packetblaster.lua
@@ -22,7 +22,7 @@ local function is_device_suitable (pcidev, patterns)
    end
 end
 
-function run_loadgen (c, patterns, duration)
+function run_loadgen (c, patterns, opts)
    local nics = 0
    pci.scan_devices()
    for _,device in ipairs(pci.devices) do
@@ -42,7 +42,7 @@ function run_loadgen (c, patterns, duration)
    end
    local t = timer.new("report", fn, 1e9, 'repeating')
    timer.activate(t)
-   if duration then engine.main({duration=duration})
+   if opts.duration then engine.main({duration=opts.duration})
    else             engine.main() end
 end
 local function show_usage(exit_code)

--- a/src/program/packetblaster/packetblaster.lua
+++ b/src/program/packetblaster/packetblaster.lua
@@ -25,13 +25,14 @@ end
 
 function run_loadgen (c, patterns, opts)
    assert(type(opts) == "table")
+   local use_loadgen = opts.loop == nil or opts.loop
    local nics = 0
    pci.scan_devices()
    for _,device in ipairs(pci.devices) do
       if is_device_suitable(device, patterns) then
          nics = nics + 1
          local name = "nic"..nics
-         if opts.loop then
+         if use_loadgen then
             config.app(c, name, LoadGen, device.pciaddress)
          else
             config.app(c, name, Intel82599, {pciaddr = device.pciaddress})

--- a/src/program/packetblaster/replay/README
+++ b/src/program/packetblaster/replay/README
@@ -2,12 +2,11 @@ Usage: packetblaster replay [OPTIONS] <PCAPFILE> <PCI>...
 
   -D DURATION, --duration DURATION
                              Run for DURATION seconds.
-			     Default: unlimited
-  -h, --help
-                             Print usage information.
-
+                             Default: unlimited
   --no-loop                  Do not loop through <PCAPFILE>.
                              Duration is one second if not set.
+  -h, --help
+                             Print usage information.
 
 packetblaster transmits packets continuously to one or more network adapters.
 The PCI arguments are Lua pattern strings that are used to match the network

--- a/src/program/packetblaster/replay/README
+++ b/src/program/packetblaster/replay/README
@@ -6,6 +6,9 @@ Usage: packetblaster replay [OPTIONS] <PCAPFILE> <PCI>...
   -h, --help
                              Print usage information.
 
+  --no-loop                  Do not loop through <PCAPFILE>.
+                             Duration is one second if not set.
+
 packetblaster transmits packets continuously to one or more network adapters.
 The PCI arguments are Lua pattern strings that are used to match the network
 adapters to use. The packets are extracted from PCAPFILE.

--- a/src/program/packetblaster/replay/replay.lua
+++ b/src/program/packetblaster/replay/replay.lua
@@ -12,7 +12,8 @@ local packetblaster = require("program.packetblaster.packetblaster")
 
 local long_opts = {
    duration     = "D",
-   help         = "h"
+   help         = "h",
+   ["no-loop"]  = 0,
 }
 
 local function show_usage (code)
@@ -31,15 +32,23 @@ function run (args)
    function handlers.h ()
       show_usage(0)
    end
+   handlers["no-loop"] = function ()
+      opts.loop = false
+   end
 
    args = lib.dogetopt(args, handlers, "hD:", long_opts)
    if #args < 2 then show_usage(1) end
    local filename = table.remove(args, 1)
    print (string.format("filename=%s", filename))
    config.app(c, "pcap", PcapReader, filename)
-   config.app(c, "loop", basic_apps.Repeater)
    config.app(c, "source", basic_apps.Tee)
-   config.link(c, "pcap.output -> loop.input")
-   config.link(c, "loop.output -> source.input")
+   if opts.loop then
+      config.app(c, "loop", basic_apps.Repeater)
+      config.link(c, "pcap.output -> loop.input")
+      config.link(c, "loop.output -> source.input")
+   else
+      config.link(c, "pcap.output -> source.input")
+      if not opts.duration then opts.duration = 1 end
+   end
    packetblaster.run_loadgen(c, args, opts)
 end

--- a/src/program/packetblaster/replay/replay.lua
+++ b/src/program/packetblaster/replay/replay.lua
@@ -21,17 +21,18 @@ local function show_usage (code)
 end
 
 function run (args)
-   local opt = {}
+   local handlers = {}
+   local opts = {}
    local duration
    local c = config.new()
-   function opt.D (arg)
-      duration = assert(tonumber(arg), "duration is not a number!")
+   function handlers.D (arg)
+      opts.duration = assert(tonumber(arg), "duration is not a number!")
    end
-   function opt.h ()
+   function handlers.h ()
       show_usage(0)
    end
 
-   args = lib.dogetopt(args, opt, "hD:", long_opts)
+   args = lib.dogetopt(args, handlers, "hD:", long_opts)
    if #args < 2 then show_usage(1) end
    local filename = table.remove(args, 1)
    print (string.format("filename=%s", filename))
@@ -40,5 +41,5 @@ function run (args)
    config.app(c, "source", basic_apps.Tee)
    config.link(c, "pcap.output -> loop.input")
    config.link(c, "loop.output -> source.input")
-   packetblaster.run_loadgen(c, args, duration)
+   packetblaster.run_loadgen(c, args, opts)
 end

--- a/src/program/packetblaster/replay/replay.lua
+++ b/src/program/packetblaster/replay/replay.lua
@@ -9,26 +9,30 @@ local PcapReader = require("apps.pcap.pcap").PcapReader
 local lib        = require("core.lib")
 
 local packetblaster = require("program.packetblaster.packetblaster")
-local usage = require("program.packetblaster.replay.README_inc")
 
 local long_opts = {
    duration     = "D",
    help         = "h"
 }
 
+local function show_usage (code)
+   print(require("program.packetblaster.replay.README_inc"))
+   main.exit(code)
+end
+
 function run (args)
    local opt = {}
    local duration
    local c = config.new()
-   function opt.D (arg) 
-      duration = assert(tonumber(arg), "duration is not a number!")  
+   function opt.D (arg)
+      duration = assert(tonumber(arg), "duration is not a number!")
    end
-   function opt.h (arg)
-      print(usage)
-      main.exit(1)
+   function opt.h ()
+      show_usage(0)
    end
 
    args = lib.dogetopt(args, opt, "hD:", long_opts)
+   if #args < 2 then show_usage(1) end
    local filename = table.remove(args, 1)
    print (string.format("filename=%s", filename))
    config.app(c, "pcap", PcapReader, filename)

--- a/src/program/packetblaster/replay/replay.lua
+++ b/src/program/packetblaster/replay/replay.lua
@@ -22,10 +22,9 @@ local function show_usage (code)
 end
 
 function run (args)
-   local handlers = {}
-   local opts = {}
-   local duration
    local c = config.new()
+   local handlers = {}
+   local opts = { loop = true }
    function handlers.D (arg)
       opts.duration = assert(tonumber(arg), "duration is not a number!")
    end

--- a/src/program/packetblaster/synth/README
+++ b/src/program/packetblaster/synth/README
@@ -13,8 +13,6 @@ Usage: packetblaster synth [OPTIONS] <PCI>...
   -D DURATION, --duration DURATION
                              Run for DURATION seconds.
                              Default: unlimited
-  --no-loop                  Do not loop through <PCAPFILE>.
-                             Duration is one second if not set.
   -h, --help
                              Print usage information.
 

--- a/src/program/packetblaster/synth/README
+++ b/src/program/packetblaster/synth/README
@@ -2,17 +2,19 @@ Usage: packetblaster synth [OPTIONS] <PCI>...
 
   -s SOURCE, --src SOURCE
                              Source MAC-Address.
-			     Default: 00:00:00:00:00:00
+                             Default: 00:00:00:00:00:00
   -d DESTINATION, --dst DESTINATION
                              Destination MAC-Address.
-			     Default: 00:00:00:00:00:00
+                             Default: 00:00:00:00:00:00
   -S SIZES, --sizes SIZES
                              A comma separated list of numbers. Send packets of
                              SIZES bytes.
                              Default: 64
   -D DURATION, --duration DURATION
                              Run for DURATION seconds.
-			     Default: unlimited
+                             Default: unlimited
+  --no-loop                  Do not loop through <PCAPFILE>.
+                             Duration is one second if not set.
   -h, --help
                              Print usage information.
 

--- a/src/program/packetblaster/synth/synth.lua
+++ b/src/program/packetblaster/synth/synth.lua
@@ -15,7 +15,6 @@ local long_opts = {
    src          = "s",
    dst          = "d",
    sizes        = "S",
-   ["no-loop"]  = 0,
 }
 
 local function show_usage (code)
@@ -26,15 +25,12 @@ end
 function run (args)
    local c = config.new()
    local handlers = {}
-   local opts = {loop = true}
+   local opts = {}
    function handlers.D (arg)
       opts.duration = assert(tonumber(arg), "duration is not a number!")
    end
    function handlers.h ()
       show_usage(0)
-   end
-   handlers["no-loop"] = function ()
-      opts.loop = false
    end
 
    local source
@@ -50,7 +46,6 @@ function run (args)
    end
 
    args = lib.dogetopt(args, handlers, "hD:s:d:S:", long_opts)
-   if not (sizes or source or destination) then show_usage(1) end
    config.app(c, "source", Synth, { sizes = sizes,
       src = source, dst = destination })
    packetblaster.run_loadgen(c, args, opts)

--- a/src/program/packetblaster/synth/synth.lua
+++ b/src/program/packetblaster/synth/synth.lua
@@ -8,7 +8,6 @@ local Synth     = require("apps.test.synth").Synth
 local lib       = require("core.lib")
 
 local packetblaster = require("program.packetblaster.packetblaster")
-local usage = require("program.packetblaster.synth.README_inc")
 
 local long_opts = {
    duration     = "D",
@@ -18,16 +17,20 @@ local long_opts = {
    sizes        = "S"
 }
 
+local function show_usage (code)
+   print(require("program.packetblaster.synth.README_inc"))
+   main.exit(code)
+end
+
 function run (args)
    local opt = {}
    local duration
    local c = config.new()
-   function opt.D (arg) 
-      duration = assert(tonumber(arg), "duration is not a number!")  
+   function opt.D (arg)
+      duration = assert(tonumber(arg), "duration is not a number!")
    end
-   function opt.h (arg)
-      print(usage)
-      main.exit(1)
+   function opt.h ()
+      show_usage(0)
    end
 
    local source
@@ -36,14 +39,15 @@ function run (args)
    function opt.s (arg) source = arg end
    function opt.d (arg) destination = arg end
    function opt.S (arg)
-     sizes = {}
-     for size in string.gmatch(arg, "%d+") do
-       sizes[#sizes+1] = tonumber(size)
-     end
+      sizes = {}
+      for size in string.gmatch(arg, "%d+") do
+         sizes[#sizes+1] = tonumber(size)
+      end
    end
 
    args = lib.dogetopt(args, opt, "hD:s:d:S:", long_opts)
+   if not (sizes or source or destination) then show_usage(1) end
    config.app(c, "source", Synth, { sizes = sizes,
-     src = source, dst = destination })
+      src = source, dst = destination })
    packetblaster.run_loadgen(c, args, duration)
 end

--- a/src/program/packetblaster/synth/synth.lua
+++ b/src/program/packetblaster/synth/synth.lua
@@ -14,7 +14,8 @@ local long_opts = {
    help         = "h",
    src          = "s",
    dst          = "d",
-   sizes        = "S"
+   sizes        = "S",
+   ["no-loop"]  = 0,
 }
 
 local function show_usage (code)
@@ -31,6 +32,9 @@ function run (args)
    end
    function handlers.h ()
       show_usage(0)
+   end
+   handlers["no-loop"] = function ()
+      opts.loop = false
    end
 
    local source

--- a/src/program/packetblaster/synth/synth.lua
+++ b/src/program/packetblaster/synth/synth.lua
@@ -23,9 +23,9 @@ local function show_usage (code)
 end
 
 function run (args)
-   local handlers = {}
-   local opts = {}
    local c = config.new()
+   local handlers = {}
+   local opts = {loop = true}
    function handlers.D (arg)
       opts.duration = assert(tonumber(arg), "duration is not a number!")
    end

--- a/src/program/packetblaster/synth/synth.lua
+++ b/src/program/packetblaster/synth/synth.lua
@@ -23,31 +23,31 @@ local function show_usage (code)
 end
 
 function run (args)
-   local opt = {}
-   local duration
+   local handlers = {}
+   local opts = {}
    local c = config.new()
-   function opt.D (arg)
-      duration = assert(tonumber(arg), "duration is not a number!")
+   function handlers.D (arg)
+      opts.duration = assert(tonumber(arg), "duration is not a number!")
    end
-   function opt.h ()
+   function handlers.h ()
       show_usage(0)
    end
 
    local source
    local destination
    local sizes
-   function opt.s (arg) source = arg end
-   function opt.d (arg) destination = arg end
-   function opt.S (arg)
+   function handlers.s (arg) source = arg end
+   function handlers.d (arg) destination = arg end
+   function handlers.S (arg)
       sizes = {}
       for size in string.gmatch(arg, "%d+") do
          sizes[#sizes+1] = tonumber(size)
       end
    end
 
-   args = lib.dogetopt(args, opt, "hD:s:d:S:", long_opts)
+   args = lib.dogetopt(args, handlers, "hD:s:d:S:", long_opts)
    if not (sizes or source or destination) then show_usage(1) end
    config.app(c, "source", Synth, { sizes = sizes,
       src = source, dst = destination })
-   packetblaster.run_loadgen(c, args, duration)
+   packetblaster.run_loadgen(c, args, opts)
 end


### PR DESCRIPTION
When running packetblaster replay with _--no-loop_ switch, input pcap file is only iterated once. Duration is set to one second by default if not set.

I needed to refactor _synth.lua_ as well. The PR cleans up other necessary files too and fixes passing wrong number of arguments to _replay_.

Examples:

Packetblaster replay:

```
$ sudo ./snabb packetblaster replay -D 1 v6-10.pcap 81:00.0 81:00.1
filename=v6-10.pcap
Transmissions (last 1 sec):
apps report:
nic1
81:00.0 TXDGPC (TX packets)     2,142,717       GOTCL (TX octets)       1,186,937,244
81:00.0 RXDGPC (RX packets)     0       GORCL (RX octets)       1,186,942,230
nic2
81:00.1 TXDGPC (TX packets)     2,142,838       GOTCL (TX octets)       1,186,983,780
81:00.1 RXDGPC (RX packets)     0       GORCL (RX octets)       1,187,038,626
```

Packetblaster replay with --no-loop switch:

```
$ sudo ./snabb packetblaster replay --no-loop v6-10.pcap 81:00.0 81:00.1
filename=v6-10.pcap
link report:
                  10 sent on pcap.output -> source.input (loss rate: 0%)
                  10 sent on source.1 -> nic1.input (loss rate: 0%)
                  10 sent on source.2 -> nic2.input (loss rate: 0%)
```

Packetblaster synth:

```
sudo ./snabb packetblaster synth -D 1 -d 22:22:22:22:22:22 -S 32,64,128 81:00.0 81:00.1
Transmissions (last 1 sec):
apps report:
nic1
81:00.0 TXDGPC (TX packets)     11,421,721      GOTCL (TX octets)       1,004,995,792
81:00.0 RXDGPC (RX packets)     0       GORCL (RX octets)       1,004,810,664
nic2
81:00.1 TXDGPC (TX packets)     11,419,914      GOTCL (TX octets)       1,004,838,780
81:00.1 RXDGPC (RX packets)     0       GORCL (RX octets)       1,005,060,804
```
