### PR TITLE
IPsec: update Snabb NFV integration

### DIFF
--- a/src/apps/ipsec/README.md
+++ b/src/apps/ipsec/README.md
@@ -2,16 +2,12 @@
 
 ## AES128gcm (apps.ipsec.esp)
 
-The `AES128gcm` implements an ESP transport tunnel using the AES-GCM-128
+The `AES128gcm` implements ESP in transport mode using the AES-GCM-128
 cipher. It encrypts packets received on its `decapsulated` port and transmits
 them on its `encapsulated` port, and vice-versa. Packets arriving on the
 `decapsulated` port must have an IPv6 header, and packets arriving on the
 `encapsulated` port must have an IPv6 header followed by an ESP header,
 otherwise they will be discarded.
-
-References:
-
- - `lib.ipsec.esp`
 
     DIAGRAM: AES128gcm
                    +-----------+
@@ -26,6 +22,10 @@ References:
               <-------|---/ /------->
                       \-----/      decapsulated
 
+References:
+
+ - `lib.ipsec.esp`
+
 ### Configuration
 
 The `AES128gcm` app accepts a table as its configuration argument. The
@@ -33,12 +33,49 @@ following keys are defined:
 
 — Key **spi**
 
-*Required*. Security Parameter Index. A 32 bit integer.
+*Required*. A 32 bit integer denoting the “Security Parameters Index” as
+specified in RFC 4303.
 
-— Key **key**
+— Key **transmit_key**
 
-*Required*. 20 bytes in form of a hex encoded string.
+*Required*. Hexadecimal string of 32 digits (two digits for each byte) that
+denotes a 128-bit AES key as specified in RFC 4106 used for the encryption of
+outgoing packets.
 
-— Key **replay_window**
+— Key **transmit_salt**
 
-*Optional*. Size of the “Anti-Replay Window”. Defaults to 128.
+*Required*. Hexadecimal string of eight digits (two digits for each byte) that
+denotes four bytes of salt as specified in RFC 4106 used for the encryption of
+outgoing packets..
+
+— Key **receive_key**
+
+*Required*. Hexadecimal string of 32 digits (two digits for each byte) that
+denotes a 128-bit AES key as specified in RFC 4106 used for the decryption of
+incoming packets.
+
+— Key **receive_salt**
+
+*Required*. Hexadecimal string of eight digits (two digits for each byte) that
+denotes four bytes of salt as specified in RFC 4106 used for the decryption of
+incoming packets.
+
+— Key **receive_window**
+
+*Optional*. Minimum width of the window in which out of order packets are
+accepted as specified in RFC 4303. The default is 128.
+
+— Key **resync_threshold**
+
+Optional*. Number of consecutive packets allowed to fail decapsulation before
+attempting “Re-synchronization” as specified in RFC 4303. The default is 1024.
+
+— Key **resync_attempts**
+
+*Optional*. Number of attempts to re-synchronize a packet that triggered
+“Re-synchronization” as specified in RFC 4303. The default is 8.
+
+— Key **auditing**
+
+*Optional.* A boolean value indicating whether to enable or disable “Auditing”
+as specified in RFC 4303. The default is `nil` (no auditing).

--- a/src/apps/ipsec/README.md
+++ b/src/apps/ipsec/README.md
@@ -46,7 +46,7 @@ outgoing packets.
 
 *Required*. Hexadecimal string of eight digits (two digits for each byte) that
 denotes four bytes of salt as specified in RFC 4106 used for the encryption of
-outgoing packets..
+outgoing packets.
 
 — Key **receive_key**
 
@@ -67,7 +67,7 @@ accepted as specified in RFC 4303. The default is 128.
 
 — Key **resync_threshold**
 
-Optional*. Number of consecutive packets allowed to fail decapsulation before
+*Optional*. Number of consecutive packets allowed to fail decapsulation before
 attempting “Re-synchronization” as specified in RFC 4303. The default is 1024.
 
 — Key **resync_attempts**

