### PR TITLE
Reset IPv4 checksum before recalculating it

### DIFF
--- a/src/lib/protocol/ipv4.lua
+++ b/src/lib/protocol/ipv4.lua
@@ -148,6 +148,7 @@ function ipv4:protocol (protocol)
 end
 
 function ipv4:checksum ()
+   self:header().checksum = 0
    self:header().checksum = htons(ipsum(ffi.cast("uint8_t *", self:header()),
                                         self:sizeof(), 0))
    return ntohs(self:header().checksum)
@@ -206,7 +207,7 @@ local function test_ipv4_checksum ()
 
    local p = packet.from_string(lib.hexundump([[
       52:54:00:02:02:02 52:54:00:01:01:01 08 00 45 00
-      00 34 59 1a 40 00 40 06 00 00 c0 a8 14 a9 6b 15
+      00 34 59 1a 40 00 40 06 b0 8e c0 a8 14 a9 6b 15
       f0 b4 de 0b 01 bb e7 db 57 bc 91 cd 18 32 80 10
       05 9f 00 00 00 00 01 01 08 0a 06 0c 5c bd fa 4a
       e1 65


### PR DESCRIPTION
Checksum method in `lib/protocol/ipv4.lua` always recalculates an IPv4 header checksum. The checksum field must be set to zero before recalculation.

There was a checksum unit test function in the module but it couldn't detect this error because the sample packet had its checksum field equals to zero.
