### PR TITLE
Replace lib.timer() with lib.timeout() and lib.throttle()

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -827,6 +827,15 @@ result of calling *timefun*, and is saved in the resulting closure. A
 *duration* has elapsed when its deadline is less than or equal the value
 obtained using *timefun* when calling the closure.
 
+— Function **lib.throttle** *seconds*
+
+Return a closure that returns `true` at most once during any *seconds*
+(a floating point value) time interval, otherwise false.
+
+— Function **lib.timeout** *seconds*
+
+Returns a closure that returns `true` if *seconds* (a floating point
+value) have elapsed since it was created, otherwise false.
 
 — Function **lib.waitfor** *condition*
 

--- a/src/README.md
+++ b/src/README.md
@@ -815,18 +815,6 @@ Returns a table that acts as a bounds checked wrapper around a C array of
 ctype and the caller must ensure that the allocated memory region at
 *base*/*offset* is at least `sizeof(type)*size` bytes long.
 
-— Function **lib.timer** *duration*, *mode*, *timefun*
-
-Returns a closure that will return `false` until *duration* has elapsed. If
-*mode* is `'repeating'` the timer will reset itself after returning `true`,
-thus implementing an interval timer. *Timefun* is used to get a monotonic time.
-*Timefun* defaults to `C.get_time_ns`.
-
-The “deadline” for a given *duration* is computed by adding *duration* to the
-result of calling *timefun*, and is saved in the resulting closure. A
-*duration* has elapsed when its deadline is less than or equal the value
-obtained using *timefun* when calling the closure.
-
 — Function **lib.throttle** *seconds*
 
 Return a closure that returns `true` at most once during any *seconds*

--- a/src/apps/intel/intel_app.lua
+++ b/src/apps/intel/intel_app.lua
@@ -91,7 +91,7 @@ function Intel82599:new (conf)
           txbcast   = {counter},
           txdrop    = {counter},
           txerrors  = {counter}})
-      self.stats.sync_timer = lib.timer(0.001, 'repeating', engine.now)
+      self.stats.sync_timer = lib.throttle(0.001)
 
       if not conf.vmdq and conf.macaddr then
          counter.set(self.stats.shm.macaddr, macaddress:new(conf.macaddr).bits)

--- a/src/apps/packet_filter/pcap_filter.lua
+++ b/src/apps/packet_filter/pcap_filter.lua
@@ -113,7 +113,7 @@ function selftest_run (stateful, expected, tolerance)
 
    print(("Run for 1 second (stateful = %s)..."):format(stateful))
 
-   local deadline = lib.timer(1e9)
+   local deadline = lib.timeout(1.0)
    repeat app.breathe() until deadline()
 
    app.report({showlinks=true})

--- a/src/core/lib.lua
+++ b/src/core/lib.lua
@@ -248,25 +248,6 @@ function bounds_checked (type, base, offset, size)
    return wrap(ffi.cast(tptr, ffi.cast("uint8_t *", base) + offset))
 end
 
--- Return a function that will return false until duration has elapsed.
--- If mode is 'repeating' the timer will reset itself after returning true,
--- thus implementing an interval timer. Timefun defaults to `C.get_time_ns'.
-function timer (duration, mode, timefun)
-   timefun = timefun or C.get_time_ns
-   local deadline = timefun() + duration
-   local function oneshot ()
-      return timefun() >= deadline
-   end
-   local function repeating ()
-      if timefun() >= deadline then
-         deadline = timefun() + duration
-         return true
-      else return false end
-   end
-   if mode == 'repeating' then return repeating
-   else return oneshot end
-end
-
 -- Return a throttle function.
 --
 -- The throttle returns true at most once in any <seconds> time interval.

--- a/src/core/lib.lua
+++ b/src/core/lib.lua
@@ -267,6 +267,30 @@ function timer (duration, mode, timefun)
    else return oneshot end
 end
 
+-- Return a throttle function.
+--
+-- The throttle returns true at most once in any <seconds> time interval.
+function throttle (seconds)
+   local deadline = engine.now()
+   return function ()
+      if engine.now() > deadline then
+         deadline = engine.now() + seconds
+         return true
+      else
+         return false
+      end
+   end
+end
+
+-- Return a timeout function.
+--
+-- The timeout function returns true only if <seconds> have elapsed
+-- since it was created.
+function timeout (seconds)
+   local deadline = engine.now() + seconds
+   return function () return engine.now() > deadline end
+end
+
 -- Loop until the function `condition` returns true.
 function waitfor (condition)
    while not condition() do C.usleep(100) end

--- a/src/core/lib.lua
+++ b/src/core/lib.lua
@@ -259,7 +259,7 @@ function timer (duration, mode, timefun)
    end
    local function repeating ()
       if timefun() >= deadline then
-         deadline = deadline + duration
+         deadline = timefun() + duration
          return true
       else return false end
    end


### PR DESCRIPTION
This branch contains several commits in a series.

The net effect is to replace the library function `lib.timer(duration, mode, timefun)` with a pair of simpler counterparts:

- `lib.timeout(seconds)` returns a function that starts returning true after *seconds* have elapsed.
- `lib.throttle(seconds)` returns a function that returns true but never twice in a *seconds* interval.

The idea is that two simple functions are better than one complex one. *Seconds* is always floating-point so you can write `0.25` for 250ms or `1e-9` for 1ns.

This started with commit a233c98 preventing `lib.timer()` from "saving up" timeouts like a token bucket but then it seemed worth taking a step further.

The case against keeping `lib.timer()`:
- Complex interface that requires many words to describe.
- Punts a hard problem to the user: what is the most appropriate time source?
- Duration units depend on the time source chosen (we are using both seconds and nanoseconds).
- Only called twice in the whole Snabb master code tree anyway.

The new timers are always using `engine.now()` as the time source but this function has been updated to return a fresh time value when called from outside the engine loop (instead of a potentially stale one.) One consequence is that the timers will not update during a breath but only between breaths or outside breaths.

Separately it could be worth seeing what Hydra says about dropping this whole time-caching business and always calling out for a fresh time value instead...