### PR TITLE
Configure callback for “Macro apps”

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -85,10 +85,20 @@ unimplemented are marked as "optional".
 
 — Method **myapp:new** *arg*
 
-*Required*. Create an instance of the app with a given argument *arg*.
-`Myapp:new` must return an instance of the app. The handling of *arg* is
-up to the app but it is encouraged to use `core.config`'s `parse_app_arg`
-to parse *arg*.
+*Required*. Create an instance of the app with a given argument *arg*. The
+`new` method must return an instance of the app. The handling of *arg* is up to
+the app but it is encouraged to use `core.config`'s `parse_app_arg` to parse
+*arg*.
+
+
+— Method **myapp:configure** *configuration*, *name*, *arg*
+
+*Optional*. If this method is defined the `new` method is not ignored and not
+required, and when *myapp* is configured using `config.app` this method is
+called instead of instantiating *myapp* using `new`. The `configure` method is
+called with the *configuration*, *name*, and *arg* given to `config.app`, and
+is intended to be used to add arbitrary apps and links to *configuration* using
+`config.app` and `config.link`.
 
 
 — Field **myapp.input**

--- a/src/README.md
+++ b/src/README.md
@@ -85,15 +85,15 @@ unimplemented are marked as "optional".
 
 — Method **myapp:new** *arg*
 
-*Required*. Create an instance of the app with a given argument *arg*. The
-`new` method must return an instance of the app. The handling of *arg* is up to
+*Required*. Create an instance of *myapp* with a given argument *arg*. The
+`new` method must return an instance of *myapp*. The handling of *arg* is up to
 the app but it is encouraged to use `core.config`'s `parse_app_arg` to parse
 *arg*.
 
 
 — Method **myapp:configure** *configuration*, *name*, *arg*
 
-*Optional*. If this method is defined the `new` method is not ignored and not
+*Optional*. If this method is defined the `new` method is ignored and not
 required, and when *myapp* is configured using `config.app` this method is
 called instead of instantiating *myapp* using `new`. The `configure` method is
 called with the *configuration*, *name*, and *arg* given to `config.app`, and

--- a/src/core/app.lua
+++ b/src/core/app.lua
@@ -532,5 +532,5 @@ function selftest ()
       got.configuration, got.name, got.arg = c, name, arg
    end
    config.app(c_macro, args.name, MacroApp, args.arg)
-   assert(lib.equeal(args, got), "configure callback broken")
+   assert(lib.equal(args, got), "configure callback broken")
 end

--- a/src/core/app.lua
+++ b/src/core/app.lua
@@ -526,4 +526,11 @@ function selftest ()
    assert(app_table.app3 == orig_app3) -- should be the same
    main({duration = 4, report = {showapps = true}})
    assert(app_table.app3 ~= orig_app3) -- should be restarted
+   local c_macro, MacroApp = config.new(), {}
+   local args, got = {configuration=c_macro, name="macroTest", arg=42}, {}
+   function MacroApp:configure (c, name, arg)
+      got.configuration, got.name, got.arg = c, name, arg
+   end
+   config.app(c_macro, args.name, MacroApp, args.arg)
+   assert(lib.equeal(args, got), "configure callback broken")
 end

--- a/src/core/config.lua
+++ b/src/core/config.lua
@@ -32,7 +32,11 @@ function app (config, name, class, arg)
       if status then arg = result
       else error("failed to configure '"..name.."': "..result) end
    end
-   config.apps[name] = { class = class, arg = arg}
+   if class.configure then
+      class:configure(config, name, arg)
+   else
+      config.apps[name] = { class = class, arg = arg}
+   end
 end
 
 -- API: Add a link to the configuration.


### PR DESCRIPTION
This new `configure` callback (as used in #1068) allows the creation of transparent “macro apps”, which are not instantiated, but instead modify the configuration they are configured on:

— Method **myapp:configure** *configuration*, *name*, *arg*

*Optional*. If this method is defined the `new` method is ignored and not
required, and when *myapp* is configured using `config.app` this method is
called instead of instantiating *myapp* using `new`. The `configure` method is
called with the *configuration*, *name*, and *arg* given to `config.app`, and
is intended to be used to add arbitrary apps and links to *configuration* using
`config.app` and `config.link`.