### PR TITLE
apps.test.synth: send correct amount of packets per breath.

### DIFF
--- a/src/apps/test/synth.lua
+++ b/src/apps/test/synth.lua
@@ -35,9 +35,11 @@ end
 
 function Synth:pull ()
    for _, o in ipairs(self.output) do
-      for i = 1, engine.pull_npackets do
+      local n = 0
+      while n < engine.pull_npackets do
          for _, p in ipairs(self.packets) do
 	    transmit(o, packet.clone(p))
+            n = n + 1
 	 end
       end
    end


### PR DESCRIPTION
The `Synth` up would send a multiple of `engine.pull_npackets` if it had more than one `size`, now it sends `pull_npackets + (pull_npackets % #sizes)` per breath.
