### PR TITLE
Overload assert to synergize with ljsyscall

### DIFF
--- a/src/apps/socket/raw.lua
+++ b/src/apps/socket/raw.lua
@@ -12,13 +12,6 @@ local ethernet = require("lib.protocol.ethernet")
 local ffi = require("ffi")
 local C = ffi.C
 
---ljsyscall returns error as a a cdata instead of a string,
---and the standard assert() doesn't use tostring() on it.
-local function assert(v, ...)
-   if not v then error(tostring(... or 'assertion failed'), 2) end
-   return v, ...
-end
-
 local c, t = S.c, S.types.t
 
 RawSocket = {}

--- a/src/apps/socket/unix.lua
+++ b/src/apps/socket/unix.lua
@@ -9,13 +9,6 @@ local link   = require("core.link")
 local packet = require("core.packet")
 local S      = require("syscall")
 
---ljsyscall returns error as a a cdata instead of a string,
---and the standard assert() doesn't use tostring() on it.
-local function assert(v, ...)
-   if not v then error(tostring(... or 'assertion failed'), 2) end
-   return v, ...
-end
-
 UnixSocket = {}
 UnixSocket.__index = UnixSocket
 

--- a/src/core/lib.lua
+++ b/src/core/lib.lua
@@ -11,13 +11,6 @@ local bit = require("bit")
 local band, bor, bnot, lshift, rshift, bswap =
    bit.band, bit.bor, bit.bnot, bit.lshift, bit.rshift, bit.bswap
 
--- Alternate version of assert that calls tostring on it second argument. Very
--- useful for working with ljsyscall.
-function assert (v, ...)
-   if v then return v, ... end
-   error(tostring(... or "assertion failed!"))
-end
-
 -- Returns true if x and y are structurally similar (isomorphic).
 function equal (x, y)
    if type(x) ~= type(y) then return false end

--- a/src/core/lib.lua
+++ b/src/core/lib.lua
@@ -11,6 +11,13 @@ local bit = require("bit")
 local band, bor, bnot, lshift, rshift, bswap =
    bit.band, bit.bor, bit.bnot, bit.lshift, bit.rshift, bit.bswap
 
+-- Alternate version of assert that calls tostring on it second argument. Very
+-- useful for working with ljsyscall.
+function assert (v, ...)
+   if v then return v, ... end
+   error(tostring(... or "assertion failed!"))
+end
+
 -- Returns true if x and y are structurally similar (isomorphic).
 function equal (x, y)
    if type(x) ~= type(y) then return false end

--- a/src/core/main.lua
+++ b/src/core/main.lua
@@ -164,7 +164,8 @@ function selftest ()
 end
 
 -- Fork into worker process and supervisor
-local worker_pid = S.fork()
+local worker_pid, err = S.fork()
+assert(worker_pid, tostring(err))
 if worker_pid == 0 then
    -- Worker: Use prctl to ensure we are killed (SIGHUP) when our parent quits
    -- and run main.

--- a/src/core/main.lua
+++ b/src/core/main.lua
@@ -112,10 +112,11 @@ end
 
 --- Globally initialize some things. Module can depend on this being done.
 function initialize ()
-   require("core.lib")
+   -- Global API
+   _G.lib    = require("core.lib")
+   _G.assert = _G.lib.assert
    require("core.clib_h")
    require("core.lib_h")
-   -- Global API
    _G.config = require("core.config")
    _G.engine = require("core.app")
    _G.memory = require("core.memory")

--- a/src/core/main.lua
+++ b/src/core/main.lua
@@ -19,6 +19,13 @@ local S = require("syscall")
 require("lib.lua.strict")
 require("lib.lua.class")
 
+-- ljsyscall returns error as a cdata instead of a string, and the standard
+-- assert doesn't use tostring on it.
+_G.assert = function (v, ...)
+   if v then return v, ... end
+   error(tostring(... or "assertion failed!"))
+end
+
 -- Reserve names that we want to use for global module.
 -- (This way we avoid errors from the 'strict' module.)
 _G.config, _G.engine, _G.memory, _G.link, _G.packet, _G.timer,
@@ -112,11 +119,10 @@ end
 
 --- Globally initialize some things. Module can depend on this being done.
 function initialize ()
-   -- Global API
-   _G.lib    = require("core.lib")
-   _G.assert = _G.lib.assert
+   require("core.lib")
    require("core.clib_h")
    require("core.lib_h")
+   -- Global API
    _G.config = require("core.config")
    _G.engine = require("core.app")
    _G.memory = require("core.memory")

--- a/src/core/memory.lua
+++ b/src/core/memory.lua
@@ -57,8 +57,7 @@ end
 --- ### HugeTLB: Allocate contiguous memory in bulk from Linux
 
 function allocate_hugetlb_chunk ()
-   local fd, err = syscall.open("/proc/sys/vm/nr_hugepages","rdonly")
-   assert(fd, tostring(err))
+   local fd = assert(syscall.open("/proc/sys/vm/nr_hugepages","rdonly"))
    fd:flock("ex")
    for i =1, 3 do
       local page = C.allocate_huge_page(huge_page_size)

--- a/src/lib/hardware/pci.lua
+++ b/src/lib/hardware/pci.lua
@@ -142,15 +142,12 @@ function map_pci_memory (device, n, lock)
    if lock then
      assert(f:flock("ex, nb"), "failed to lock " .. filepath)
    end
-   local st, err = f:stat()
-   assert(st, tostring(err))
-   local mem, err = f:mmap(nil, st.size, "read, write", "shared", 0)
-   assert(mem, tostring(err))
+   local st = assert(f:stat())
+   local mem = assert(f:mmap(nil, st.size, "read, write", "shared", 0))
    return ffi.cast("uint32_t *", mem), f
 end
 function close_pci_resource (fd, base)
-   local st, err = fd:stat()
-   assert(st, tostring(err))
+   local st = assert(fd:stat())
    S.munmap(base, st.size)
    fd:close()
 end
@@ -159,8 +156,7 @@ end
 --- mastering is enabled.
 function set_bus_master (device, enable)
    root_check()
-   local f,err = S.open(path(device).."/config", "rdwr")
-   assert(f, tostring(err))
+   local f = assert(S.open(path(device).."/config", "rdwr"))
    local fd = f:getfd()
 
    local value = ffi.new("uint16_t[1]")

--- a/src/program/lisper/lisper.lua
+++ b/src/program/lisper/lisper.lua
@@ -28,11 +28,6 @@ local ntohl = lib.ntohl
 local getenv = lib.getenv
 local hexdump = lib.hexdump
 
-local function assert(v, ...) --assert overload because
-   if v then return v, ... end
-   error(tostring((...) or "Assertion failed"), 2)
-end
-
 local function parsehex(s)
    return (s:gsub("[0-9a-fA-F][0-9a-fA-F]", function(cc)
      return string.char(tonumber(cc, 16))


### PR DESCRIPTION
This adds `core.lib.assert` and exposes it globally to replace various ad-hoc `assert` re-implementations. This variant of `assert` is convenient because it calls `tostring` on its second argument, which synergizes well with ljsyscall that returns metaobjects for errors. Since Snabb is a heavy user of ljsyscall, I figured this change will benefit the overall code base. Evidence: there were multiple ad-hoc assert definitions because of this exact issue.

Depends on: #1017 