### PR TITLE
manual: support NixOS 16.03 and 16.09 texlive package sets

### DIFF
--- a/src/doc/default.nix
+++ b/src/doc/default.nix
@@ -13,8 +13,8 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ ditaa pandoc git
    (texlive.combine {
-      inherit (texlive) scheme-small luatex luatexbase sectsty titlesec cprotect bigfoot titling droid;
-    })
+      inherit (texlive) scheme-small luatex luatexbase sectsty titlesec cprotect bigfoot titling droid collection-luatex;
+   })
   ];
 
   patchPhase = ''


### PR DESCRIPTION
Otherwise manual doesn't build on NixOS 16.09 (beta to be released today).