### PR TITLE
Numa upstream

### DIFF
--- a/lib/ljsyscall/syscall/linux/c.lua
+++ b/lib/ljsyscall/syscall/linux/c.lua
@@ -347,6 +347,13 @@ function C.sched_setparam(pid, param)
   return syscall(sys.sched_setparam, int(pid), void(param))
 end
 
+function C.get_mempolicy(mode, mask, maxnode, addr, flags)
+  return syscall(sys.get_mempolicy, void(mode), void(mask), ulong(maxnode), ulong(addr), ulong(flags))
+end
+function C.set_mempolicy(mode, mask, maxnode)
+  return syscall(sys.set_mempolicy, int(mode), void(mask), ulong(maxnode))
+end
+
 -- in librt for glibc but use syscalls instead of loading another library
 function C.clock_nanosleep(clk_id, flags, req, rem)
   return syscall(sys.clock_nanosleep, int(clk_id), int(flags), void(req), void(rem))

--- a/lib/ljsyscall/syscall/linux/c.lua
+++ b/lib/ljsyscall/syscall/linux/c.lua
@@ -354,6 +354,10 @@ function C.set_mempolicy(mode, mask, maxnode)
   return syscall(sys.set_mempolicy, int(mode), void(mask), ulong(maxnode))
 end
 
+function C.migrate_pages(pid, maxnode, from, to)
+  return syscall(sys.migrate_pages, int(pid), ulong(maxnode), void(from), void(to))
+end
+
 -- in librt for glibc but use syscalls instead of loading another library
 function C.clock_nanosleep(clk_id, flags, req, rem)
   return syscall(sys.clock_nanosleep, int(clk_id), int(flags), void(req), void(rem))

--- a/lib/ljsyscall/syscall/linux/c.lua
+++ b/lib/ljsyscall/syscall/linux/c.lua
@@ -691,7 +691,7 @@ C.gettimeofday = ffi.C.gettimeofday
 --function C.gettimeofday(tv, tz) return syscall(sys.gettimeofday, void(tv), void(tz)) end
 
 -- glibc does not provide getcpu; it is however VDSO
-function C.getcpu(cpu, node, tcache) return syscall(sys.getcpu, void(node), void(node), void(tcache)) end
+function C.getcpu(cpu, node, tcache) return syscall(sys.getcpu, void(cpu), void(node), void(tcache)) end
 -- time is VDSO but not really performance critical; does not exist for some architectures
 if sys.time then
   function C.time(t) return syscall(sys.time, void(t)) end

--- a/lib/ljsyscall/syscall/linux/constants.lua
+++ b/lib/ljsyscall/syscall/linux/constants.lua
@@ -3149,6 +3149,23 @@ c.IPT_SO_GET = strflag {
   REVISION_TARGET      = IPT_BASE_CTL + 3,
 }
 
