### PR TITLE
Optimize reconfiguration

### DIFF
--- a/src/core/app.lua
+++ b/src/core/app.lua
@@ -95,19 +95,19 @@ function restart_dead_apps ()
 
    for name, app in pairs(app_table) do
       if app.dead and (now() - app.dead.time) >= restart_delay then
-         local function add_action(action, ...)
-            table.insert(actions, { action, { ... } })
-         end
          io.stderr:write(("Restarting %s (died at %f: %s)\n")
                          :format(name, app.dead.time, app.dead.error))
-         add_action('stop_app', name)
-         add_action('start_app', name,
-                    configuration.apps[name].class,
-                    configuration.apps[name].arg)
+         local info = configuration.apps[name]
+         table.insert(actions, {'stop_app', {name}})
+         table.insert(actions, {'start_app', {name, info.class, info.arg}})
          for linkspec in pairs(configuration.links) do
             local fa, fl, ta, tl = config.parse_link(linkspec)
-            if fa == name then add_action('link_output', fa, fl, linkspec) end
-            if ta == name then add_action('link_input', ta, tl, linkspec) end
+            if fa == name then
+               table.insert(actions, {'link_output', {fa, fl, linkspec}})
+            end
+            if ta == name then
+               table.insert(actions, {'link_input', {ta, tl, linkspec}})
+            end
          end
       end
    end

--- a/src/core/app.lua
+++ b/src/core/app.lua
@@ -214,12 +214,14 @@ function apply_config_actions (actions)
       local link = app.output[linkname]
       app.output[linkname] = nil
       remove_link_from_array(app.output, link)
+      if app.link then app:link() end
    end
    function ops.unlink_input (appname, linkname)
       local app = app_table[appname]
       local link = app.input[linkname]
       app.input[linkname] = nil
       remove_link_from_array(app.input, link)
+      if app.link then app:link() end
    end
    function ops.free_link (linkspec)
       link.free(link_table[linkspec], linkspec)
@@ -235,12 +237,14 @@ function apply_config_actions (actions)
       local link = assert(link_table[linkspec])
       app.output[linkname] = link
       table.insert(app.output, link)
+      if app.link then app:link() end
    end
    function ops.link_input (appname, linkname, linkspec)
       local app = app_table[appname]
       local link = assert(link_table[linkspec])
       app.input[linkname] = link
       table.insert(app.input, link)
+      if app.link then app:link() end
    end
    function ops.stop_app (name)
       local app = app_table[name]

--- a/src/core/app.lua
+++ b/src/core/app.lua
@@ -267,7 +267,7 @@ function apply_config_actions (actions)
       end
       configuration.apps[name] = { class = class, arg = arg }
    end
-   function ops.reconfig (name, arg)
+   function ops.reconfig_app (name, arg)
       local app = app_table[name]
       app:reconfig(arg)
       configuration.apps[name].arg = arg

--- a/src/core/app.lua
+++ b/src/core/app.lua
@@ -253,8 +253,8 @@ function apply_config_actions (actions, conf)
    compute_breathe_order ()
 end
 
--- Sort the NODES that are reachable from ENTRIES topologically
--- according to SUCCESSORS via reverse-post-order numbering.  This
+-- Sort the NODES topologically according to SUCCESSORS via
+-- reverse-post-order numbering.  The sort starts with ENTRIES.  This
 -- implementation is recursive; we should change it to be iterative
 -- instead.
 function tsort (nodes, entries, successors)
@@ -268,6 +268,9 @@ function tsort (nodes, entries, successors)
       table.insert(post_order, node)
    end
    for _,node in ipairs(entries) do
+      if not visited[node] then visit(node) end
+   end
+   for _,node in ipairs(nodes) do
       if not visited[node] then visit(node) end
    end
    local ret = {}
@@ -294,6 +297,14 @@ function compute_breathe_order ()
       successors[app] = succs
    end
    breathe_push_order = tsort(app_array, breathe_pull_order, successors)
+   local i = 1
+   while i <= #breathe_push_order do
+      if breathe_push_order[i].push then
+         i = i + 1
+      else
+         table.remove(breathe_push_order, i)
+      end
+   end
 end
 
 -- Call this to "run snabb switch".

--- a/src/core/app.lua
+++ b/src/core/app.lua
@@ -25,10 +25,8 @@ local use_restart = false
 
 test_skipped_code = 43
 
--- The set of all active apps and links in the system.
--- Indexed both by name (in a table) and by number (in an array).
-app_table,  app_array  = {}, {}
-link_table, link_array = {}, {}
+-- The set of all active apps and links in the system, indexed by name.
+app_table, link_table = {}, {}
 
 configuration = config.new()
 
