### PR TITLE
[wip] Add JIT optimization tool: lib.specialize(fn)

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -909,6 +909,19 @@ lib.parse({foo=42, bar=43}, {foo={required=true}, bar={}, baz={default=44}})
   => {foo=42, bar=43, baz=44}
 ```
 
+— Function **lib.specialize** *function*
+
+Returns a clone of the given function with a shallow copy of its
+function definition. The clone function has a separate bytecode
+definition and any JIT traces that start in the clone will be
+aggressively specialized by LuaJIT for the environment of the clone.
+
+This can lead to especially efficient machine code when:
+- The function being specialized contains a loop (`for` or `while` or `repeat`) directly in its source code (not in a subroutine because the bytecode cloning is shallow).
+- The function will benefit from being compiled separately from other uses, for example because the way the clone will be called is expected to lead to a peculiar flow of control.
+- The function refers to values in its closure environment, which the JIT will treat more like constants than variables.
+
+See background information at [LuaJIT/LuaJIT#208](https://github.com/LuaJIT/LuaJIT/issues/208).
 
 ## Main
 

--- a/src/core/app.lua
+++ b/src/core/app.lua
@@ -196,6 +196,7 @@ function apply_config_actions (actions, conf)
          app.shm.dtime = {counter, C.get_unix_time()}
          app.shm = shm.create_frame("apps/"..name, app.shm)
       end
+      specialize(app)
    end
    function ops.restart (name)
       ops.stop(name)
@@ -209,6 +210,7 @@ function apply_config_actions (actions, conf)
          new_app_table[name] = app
          table.insert(new_app_array, app)
          app_name_to_index[name] = #new_app_array
+         specialize(app)
       else
          ops.restart(name)
       end
@@ -250,6 +252,13 @@ function apply_config_actions (actions, conf)
    for _, app in ipairs(app_array) do
       if app.link then app:link() end
    end
+end
+
+-- Specialize an app so that its pull and push methods can be JITed
+-- into instance-specific machine code.
+function specialize (app)
+   if app.pull then app.pull = lib.specialize(app.pull) end
+   if app.push then app.push = lib.specialize(app.push) end
 end
 
 -- Call this to "run snabb switch".

--- a/src/core/lib.lua
+++ b/src/core/lib.lua
@@ -738,6 +738,24 @@ function parse (arg, config)
    return ret
 end
 
+-- Return a clone of the given function with separate bytecode.
+-- (Code taken from http://leafo.net/guides/function-cloning-in-lua.html)
+function specialize (fn)
+  local dumped = string.dump(fn)
+  local cloned = loadstring(dumped)
+  local i = 1
+  while true do
+    local name = debug.getupvalue(fn, i)
+    if not name then
+      break
+    end
+    debug.upvaluejoin(cloned, i, fn, i)
+    i = i + 1
+  end
+  return cloned
+end
+
+
 function selftest ()
    print("selftest: lib")
    print("Testing equal")


### PR DESCRIPTION
This branch contains a work-in-progress "design pattern" for making LuaJIT perform really aggressive optimizations under certain circumstances. This is based on the same technique that was recently used to optimize vhost-user (#1001).

The high-level intention is to make the `pull()` and `push()` methods of each app _instance_ be JITed individually and to treat the app configuration parameters as if they were constants. JITing instances separately means that each one will have dedicated machine code and they will not interfere with each other (for example no collisions between instances like the ctype diversity in #612). Treating configuration parameters as constants is essentially "inlining" the configuration values as if they were written as constants in the source file i.e. allowing the optimizer to take advantage of their exact values. (The methods are re-JITed when the app configuration changes.)

The JIT is able to take this even further and to generate machine code that reference singleton objects (such as the app `self` object) using absolute addresses so it is not even necessary to assign a register to hold the address.

Likely some experience will be needed in order to use this feature effectively. Can also be that certain of these benefits are already available in practice without using this special feature.

Notably this will only be effective for apps that start _JIT traces_ in their pull or push methods, which is loosely any app that includes a loop (`for`, `while`, or `repeat`) directly in its pull or push method. If we wanted this to also affect traces started in subroutines then we would need to take a slightly different approach. Could be that we can formulate this in a better way that is easier to understand. Caveat emptor.

This is intended as part of an overall effort to better understand the internal workings of LuaJIT in order to eventually explain them concisely and potentially also to identify tricks for generating code better than what is possible with an ahead-of-time static compiler.

See background discussion at LuaJIT/LuaJIT#208.
