### PR TITLE
README.md: link to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ join the [snabb-devel mailing
 list](https://groups.google.com/forum/#!forum/snabb-devel) and read
 on.
 
+## Documentation
+
+- [API Reference](http://snabbco.github.io/)
+- [Contributor Hints](https://github.com/snabbco/snabb/blob/master/CONTRIBUTING.md#hints-for-contributors)
+
 ## How does it work?
 
 Snabb is written using these main techniques:
@@ -119,4 +124,3 @@ Here are the ways you can get involved:
 - Join the [snabb-devel mailing list](https://groups.google.com/forum/#!forum/snabb-devel).
 - Send a mail to [introduce yourself](https://groups.google.com/forum/#!searchin/snabb-devel/introduce/snabb-devel/d8t6hGClnQY/flztyLiIGzoJ) to the community (don't be shy!).
 - Create your very own application: [Getting Started](src/doc/getting-started.md).
-


### PR DESCRIPTION
For me this is a no-brainer, we have fairly detailed documentation but no obvious public reference towards it. This puts a reference in a place where people looking for it will likely find it.