@@ -96,9 +94,7 @@ function restart_dead_apps ()
    local actions = { start={}, restart={}, reconfig={}, keep={}, stop={} }
    local restart = false
 
-   -- Collect 'restart' actions for dead apps and log their errors.
-   for i = 1, #app_array do
-      local app = app_array[i]
+   for name, app in pairs(app_table) do
       if app.dead and (now() - app.dead.time) >= restart_delay then
          restart = true
          io.stderr:write(("Restarting %s (died at %f: %s)\n")
@@ -157,10 +153,7 @@ end
 -- Update the active app network by applying the necessary actions.
 function apply_config_actions (actions, conf)
    -- The purpose of this function is to populate these tables:
-   local new_app_table,  new_app_array  = {}, {}
-   local new_link_table, new_link_array = {}, {}
-   -- Temporary name->index table for use in link renumbering
-   local app_name_to_index = {}
+   local new_app_table, new_link_table = {}, {}
    -- Table of functions that execute config actions
    local ops = {}
    function ops.stop (name)
@@ -173,8 +166,6 @@ function apply_config_actions (actions, conf)
    end
    function ops.keep (name)
       new_app_table[name] = app_table[name]
-      table.insert(new_app_array, app_table[name])
-      app_name_to_index[name] = #new_app_array
    end
    function ops.start (name)
       local class = conf.apps[name].class
@@ -189,8 +180,6 @@ function apply_config_actions (actions, conf)
       app.output = {}
       app.input = {}
       new_app_table[name] = app
-      table.insert(new_app_array, app)
-      app_name_to_index[name] = #new_app_array
       app.zone = zone
       if app.shm then
          app.shm.dtime = {counter, C.get_unix_time()}
@@ -207,8 +196,6 @@ function apply_config_actions (actions, conf)
          local app = app_table[name]
          app:reconfig(arg)
          new_app_table[name] = app
-         table.insert(new_app_array, app)
-         app_name_to_index[name] = #new_app_array
       else
          ops.restart(name)
       end
@@ -229,7 +216,6 @@ function apply_config_actions (actions, conf)
       if not new_app_table[ta] then error("no such app: " .. ta) end
       -- Create or reuse a link and assign/update receiving app index
       local link = link_table[linkspec] or link.new(linkspec)
-      link.receiving_app = app_name_to_index[ta]
       -- Add link to apps
       new_app_table[fa].output[fl] = link
       table.insert(new_app_table[fa].output, link)
@@ -237,7 +223,6 @@ function apply_config_actions (actions, conf)
       table.insert(new_app_table[ta].input, link)
       -- Remember link
       new_link_table[linkspec] = link
-      table.insert(new_link_array, link)
    end
    -- Free obsolete links.
    for linkspec, r in pairs(link_table) do
@@ -245,9 +230,8 @@ function apply_config_actions (actions, conf)
    end
    -- Commit changes.
    app_table, link_table = new_app_table, new_link_table
-   app_array, link_array = new_app_array, new_link_array
    -- Trigger link event for each app.
-   for _, app in ipairs(app_array) do
+   for name, app in pairs(app_table) do
       if app.link then app:link() end
    end
    compute_breathe_order ()
@@ -270,7 +254,7 @@ function tsort (nodes, entries, successors)
    for _,node in ipairs(entries) do
       if not visited[node] then visit(node) end
    end
-   for _,node in ipairs(nodes) do
+   for name,node in pairs(nodes) do
       if not visited[node] then visit(node) end
    end
    local ret = {}
@@ -286,17 +270,17 @@ breathe_push_order = {}
 function compute_breathe_order ()
    breathe_pull_order = {}
    local inputs = {}
-   for i, app in ipairs(app_array) do
+   for name, app in pairs(app_table) do
       if app.pull then table.insert(breathe_pull_order, app) end
       for _,link in pairs(app.input) do inputs[link] = app  end
    end
    local successors = {}
-   for i, app in ipairs(app_array) do
+   for name, app in pairs(app_table) do
       local succs = {}
       for _,link in pairs(app.output) do table.insert(succs, inputs[link]) end
       successors[app] = succs
    end
-   breathe_push_order = tsort(app_array, breathe_pull_order, successors)
+   breathe_push_order = tsort(app_table, breathe_pull_order, successors)
    local i = 1
    while i <= #breathe_push_order do
       if breathe_push_order[i].push then
@@ -481,7 +465,7 @@ end
 
 function selftest ()
    print("selftest: app")
-   local App = {}
+   local App = { push = true }
    function App:new () return setmetatable({}, {__index = App}) end
    local c1 = config.new()
    config.app(c1, "app1", App)
@@ -489,12 +473,12 @@ function selftest ()
    config.link(c1, "app1.x -> app2.x")
    print("empty -> c1")
    configure(c1)
-   assert(#app_array == 2)
-   assert(#link_array == 1)
+   assert(#breathe_pull_order == 0)
+   assert(#breathe_push_order == 2)
    assert(app_table.app1 and app_table.app2)
    local orig_app1 = app_table.app1
    local orig_app2 = app_table.app2
-   local orig_link = link_array[1]
+   local orig_link = link_table['app1.x -> app2.x']
    print("c1 -> c1")
    configure(c1)
    assert(app_table.app1 == orig_app1)
@@ -506,8 +490,8 @@ function selftest ()
    config.link(c2, "app2.x -> app1.x")
    print("c1 -> c2")
    configure(c2)
-   assert(#app_array == 2)
-   assert(#link_array == 2)
+   assert(#breathe_pull_order == 0)
+   assert(#breathe_push_order == 2)
    assert(app_table.app1 ~= orig_app1) -- should be restarted
    assert(app_table.app2 == orig_app2) -- should be the same
    -- tostring() because == does not work on FFI structs?
@@ -516,12 +500,12 @@ function selftest ()
    configure(c1) -- c2 -> c1
    assert(app_table.app1 ~= orig_app1) -- should be restarted
    assert(app_table.app2 == orig_app2) -- should be the same
-   assert(#app_array == 2)
-   assert(#link_array == 1)
+   assert(#breathe_pull_order == 0)
+   assert(#breathe_push_order == 2)
    print("c1 -> empty")
    configure(config.new())
-   assert(#app_array == 0)
-   assert(#link_array == 0)
+   assert(#breathe_pull_order == 0)
+   assert(#breathe_push_order == 0)
    -- Test app arg validation
    local AppC = {
       config = {
@@ -560,8 +544,6 @@ function selftest ()
    local orig_app1 = app_table.app1
    local orig_app2 = app_table.app2
    local orig_app3 = app_table.app3
-   local orig_link1 = link_array[1]
-   local orig_link2 = link_array[2]
    main({duration = 4, report = {showapps = true}})
    assert(app_table.app1 ~= orig_app1) -- should be restarted
    assert(app_table.app2 ~= orig_app2) -- should be restarted

--- a/src/core/app.lua
+++ b/src/core/app.lua
@@ -137,9 +137,9 @@ function compute_config_actions (old, new)
    for linkspec in pairs(old.links) do
       if not new.links[linkspec] then
          local fa, fl, ta, tl = config.parse_link(linkspec)
-         if old.apps[fa] then add_action('unlink_output', fa, fl) end
-         if old.apps[ta] then add_action('unlink_input', ta, tl) end
-         if not new[linkspec] then add_action('free_link', linkspec) end
+         add_action('unlink_output', fa, fl)
+         add_action('unlink_input', ta, tl)
+         add_action('free_link', linkspec)
       end
    end
 

--- a/src/core/link.h
+++ b/src/core/link.h
@@ -15,12 +15,5 @@ struct link {
   //   read:  the next element to be read
   //   write: the next element to be written
   int read, write;
-  // Index (into the Lua app.active_apps array) of the app that
-  // receives from this link.
-  int receiving_app;
-  // True when there are new packets to process.
-  // Set when a new packet is added to the ring and cleared after
-  // 'receiving_app' runs.
-  bool has_new_data;
 };
 

--- a/src/core/link.lua
+++ b/src/core/link.lua
@@ -66,7 +66,6 @@ function transmit (r, p)
       r.write = band(r.write + 1, size - 1)
       counter.add(r.stats.txpackets)
       counter.add(r.stats.txbytes, p.length)
-      r.has_new_data = true
    end
 end
 

--- a/src/lib/timers/ingress_drop_monitor.lua
+++ b/src/lib/timers/ingress_drop_monitor.lua
@@ -41,7 +41,7 @@ function new(args)
 end
 
 function IngressDropMonitor:sample ()
-   local app_array = engine.app_array
+   local app_array = engine.breathe_push_order
    local sum = self.current_value
    sum[0] = 0
    for i = 1, #app_array do

--- a/src/program/snabbvmx/lwaftr/setup.lua
+++ b/src/program/snabbvmx/lwaftr/setup.lua
@@ -304,8 +304,8 @@ local function lwaftr_app_check (c, conf, lwconf, sources, sinks)
    assert(type(conf) == "table")
    assert(type(lwconf) == "table")
 
-   local v4_input, v6_input = unpack(sources)
-   local v4_output, v6_output = unpack(sinks)
+   local v4_src, v6_src = unpack(sources)
+   local v4_sink, v6_sink = unpack(sinks)
 
    if conf.ipv6_interface then
       if conf.ipv6_interface.fragmentation then
@@ -319,21 +319,21 @@ local function lwaftr_app_check (c, conf, lwconf, sources, sinks)
             counters = counters,
             mtu = mtu,
          })
-         config.link(c, v6_output .. " -> reassemblerv6.input")
-         config.link(c, "fragmenterv6.output -> " .. v6_input)
-         v6_input, v6_output  = "fragmenterv6.input", "reassemblerv6.output"
+         config.link(c, v6_src .. " -> reassemblerv6.input")
+         config.link(c, "fragmenterv6.output -> " .. v6_sink)
+         v6_src, v6_sink  = "reassemblerv6.output", "fragmenterv6.input"
       end
       if conf.ipv6_interface.ipv6_ingress_filter then
          local filter = conf.ipv6_interface.ipv6_ingress_filter
          config.app(c, "ingress_filterv6", PcapFilter, { filter = filter })
-         config.link(c, v6_output .. " -> ingress_filterv6.input")
-         v6_output = "ingress_filterv6.output"
+         config.link(c, v6_src .. " -> ingress_filterv6.input")
+         v6_src = "ingress_filterv6.output"
       end
       if conf.ipv6_interface.ipv6_egress_filter then
          local filter = conf.ipv6_interface.ipv6_egress_filter
          config.app(c, "egress_filterv6", PcapFilter, { filter = filter })
-         config.link(c, "egress_filterv6.output -> " .. v6_input)
-         v6_input = "egress_filterv6.input"
+         config.link(c, "egress_filterv6.output -> " .. v6_sink)
+         v6_sink = "egress_filterv6.input"
       end
    end
 
@@ -349,34 +349,34 @@ local function lwaftr_app_check (c, conf, lwconf, sources, sinks)
             counters = counters,
             mtu = mtu
          })
-         config.link(c, v4_output .. " -> reassemblerv4.input")
-         config.link(c, "fragmenterv4.output -> " .. v4_input)
-         v4_input, v4_output  = "fragmenterv4.input", "reassemblerv4.output"
+         config.link(c, v4_src .. " -> reassemblerv4.input")
+         config.link(c, "fragmenterv4.output -> " .. v4_sink)
+         v4_src, v4_sink  = "reassemblerv4.output", "fragmenterv4.input"
       end
       if conf.ipv4_interface.ipv4_ingress_filter then
          local filter = conf.ipv4_interface.ipv4_ingress_filter
          config.app(c, "ingress_filterv4", PcapFilter, { filter = filter })
-         config.link(c, v4_output .. " -> ingress_filterv4.input")
-         v4_output = "ingress_filterv4.output"
+         config.link(c, v4_src .. " -> ingress_filterv4.input")
+         v4_src = "ingress_filterv4.output"
       end
       if conf.ipv4_interface.ipv4_egress_filter then
          local filter = conf.ipv4_interface.ipv4_egress_filter
          config.app(c, "egress_filterv4", PcapFilter, { filter = filter })
-         config.link(c, "egress_filterv4.output -> " .. v4_input)
-         v4_input = "egress_filterv4.input"
+         config.link(c, "egress_filterv4.output -> " .. v4_sink)
+         v4_sink = "egress_filterv4.input"
       end
    end
 
    if conf.ipv4_interface and conf.ipv6_interface then
       config.app(c, "nh_fwd6", nh_fwd.nh_fwd6,
                  subset(nh_fwd.nh_fwd6.config, conf.ipv6_interface))
-      config.link(c, v6_input.." -> nh_fwd6.wire")
-      config.link(c, "nh_fwd6.wire -> "..v6_output)
+      config.link(c, v6_src.." -> nh_fwd6.wire")
+      config.link(c, "nh_fwd6.wire -> "..v6_sink)
 
       config.app(c, "nh_fwd4", nh_fwd.nh_fwd4,
                  subset(nh_fwd.nh_fwd4.config, conf.ipv4_interface))
-      config.link(c, v4_input.."-> nh_fwd4.wire")
-      config.link(c, "nh_fwd4.wire -> "..v6_output)
+      config.link(c, v4_src.."-> nh_fwd4.wire")
+      config.link(c, "nh_fwd4.wire -> "..v4_sink)
 
       lwconf.counters = lwcounter.init_counters()
       config.app(c, "lwaftr", lwaftr.LwAftr, lwconf)


### PR DESCRIPTION
This PR refactors (re)configuration so that compute_config_actions
results in an ordered list of actions, O(n) in the size of the change
rather than of the graph, such that apply_config_actions can just mindlessly
apply them.

apply_config_actions is now a mutating procedure which mutates the app
table, the link table, and the current configuration to reflect the
result of applying the config diff in compute_config_actions.

This PR also includes #1066.