### PR TITLE
Cast VLAN tags as int32

### DIFF
--- a/src/apps/vlan/vlan.lua
+++ b/src/apps/vlan/vlan.lua
@@ -17,7 +17,7 @@ Untagger = {}
 -- 802.1q
 local dot1q_tpid = 0x8100
 local o_ethernet_ethertype = 12
-local uint32_ptr_t = ffi.typeof('uint32_t*')
+local int32_ptr_t = ffi.typeof('int32_t*')
 
 
 -- build a VLAN tag consisting of 2 bytes of TPID set to 0x8100 followed by the
@@ -41,7 +41,7 @@ function push_tag(pkt, tag)
    local length = pkt.length
    pkt.length = length + 4
    C.memmove(payload + 4, payload, length - o_ethernet_ethertype)
-   cast(uint32_ptr_t, payload)[0] = tag
+   cast(int32_ptr_t, payload)[0] = tag
 end
 
 -- extract TCI (2 bytes) from packet, no check is performed to verify that the
@@ -85,7 +85,7 @@ function Untagger:push ()
    for _=1,link.nreadable(input) do
       local pkt = receive(input)
       local payload = pkt.data + o_ethernet_ethertype
-      if cast(uint32_ptr_t, payload)[0] ~= tag then
+      if cast(int32_ptr_t, payload)[0] ~= tag then
          -- Incorrect VLAN tag; drop.
          packet.free(pkt)
       else
@@ -147,6 +147,29 @@ function VlanMux:transmit(o, pkt)
    end
 end
 
+function test_tag_untag ()
+   local pkt = packet.from_string(lib.hexundump([[
+      02:aa:aa:aa:aa:aa 02:99:99:99:99:99 08 00 45 00
+      00 54 43 58 40 00 40 01 7c 5c c0 a8 0d 28 ac 14
+      01 10 08 00 9c d4 07 c0 00 01 bc fa e3 57 00 00
+      00 00 f3 44 01 00 00 00 00 00 10 11 12 13 14 15
+      16 17 18 19 1a 1b 1c 1d 1e 1f 20 21 22 23 24 25
+      26 27 28 29 2a 2b 2c 2d 2e 2f 30 31 32 33 34 35
+      36 37
+   ]], 82))
+   local payload = pkt.data + o_ethernet_ethertype
+   local vid = 0
+   for i=0,15 do
+      for j=0,255 do
+         local tag = build_tag(vid)
+         push_tag(pkt, tag)
+         assert(cast(int32_ptr_t, payload)[0] == tag)
+         vid = vid + 1
+      end
+   end
+   assert(vid == 4096)
+   print("Sucessfully tagged/untagged all potential VLAN tags (0-4095)")
+end
 
 function selftest()
    local app = require("core.app")
@@ -164,4 +187,6 @@ function selftest()
 
    print("source sent: " .. link.stats(app.app_table.source.output.output).txpackets)
    print("sink received: " .. link.stats(app.app_table.sink.input.input).rxpackets)
+
+   test_tag_untag()
 end


### PR DESCRIPTION
There are certain VLAN tags that are not correctly untagged, for instance VLAN: 128.

The problem is that VLAN tags are read as uint32. This value is compared to a tag, which is obtained as the result of a bitwise operation. As LuaJIT BitOp module works in the signed int32 range, certain tags return a negative number while being compared to an uint32, which is always a positive number.

The solution is to read VLAN tags as int32 or to read them as uint32 and to apply the `bit.tobit()` operation. `tobit()` guarantees successful comparisons between the result of bitwise operations in LuaJIT (for instance when comparing a bitwise operation to a constant). Certainly I think reading the tags as int32 is simpler.

Here is a small snippet that renders the issue:

```lua
local ffi = require("ffi")
local bit = require("bit")

local C = ffi.C
local htonl = bit.bswap

local dot1q_tpid = 0x8100
local function build_tag(vid)
   return htonl(bit.bor(bit.lshift(dot1q_tpid, 16), vid))
end

local data = ffi.new("uint8_t[?]", 4)
data[0] = 0x81
data[1] = 0
data[2] = 0
data[3] = 128

print("Target tag: "..build_tag(128))
print("Cast to uint32_t: "..ffi.cast("uint32_t*", data)[0])
print("Cast to int32_t: "..bit.tobit(ffi.cast("int32_t*", data)[0]))
print("Cast to uint32_t (tobit): "..bit.tobit(ffi.cast("uint32_t*", data)[0]))
```

Output:

```
Target tag: -2147483519
Cast to uint32_t: 2147483777
Cast to int32_t: -2147483519
Cast to uint32_t (tobit): -2147483519
```