### PR TITLE
Warn on ingress drop in NFV

### DIFF
--- a/src/lib/timers/ingress_drop_monitor.lua
+++ b/src/lib/timers/ingress_drop_monitor.lua
@@ -5,45 +5,61 @@ module(...,package.seeall)
 local ffi = require("ffi")
 
 -- Every 100 milliseconds.
-local interval = 1e8
+local default_interval = 1e8
 
-local with_restart = core.app.with_restart
+local default_tips_url =
+   "https://github.com/snabbco/snabb/blob/master/src/doc/performance-tuning.md"
+
 local now = core.app.now
 
-ingress_drop_monitor = {
-   threshold = 100000,
-   wait = 20,
-   last_flush = 0,
-   last_value = ffi.new('uint64_t[1]'),
-   current_value = ffi.new('uint64_t[1]'),
-}
+local IngressDropMonitor = {}
 
-function ingress_drop_monitor:sample ()
+function new(args)
+   local ret = {
+      threshold = args.threshold or 100000,
+      wait = args.wait or 20,
+      action = args.action or 'flush',
+      tips_url = args.tips_url or default_tips_url,
+      last_flush = 0,
+      last_value = ffi.new('uint64_t[1]'),
+      current_value = ffi.new('uint64_t[1]')
+   }
+   return setmetatable(ret, {__index=IngressDropMonitor})
+end
+
+function IngressDropMonitor:sample ()
    local app_array = engine.app_array
    local sum = self.current_value
    sum[0] = 0
    for i = 1, #app_array do
       local app = app_array[i]
       if app.ingress_packet_drops and not app.dead then
-         local status, value = with_restart(app, app.ingress_packet_drops)
-         if status then sum[0] = sum[0] + value end
+         sum[0] = sum[0] + app:ingress_packet_drops()
       end
    end
 end
 
-function ingress_drop_monitor:jit_flush_if_needed ()
+function IngressDropMonitor:jit_flush_if_needed ()
    if self.current_value[0] - self.last_value[0] < self.threshold then return end
    if now() - self.last_flush < self.wait then return end
    self.last_flush = now()
    self.last_value[0] = self.current_value[0]
-   jit.flush()
-   print("jit.flush")
    --- TODO: Change last_flush, last_value and current_value fields to be counters.
+   local msg = now()..": warning: Dropped more than "..self.threshold.." packets"
+   if self.action == 'flush' then
+      msg = msg.."; flushing JIT to try to recover"
+   end
+   msg = msg..". See "..self.tips_url.." for performance tuning tips."
+   print(msg)
+   if self.action == 'flush' then jit.flush() end
 end
 
-local function fn ()
-   ingress_drop_monitor:sample()
-   ingress_drop_monitor:jit_flush_if_needed()
+function IngressDropMonitor:timer(interval)
+   return timer.new("ingress drop monitor",
+                    function ()
+                       self:sample()
+                       self:jit_flush_if_needed()
+                    end,
+                    interval or default_interval,
+                    "repeating")
 end
-
-return timer.new("ingress drop monitor", fn, interval, "repeating")

--- a/src/program/snabbnfv/traffic/traffic.lua
+++ b/src/program/snabbnfv/traffic/traffic.lua
@@ -9,6 +9,7 @@ local ffi = require("ffi")
 local C = ffi.C
 local timer = require("core.timer")
 local pci = require("lib.hardware.pci")
+local ingress_drop_monitor = require("lib.timers.ingress_drop_monitor")
 local counter = require("core.counter")
 
 local long_opts = {
@@ -90,6 +91,7 @@ function traffic (pciaddr, confpath, sockpath)
    timer.activate(timer.new("reconf", check_for_reconfigure, 1e9, 'repeating'))
    -- Flush logs every second.
    timer.activate(timer.new("flush", io.flush, 1e9, 'repeating'))
+   timer.activate(ingress_drop_monitor.new({action='warn'}):timer())
    while true do
       needs_reconfigure = false
       print("Loading " .. confpath)


### PR DESCRIPTION
WDYT @lukego?  We found it useful to know when the slow part of our system was the NFV and not the guest.  Otherwise you can NACK it, that's fine, we keep it in the lwaftr as it is.

Following up with your comments from https://github.com/snabbco/snabb/pull/1039#issuecomment-254593224:

> Please allow me to zoom out for a moment, not to suggest changing this patch, but rather to map out the context for this whole ingress-drops business mostly for the sake of future directions.
> 
> Here is how I have it all in my head:
> 
> The problem we want to solve is to detect when a Snabb process is overloaded and then to run a callback. The callback could take corrective action (JIT flush) or provide diagnostics (log message).
> 
> Definition: Snabb is overloaded when the average packet arrival rate exceeds the average packet processing rate.
> 
> This means that during overload a backlog will grow on one or more ingress interfaces, and once the backlog exceeds the queue size we will start to drop packets. Conversely, during "underload" we are processing packets faster than they are arriving, on average, and this means that any backlog on ingress interfaces will be shrinking and each interface will regularly be drained empty during a pull().
> 
> So how do we detect overload? There are a bunch of conditions and we could use one or more of them as proxies:
> 
> ```
> Packets are being dropped on ingress. Pro: Closely related to overload that exceeds tolerable bounds. Con: Has to be implemented specially for each I/O driver.
> I/O interface runs out of packet buffers for receive (requires a complete refill on pull()). Pro/Con: Similar to (1) but perhaps easier/harder to implement for certain I/O drivers.
> I/O interface consistently outputs the maximum burst size on pull() i.e. ~100 packets per breath (engine.pull_npackets) meaning that the packet arrival rate is >= the packet processing rate (because otherwise the queue would be shrinking towards zero). Pro: Should work for any I/O driver with an ingress queue size >= ~100. Con: ?
> ```
> 
> So putting this into the context of detecting ingress overload on a Virtio-net interface if we don't immediately have a "dropped packets counter" for (1) then we could use (2) by detecting if every descriptor on the receive vring is occupied with a packet (no room for more) or (3) by checking if the number of packets pulled by the virtio app is consistently engine.pull_npackets.
> 
> How much of this makes sense and what am I missing?

All of what you say makes sense :)  The overloaded/underloaded terms make sense and I would be happy to detect that via any of the options, though (3) does sound appealing.  Still, detecting the precise number of packets dropped on ingress is important to some of our users and that's a useful thing too, and might even be orthogonal to a (3) solution.

I look forward to your trace-specific watchdog work -- that sounds much much better than doing a heavy-handled `jit.flush()`!
