### PR TITLE
core.main: check the return value of fork.

### DIFF
--- a/src/core/main.lua
+++ b/src/core/main.lua
@@ -164,7 +164,8 @@ function selftest ()
 end
 
 -- Fork into worker process and supervisor
-local worker_pid = S.fork()
+local worker_pid, err = S.fork()
+assert(worker_pid, tostring(err))
 if worker_pid == 0 then
    -- Worker: Use prctl to ensure we are killed (SIGHUP) when our parent quits
    -- and run main.


### PR DESCRIPTION
@vanfstd knows his Unix and instantly spotted this nobrainer. :-)

The return value of `S.fork` was not checked, which might lead to difficult to debug crashes in some situations.