--- a/src/apps/ipsec/esp.lua
+++ b/src/apps/ipsec/esp.lua
@@ -27,6 +27,8 @@ AES128gcm = {
 
 function AES128gcm:new (conf)
    local self = {}
+   assert(conf.transmit_salt ~= conf.receive_salt,
+          "Refusing to operate with transmit_salt == receive_salt")
    self.encrypt = esp.esp_v6_encrypt:new{
       mode = "aes-128-gcm",
       spi = conf.spi,

--- a/src/apps/ipsec/esp.lua
+++ b/src/apps/ipsec/esp.lua
@@ -10,7 +10,15 @@ local C = require("ffi").C
 
 AES128gcm = {
    config = {
-      spi = {required=true}, key = {required=true}, window_size = {}
+      spi = {required=true},
+      transmit_key = {required=true},
+      transmit_salt =  {required=true},
+      receive_key = {required=true},
+      receive_salt =  {required=true},
+      receive_window = {},
+      resync_threshold = {},
+      resync_attempts = {},
+      auditing = {}
    },
    shm = {
       txerrors = {counter}, rxerrors = {counter}
@@ -22,14 +30,17 @@ function AES128gcm:new (conf)
    self.encrypt = esp.esp_v6_encrypt:new{
       mode = "aes-128-gcm",
       spi = conf.spi,
-      keymat = conf.key:sub(1, 32),
-      salt = conf.key:sub(33, 40)}
+      key = conf.transmit_key,
+      salt = conf.transmit_salt}
    self.decrypt = esp.esp_v6_decrypt:new{
       mode = "aes-128-gcm",
       spi = conf.spi,
-      keymat = conf.key:sub(1, 32),
-      salt = conf.key:sub(33, 40),
-      window_size = conf.replay_window}
+      key = conf.receive_key,
+      salt = conf.receive_salt,
+      window_size = conf.receive_window,
+      resync_threshold = conf.resync_threshold,
+      resync_attempts = conf.resync_attempts,
+      auditing = conf.auditing}
    return setmetatable(self, {__index = AES128gcm})
 end
 

--- a/src/doc/genbook.sh
+++ b/src/doc/genbook.sh
@@ -54,6 +54,8 @@ $(cat $mdroot/apps/vpn/README.md)
 
 $(cat $mdroot/apps/socket/README.md)
 
+$(cat $mdroot/apps/ipsec/README.md)
+
 # Libraries
 
 $(cat $mdroot/lib/README.checksum.md)
@@ -72,7 +74,7 @@ $(cat $mdroot/lib/protocol/README.md)
 
 ## IPsec
 
-$(cat ../lib/ipsec/README.md)
+$(cat $mdroot/lib/ipsec/README.md)
 
 ## Snabb NFV
 

--- a/src/lib/ipsec/README.md
+++ b/src/lib/ipsec/README.md
@@ -13,12 +13,25 @@ UDP, L2TPv3) and also encrypts the contents of the inner protocol
 header. The decrypt class does the reverse: it decrypts the inner
 protocol header and removes the ESP protocol header.
 
-Anti-replay protection as well as recovery from synchronization loss due to
-excessive packet loss are *not* implemented.
+    DIAGRAM: ESP-Transport
+         BEFORE ENCAPSULATION
+    +-----------+-------------+------------+
+    |orig Ether‑| orig IP Hdr |            |
+    |net Hdr    |(any options)|  Payload   |
+    +-----------+-------------+------------+
+    
+         AFTER ENCAPSULATION
+    +-----------+-------------+-----+------------+---------+----+
+    |orig Ether‑| orig IP Hd  | ESP |            |   ESP   | ESP|
+    |net Hdr    |(any options)| Hdr |  Payload   | Trailer | ICV|
+    +-----------+-------------+-----+------------+---------+----+
+                                     <-----encryption----->
+                               <---------integrity-------->
 
 References:
 
 - [IPsec Wikipedia page](https://en.wikipedia.org/wiki/IPsec).
+- [RFC 4303](https://tools.ietf.org/html/rfc4303) on IPsec ESP.
 - [RFC 4106](https://tools.ietf.org/html/rfc4106) on using AES-GCM with IPsec ESP.
 - [LISP Data-Plane Confidentiality](https://tools.ietf.org/html/draft-ietf-lisp-crypto-02) example of a software layer above these apps that includes key exchange.
 
@@ -31,19 +44,21 @@ be a table with the following keys:
 
 * `mode` - Encryption mode (string). The only accepted value is the
   string `"aes-128-gcm"`.
-* `keymat` - Hex string containing 16 bytes of key material as specified
-  in RFC 4106.
-* `salt` - Hex string containing four bytes of salt as specified in
-  RFC 4106.
-* `spi` - “Security Parameter Index” as specified in RFC 4303.
-* `window_size` - *Optional*. Width of the window in which out of order packets
-  are accepted. The default is 128. (`esp_v6_decrypt` only.)
-* `resync_threshold` - *Optional*. Number of consecutive packets allowed to
-  fail decapsulation before attempting re-synchronization. The default is
-  10000. (`esp_v6_decrypt` only.)
-* `resync_attempts` - *Optional*. Number of attempts to re-synchronize
-  a packet that triggered re-synchronization. The default is 10.
+* `spi` - A 32 bit integer denoting the “Security Parameters Index” as
+  specified in RFC 4303.
+* `key` - Hexadecimal string of 32 digits (two digits for each byte) that
+  denotes a 128-bit AES key as specified in RFC 4106.
+* `salt` - Hexadecimal string of eight digits (two digits for each byte) that
+  denotes four bytes of salt as specified in RFC 4106.
+* `window_size` - *Optional*. Minimum width of the window in which out of order
+  packets are accepted as specified in RFC 4303. The default is 128.
   (`esp_v6_decrypt` only.)
+* `resync_threshold` - *Optional*. Number of consecutive packets allowed to
+  fail decapsulation before attempting “Re-synchronization” as specified in
+  RFC 4303. The default is 1024. (`esp_v6_decrypt` only.)
+* `resync_attempts` - *Optional*. Number of attempts to re-synchronize
+  a packet that triggered “Re-synchronization” as specified in RFC 4303. The
+  default is 8. (`esp_v6_decrypt` only.)
 * `auditing` - *Optional.* A boolean value indicating whether to enable or
   disable “Auditing” as specified in RFC 4303. The default is `nil` (no
   auditing). (`esp_v6_decrypt` only.)

--- a/src/lib/ipsec/aes_128_gcm.lua
+++ b/src/lib/ipsec/aes_128_gcm.lua
@@ -68,21 +68,21 @@ end
 local function u8_ptr (ptr) return ffi.cast("uint8_t *", ptr) end
 
 -- Encrypt a single 128-bit block with the basic AES block cipher.
-local function aes_128_block (block, keymat)
+local function aes_128_block (block, key)
    local gcm_data = ffi.new("gcm_data __attribute__((aligned(16)))")
-   ASM.aes_keyexp_128_enc_avx(keymat, gcm_data)
+   ASM.aes_keyexp_128_enc_avx(key, gcm_data)
    ASM.aesni_encrypt_single_block(gcm_data, block)
 end
 
 local aes_128_gcm = {}
 
-function aes_128_gcm:new (spi, keymat, salt)
+function aes_128_gcm:new (spi, key, salt)
    assert(spi, "Need SPI.")
-   assert(keymat and #keymat == 32, "Need 16 bytes of key material.")
+   assert(key and #key == 32, "Need 16 bytes of key material.")
    assert(salt and #salt == 8, "Need 4 bytes of salt.")
    local o = {}
-   o.keymat = ffi.new("uint8_t[16]")
-   ffi.copy(o.keymat, lib.hexundump(keymat, 16), 16)
+   o.key = ffi.new("uint8_t[16]")
+   ffi.copy(o.key, lib.hexundump(key, 16), 16)
    o.IV_SIZE = 8
    o.iv = iv:new(lib.hexundump(salt, 4))
    o.AUTH_SIZE = 16
@@ -91,9 +91,9 @@ function aes_128_gcm:new (spi, keymat, salt)
    o.aad = aad:new(spi)
    -- Compute subkey (H)
    o.hash_subkey = ffi.new("uint8_t[?] __attribute__((aligned(16)))", 16)
-   aes_128_block(o.hash_subkey, o.keymat)
+   aes_128_block(o.hash_subkey, o.key)
    o.gcm_data = ffi.new("gcm_data __attribute__((aligned(16)))")
-   ASM.aes_keyexp_128_enc_avx(o.keymat, o.gcm_data)
+   ASM.aes_keyexp_128_enc_avx(o.key, o.gcm_data)
    ASM.aesni_gcm_precomp_avx_gen4(o.gcm_data, o.hash_subkey)
    return setmetatable(o, {__index=aes_128_gcm})
 end

--- a/src/lib/ipsec/esp.lua
+++ b/src/lib/ipsec/esp.lua
@@ -115,9 +115,9 @@ function esp_v6_decrypt:new (conf)
    o.CTEXT_OFFSET = ESP_SIZE + gcm.IV_SIZE
    o.PLAIN_OVERHEAD = PAYLOAD_OFFSET + ESP_SIZE + gcm.IV_SIZE + gcm.AUTH_SIZE
    o.window_size = conf.window_size or 128
+   o.window_size = o.window_size + padding(8, o.window_size)
    o.resync_threshold = conf.resync_threshold or 1024
    o.resync_attempts = conf.resync_attempts or 8
-   assert(o.window_size % 8 == 0, "window_size must be a multiple of 8.")
    o.window = ffi.new(window_t, o.window_size / 8)
    o.decap_fail = 0
    o.auditing = conf.auditing

--- a/src/lib/ipsec/esp.lua
+++ b/src/lib/ipsec/esp.lua
@@ -42,7 +42,7 @@ local ESP_TAIL_SIZE = esp_tail:sizeof()
 function esp_v6_new (conf)
    assert(conf.mode == "aes-128-gcm", "Only supports aes-128-gcm.")
    assert(conf.spi, "Need SPI.")
-   local gcm = aes_128_gcm:new(conf.spi, conf.keymat, conf.salt)
+   local gcm = aes_128_gcm:new(conf.spi, conf.key, conf.salt)
    local o = {}
    o.ESP_OVERHEAD = ESP_SIZE + ESP_TAIL_SIZE + gcm.IV_SIZE + gcm.AUTH_SIZE
    o.aes_128_gcm = gcm
@@ -214,7 +214,7 @@ function selftest ()
    local ipv6 = require("lib.protocol.ipv6")
    local conf = { spi = 0x0,
                   mode = "aes-128-gcm",
-                  keymat = "00112233445566778899AABBCCDDEEFF",
+                  key = "00112233445566778899AABBCCDDEEFF",
                   salt = "00112233",
                   resync_threshold = 16,
                   resync_attempts = 8}

--- a/src/program/snabbmark/snabbmark.lua
+++ b/src/program/snabbmark/snabbmark.lua
@@ -352,7 +352,7 @@ function esp (npackets, packet_size, mode, profile)
    local plain = d:packet()
    local conf = { spi = 0x0,
                   mode = "aes-128-gcm",
-                  keymat = "00112233445566778899AABBCCDDEEFF",
+                  key = "00112233445566778899AABBCCDDEEFF",
                   salt = "00112233"}
    local enc, dec = esp.esp_v6_encrypt:new(conf), esp.esp_v6_decrypt:new(conf)
 

--- a/src/program/snabbnfv/README.md
+++ b/src/program/snabbnfv/README.md
@@ -69,13 +69,16 @@ tunnel := { type          = "L2TPv3",     -- The only type (for now)
 ```
 
 The `crypto` section allows configuration of traffic encryption based on
-`apps.esp`:
+`apps.ipsec.esp`:
 
 ```
 crypto := { type          = "esp-aes-128-gcm", -- The only type (for now)
-            spi           = <spi>,             -- Security Parameter Index
-            key           = <key>,             -- 20 bytes as a hex encoded string
-            replay_window = <n> }              -- Replay window
+            spi           = <spi>,             -- As for AES128gcm
+            transmit_key  = <key>,
+            transmit_salt = <salt>,
+            receive_key   = <key>,
+            receive_salt  = <salt>,
+            auditing      = <boolean> }
 ```
 
 

--- a/src/program/snabbnfv/nfvconfig.lua
+++ b/src/program/snabbnfv/nfvconfig.lua
@@ -89,8 +89,11 @@ function load (file, pciaddr, sockpath, soft_bench)
          local Crypto = name.."_Crypto"
          config.app(c, Crypto, AES128gcm,
                     {spi = t.crypto.spi,
-                     key = t.crypto.key,
-                     replay_window = t.crypto.replay_window})
+                     transmit_key = t.crypto.transmit_key,
+                     transmit_salt = t.crypto.transmit_salt,
+                     receive_key = t.crypto.receive_key,
+                     receive_salt = t.crypto.receive_salt,
+                     auditing = t.crypto.auditing})
          config.link(c, VM_tx.." -> "..Crypto..".decapsulated")
          config.link(c, Crypto..".decapsulated -> "..VM_rx)
          VM_rx, VM_tx = Crypto..".encapsulated", Crypto..".encapsulated"

--- a/src/program/snabbnfv/test_fixtures/nfvconfig/test_functions/crypto-tunnel.ports
+++ b/src/program/snabbnfv/test_fixtures/nfvconfig/test_functions/crypto-tunnel.ports
@@ -11,7 +11,10 @@ return {
                next_hop = "fe80:0:0:0:5054:ff:fe00:1" },
     crypto = { type = "esp-aes-128-gcm",
                spi = 0x42,
-               key = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef", }
+               transmit_key = "deadbeefdeadbeefdeadbeefdeadbeef",
+               transmit_salt = "deadbeef",
+               receive_key = "beefdeadbeefdeadbeefdeadbeefdead",
+               receive_salt = "beefdead" }
   },
   { vlan = 43,
     mac_address = "52:54:00:00:00:01",
@@ -25,6 +28,9 @@ return {
                next_hop = "fe80:0:0:0:5054:ff:fe00:0" },
     crypto = { type = "esp-aes-128-gcm",
                spi = 0x42,
-               key = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef", }
+               transmit_key = "beefdeadbeefdeadbeefdeadbeefdead",
+               transmit_salt = "beefdead",
+               receive_key = "deadbeefdeadbeefdeadbeefdeadbeef",
+               receive_salt = "deadbeef" }
   },
 }

--- a/src/program/snabbnfv/test_fixtures/nfvconfig/test_functions/crypto.ports
+++ b/src/program/snabbnfv/test_fixtures/nfvconfig/test_functions/crypto.ports
@@ -4,13 +4,19 @@ return {
     port_id = "A",
     crypto = { type = "esp-aes-128-gcm",
                spi = 0x42,
-               key = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef", }
+               transmit_key = "deadbeefdeadbeefdeadbeefdeadbeef",
+               transmit_salt = "deadbeef",
+               receive_key = "beefdeadbeefdeadbeefdeadbeefdead",
+               receive_salt = "beefdead" }
   },
   { vlan = 43,
     mac_address = "52:54:00:00:00:01",
     port_id = "B",
     crypto = { type = "esp-aes-128-gcm",
                spi = 0x42,
-               key = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef", }
+               transmit_key = "beefdeadbeefdeadbeefdeadbeefdead",
+               transmit_salt = "beefdead",
+               receive_key = "deadbeefdeadbeefdeadbeefdeadbeef",
+               receive_salt = "deadbeef" }
   },
 }

--- a/src/program/snabbnfv/traffic/README
+++ b/src/program/snabbnfv/traffic/README
@@ -61,7 +61,10 @@ CONFIG FILE FORMAT:
   apps.ipsec.esp:
 
 
-      crypto := { type = "esp-aes-128-gcm", -- The only type (for now)
-                  spi = <spi>,              -- Security Parameter Index
-                  key = <key>,              -- 20 bytes as a hex encoded string
-                  replay_window = <n> }     -- Replay window
+      crypto := { type          = "esp-aes-128-gcm", -- The only type (for now)
+                  spi           = <spi>,             -- As for AES128gcm
+                  transmit_key  = <key>,
+                  transmit_salt = <salt>,
+                  receive_key   = <key>,
+                  receive_salt  = <salt>,
+                  auditing      = <boolean> }


### PR DESCRIPTION
This fixes a critical bug in the ESP transport feature in Snabb NFV where the same key material was used for both streams (transmit/receive). A sanity check has been added to `lib.ipsec.esp` to make this misuse impossible.

Use of the confusing term “keymat” is avoided, key/salt is now always specified separately.

`window_size` is now automatically padded to a multiple of eight to loosen the restriction on the configuration value.

Documentation is updated and extended.

Cc @vanfstd 