+c.MPOL_MODE = multiflags {
+  DEFAULT = 0,
+  PREFERRED = 1,
+  BIND = 2,
+  INTERLEAVE = 3,
+  LOCAL = 4,
+  -- TODO: Only the following two flags can be ORed.
+  STATIC_NODES     = 0x80000000,
+  RELATIVE_NODES   = 0x40000000,
+}
+
+c.MPOL_FLAG = multiflags {
+  NODE	           = 1,
+  ADDR	           = 2,
+  MEMS_ALLOWED     = 4
+}
+
 c.SCHED = multiflags {
   NORMAL           = 0,
   OTHER            = 0,

--- a/lib/ljsyscall/syscall/linux/syscalls.lua
+++ b/lib/ljsyscall/syscall/linux/syscalls.lua
@@ -457,6 +457,18 @@ function S.sched_setaffinity(pid, mask, len) -- note len last as rarely used
   return retbool(C.sched_setaffinity(pid or 0, len or s.cpu_set, mktype(t.cpu_set, mask)))
 end
 
+function S.get_mempolicy(mode, mask, addr, flags)
+  mode = mode or t.int1()
+  mask = mktype(t.bitmask, mask)
+  local ret, err = C.get_mempolicy(mode, mask.mask, mask.size, addr or 0, c.MPOL_FLAG[flags])
+  if ret == -1 then return nil, t.error(err or errno()) end
+  return { mode=mode[0], mask=mask }
+end
+function S.set_mempolicy(mode, mask)
+  mask = mktype(t.bitmask, mask)
+  return retbool(C.set_mempolicy(c.MPOL_MODE[mode], mask.mask, mask.size))
+end
+
 function S.sched_get_priority_max(policy) return retnum(C.sched_get_priority_max(c.SCHED[policy])) end
 function S.sched_get_priority_min(policy) return retnum(C.sched_get_priority_min(c.SCHED[policy])) end
 

--- a/lib/ljsyscall/syscall/linux/syscalls.lua
+++ b/lib/ljsyscall/syscall/linux/syscalls.lua
@@ -469,6 +469,13 @@ function S.set_mempolicy(mode, mask)
   return retbool(C.set_mempolicy(c.MPOL_MODE[mode], mask.mask, mask.size))
 end
 
+function S.migrate_pages(pid, from, to)
+  from = mktype(t.bitmask, from)
+  to = mktype(t.bitmask, to)
+  assert(from.size == to.size, "incompatible nodemask sizes")
+  return retbool(C.migrate_pages(pid or 0, from.size, from.mask, to.mask))
+end
+
 function S.sched_get_priority_max(policy) return retnum(C.sched_get_priority_max(c.SCHED[policy])) end
 function S.sched_get_priority_min(policy) return retnum(C.sched_get_priority_min(c.SCHED[policy])) end
 

--- a/src/lib/numa.lua
+++ b/src/lib/numa.lua
@@ -1,0 +1,135 @@
+module(..., package.seeall)
+
+local S = require("syscall")
+local pci = require("lib.hardware.pci")
+
+local bound_cpu
+local bound_numa_node
+
+function cpu_get_numa_node (cpu)
+   local node = 0
+   while true do
+      local node_dir = S.open('/sys/devices/system/node/node'..node,
+                              'rdonly, directory')
+      if not node_dir then return end
+      local found = S.readlinkat(node_dir, 'cpu'..cpu)
+      node_dir:close()
+      if found then return node end
+      node = node + 1
+   end
+end
+
+function has_numa ()
+   local node1 = S.open('/sys/devices/system/node/node1', 'rdonly, directory')
+   if not node1 then return false end
+   node1:close()
+   return true
+end
+
+function pci_get_numa_node (addr)
+   addr = pci.qualified(addr)
+   local file = assert(io.open('/sys/bus/pci/devices/'..addr..'/numa_node'))
+   local node = assert(tonumber(file:read()))
+   -- node can be -1.
+   if node >= 0 then return node end
+end
+
+function choose_numa_node_for_pci_addresses (addrs, require_affinity)
+   local chosen_node, chosen_because_of_addr
+   for _, addr in ipairs(addrs) do
+      local node = pci_get_numa_node(addr)
+      if not node or node == chosen_node then
+         -- Keep trucking.
+      elseif not chosen_node then
+         chosen_node = node
+         chosen_because_of_addr = addr
+      else
+         local msg = string.format(
+            "PCI devices %s and %s have different NUMA node affinities",
+            chosen_because_of_addr, addr)
+         if require_affinity then error(msg) else print('Warning: '..msg) end
+      end
+   end
+   return chosen_node
+end
+
+function check_affinity_for_pci_addresses (addrs)
+   local policy = S.get_mempolicy()
+   if policy.mode == S.c.MPOL_MODE['default'] then
+      if has_numa() then
+         print('Warning: No NUMA memory affinity.')
+         print('Pass --cpu to bind to a CPU and its NUMA node.')
+      end
+   elseif policy.mode ~= S.c.MPOL_MODE['bind'] then
+      print("Warning: NUMA memory policy already in effect, but it's not --membind.")
+   else
+      local node = S.getcpu().node
+      local node_for_pci = choose_numa_node_for_pci_addresses(addrs)
+      if node_for_pci and node ~= node_for_pci then
+         print("Warning: Bound NUMA node does not have affinity with PCI devices.")
+      end
+   end
+end
+
+function unbind_cpu ()
+   local cpu_set = S.sched_getaffinity()
+   cpu_set:zero()
+   for i = 0, 1023 do cpu_set:set(i) end
+   assert(S.sched_setaffinity(0, cpu_set))
+   bound_cpu = nil
+end
+
+function bind_to_cpu (cpu)
+   if cpu == bound_cpu then return end
+   if not cpu then return unbind_cpu() end
+   assert(not bound_cpu, "already bound")
+
+   assert(S.sched_setaffinity(0, cpu))
+   local cpu_and_node = S.getcpu()
+   assert(cpu_and_node.cpu == cpu)
+   bound_cpu = cpu
+
+   bind_to_numa_node (cpu_and_node.node)
+end
+
+function unbind_numa_node ()
+   assert(S.set_mempolicy('default'))
+   bound_numa_node = nil
+end
+
+function bind_to_numa_node (node)
+   if node == bound_numa_node then return end
+   if not node then return unbind_numa_node() end
+   assert(not bound_numa_node, "already bound")
+
+   assert(S.set_mempolicy('bind', node))
+
+   -- Migrate any pages that might have the wrong affinity.
+   local from_mask = assert(S.get_mempolicy(nil, nil, nil, 'mems_allowed')).mask
+   assert(S.migrate_pages(0, from_mask, node))
+
+   bound_numa_node = node
+end
+
+function prevent_preemption(priority)
+   if not S.sched_setscheduler(0, "fifo", priority or 1) then
+      fatal('Failed to enable real-time scheduling.  Try running as root.')
+   end
+end
+
+function selftest ()
+   print('selftest: numa')
+   bind_to_cpu(0)
+   assert(bound_cpu == 0)
+   assert(bound_numa_node == 0)
+   assert(S.getcpu().cpu == 0)
+   assert(S.getcpu().node == 0)
+   bind_to_cpu(nil)
+   assert(bound_cpu == nil)
+   assert(bound_numa_node == 0)
+   assert(S.getcpu().node == 0)
+   bind_to_numa_node(nil)
+   assert(bound_cpu == nil)
+   assert(bound_numa_node == nil)
+   print('selftest: numa: ok')
+end


### PR DESCRIPTION
This PR is a distilled port of https://github.com/Igalia/snabb/pull/341 to Snabb master, adding a couple of interfaces to ljsyscall, pulling in a getcpu() bugfix from @kbara, and then adding a Snabb module that lets you do `numa.bind_to_cpu(CPU)` in Snabb.  That will bind the current thread to that CPU, bind the memory for that thread to that CPU's NUMA node, and migrate all memory to that NUMA node.  It's ideal for hooking up to a `--cpu` command-line argument, with no `taskset` / `numactl` shenanigans, and with the additional benefit of migrating pages.  (That's what we do in the lwaftr; this commit is from Igalia/lwaftr and something we need to land upstream before merging upstream.)

The ljsyscall change is going upstream here: https://github.com/justincormack/ljsyscall/pull/193.  Embarassingly I can't yet run docker on this guixsd machine so I haven't been able to add/fix the tests upstream yet :P  However this patch does run in production, so there's that.
