### PR TITLE
[wip] Reintroduce vhost_user statistics

### DIFF
--- a/src/apps/socket/raw.lua
+++ b/src/apps/socket/raw.lua
@@ -80,12 +80,8 @@ function RawSocket:receive ()
    p.length = sz
    counter.add(self.shm.rxbytes, sz)
    counter.add(self.shm.rxpackets)
-   if ethernet:is_mcast(p.data) then
-      counter.add(self.shm.rxmcast)
-   end
-   if ethernet:is_bcast(p.data) then
-      counter.add(self.shm.rxbcast)
-   end
+   counter.add(self.shm.rxmcast, ethernet:n_mcast(p.data))
+   counter.add(self.shm.rxbcast, ethernet:n_bcast(p.data))
    return packet.clone(p)
 end
 
@@ -97,12 +93,8 @@ function RawSocket:push ()
       self:transmit(p)
       counter.add(self.shm.txbytes, p.length)
       counter.add(self.shm.txpackets)
-      if ethernet:is_mcast(p.data) then
-         counter.add(self.shm.txmcast)
-      end
-      if ethernet:is_bcast(p.data) then
-         counter.add(self.shm.txbcast)
-      end
+      counter.add(self.shm.txmcast, ethernet:n_mcast(p.data))
+      counter.add(self.shm.txbcast, ethernet:n_bcast(p.data))
       packet.free(p)
    end
 end

--- a/src/apps/tap/tap.lua
+++ b/src/apps/tap/tap.lua
@@ -62,12 +62,8 @@ function Tap:pull ()
       link.transmit(l, p)
       counter.add(self.shm.rxbytes, len)
       counter.add(self.shm.rxpackets)
-      if ethernet:is_mcast(p.data) then
-         counter.add(self.shm.rxmcast)
-      end
-      if ethernet:is_bcast(p.data) then
-         counter.add(self.shm.rxbcast)
-      end
+      counter.add(self.shm.rxmcast, ethernet:n_mcast(p.data))
+      counter.add(self.shm.rxbcast, ethernet:n_bcast(p.data))
    end
 end
 
@@ -87,12 +83,8 @@ function Tap:push ()
       end
       counter.add(self.shm.txbytes, len)
       counter.add(self.shm.txpackets)
-      if ethernet:is_mcast(p.data) then
-         counter.add(self.shm.txmcast)
-      end
-      if ethernet:is_bcast(p.data) then
-         counter.add(self.shm.txbcast)
-      end
+      counter.add(self.shm.txmcast, ethernet:n_mcast(p.data))
+      counter.add(self.shm.txbcast, ethernet:n_bcast(p.data))
       -- The write completed so dequeue it from the link and free the packet
       link.receive(l)
       packet.free(p)

--- a/src/apps/vhost/vhost_user.lua
+++ b/src/apps/vhost/vhost_user.lua
@@ -13,6 +13,7 @@ local lib       = require("core.lib")
 local link      = require("core.link")
 local main      = require("core.main")
 local memory    = require("core.memory")
+local counter   = require("core.counter")
 local pci       = require("lib.hardware.pci")
 local net_device= require("lib.virtio.net_device")
 local timer     = require("core.timer")
@@ -41,7 +42,17 @@ function VhostUser:new (args)
          function () self:process_qemu_requests() end,
          5e8,-- 500 ms
          'non-repeating'
-      )
+      ),
+      -- counters
+      shm = { rxbytes   = {counter},
+              rxpackets = {counter},
+              rxmcast   = {counter},
+              rxbcast   = {counter},
+              rxdrop    = {counter},
+              txbytes   = {counter},
+              txpackets = {counter},
+              txmcast   = {counter},
+              txbcast   = {counter} }
    }
    self = setmetatable(o, {__index = VhostUser})
    self.dev = net_device.VirtioNetDevice:new(self,

--- a/src/lib/protocol/README.md
+++ b/src/lib/protocol/README.md
@@ -102,9 +102,19 @@ Returns the string representation of *mac* address.
 
 Returns a true value if *mac* address denotes a [Multicast address](https://en.wikipedia.org/wiki/Multicast_address#Ethernet).
 
+— Function **ethernet:n_mcast** *mac*
+
+Returns 1 if *mac* address denotes a [Multicast address](https://en.wikipedia.org/wiki/Multicast_address#Ethernet)
+and 0 otherwise.
+
 — Function **ethernet:is_bcast** *mac*
 
 Returns a true value if *mac* address denotes a [Broadcast address](https://en.wikipedia.org/wiki/Broadcast_address#Ethernet).
+
+— Function **ethernet:n_bcast** *mac*
+
+Returns 1 if *mac* address denotes a [Broadcast address](https://en.wikipedia.org/wiki/Broadcast_address#Ethernet)
+and 0 otherwise.
 
 — Function **ethernet:ipv6_mcast** *ip*
 

--- a/src/lib/virtio/net_device.lua
+++ b/src/lib/virtio/net_device.lua
@@ -170,12 +170,8 @@ function VirtioNetDevice:rx_packet_end(header_id, total_size, rx_p)
       end
       counter.add(counters.rxbytes, rx_p.length)
       counter.add(counters.rxpackets)
-      if ethernet:is_mcast(rx_p.data) then
-         counter.add(counters.rxmcast)
-      end
-      if ethernet:is_bcast(rx_p.data) then
-         counter.add(counters.rxbcast)
-      end
+      counter.add(counters.rxmcast, ethernet:n_mcast(rx_p.data))
+      counter.add(counters.rxbcast, ethernet:n_bcast(rx_p.data))
       link.transmit(l, rx_p)
    else
       debug("droprx", "len", rx_p.length)
@@ -270,12 +266,8 @@ function VirtioNetDevice:tx_packet_end(header_id, total_size, tx_p)
    local counters = self.owner.shm
    counter.add(counters.txbytes, tx_p.length)
    counter.add(counters.txpackets)
-   if ethernet:is_mcast(tx_p.data) then
-      counter.add(counters.txmcast)
-   end
-   if ethernet:is_bcast(tx_p.data) then
-      counter.add(counters.txbcast)
-   end
+   counter.add(counters.txmcast, ethernet:n_mcast(tx_p.data))
+   counter.add(counters.txbcast, ethernet:n_bcast(tx_p.data))
    packet.free(tx_p)
    self.virtq[self.ring_id]:put_buffer(header_id, total_size)
 end
@@ -352,12 +344,8 @@ function VirtioNetDevice:tx_packet_end_mrg_rxbuf(header_id, total_size, tx_p)
    if self.tx.finished then
       counter.add(counters.txbytes, tx_p.length)
       counter.add(counters.txpackets)
-      if ethernet:is_mcast(tx_p.data) then
-         counter.add(counters.txmcast)
-      end
-      if ethernet:is_bcast(tx_p.data) then
-         counter.add(counters.txbcast)
-      end
+      counter.add(counters.txmcast, ethernet:n_mcast(tx_p.data))
+      counter.add(counters.txbcast, ethernet:n_bcast(tx_p.data))
       packet.free(tx_p)
       self.tx.p = nil
       self.tx.data_sent = nil


### PR DESCRIPTION
Given the speedup of the vhost_user code due to https://github.com/snabbco/snabb/pull/1001 want to reintroduce vhost_user statistics counters from https://github.com/snabbco/snabb/pull/931. I gave this a `[wip]` tag since the performance regression caused by this change is still not acceptable.

See the Rmarkdown report for the regression: https://hydra.snabb.co/build/551126/download/2/report.html#overall-summary

Cc @lukego 
