### PR TITLE
compile_binding_table fails to compile

### DIFF
--- a/src/program/lwaftr/compile_binding_table/compile_binding_table.lua
+++ b/src/program/lwaftr/compile_binding_table/compile_binding_table.lua
@@ -27,6 +27,6 @@ function run(args)
       io.stderr:write(tostring(bt_or_err)..'\n')
       main.exit(1)
    end
-   bt_or_err:save(out_file, stream.mtime_sec, stream.mtime_nsec)
+   bt_or_err:save(out_file, input_stream.mtime_sec, input_stream.mtime_nsec)
    main.exit(0)
 end


### PR DESCRIPTION
compile_binding_table.lua:30: variable 'mtime_sec' is not declared
Issue is happening because recently in the line 24 input_stream was added in place of stream but this was missed out from line 30. Made this change and tested on my setup.