### PR TITLE
avoid allocating a packet on every breath

### DIFF
--- a/src/apps/tap/tap.lua
+++ b/src/apps/tap/tap.lua
@@ -46,9 +46,8 @@ end
 function Tap:pull ()
    local l = self.output.output
    if l == nil then return end
-   local p = self.pkt
    for i=1,engine.pull_npackets do
-      local len, err = S.read(self.sock, p.data, C.PACKET_PAYLOAD_SIZE)
+      local len, err = S.read(self.sock, self.pkt.data, C.PACKET_PAYLOAD_SIZE)
       -- errno == EAGAIN indicates that the read would of blocked as there is no
       -- packet waiting. It is not a failure.
       if not len and err.errno == const.E.AGAIN then
@@ -57,19 +56,18 @@ function Tap:pull ()
       if not len then
          error("Failed read on " .. self.name .. ": " .. tostring(err))
       end
-      p.length = len
-      link.transmit(l, p)
+      self.pkt.length = len
+      link.transmit(l, self.pkt)
       counter.add(self.shm.rxbytes, len)
       counter.add(self.shm.rxpackets)
-      if ethernet:is_mcast(p.data) then
+      if ethernet:is_mcast(self.pkt.data) then
          counter.add(self.shm.rxmcast)
       end
-      if ethernet:is_bcast(p.data) then
+      if ethernet:is_bcast(self.pkt.data) then
          counter.add(self.shm.rxbcast)
       end
-      p = packet.allocate()
+      self.pkt = packet.allocate()
    end
-   self.pkt = p
 end
 
 function Tap:push ()


### PR DESCRIPTION
Further to @alexandergall comments in slack, now tap doesn't allocate/free a packet on every breath.