### PR TITLE
Correct instructions for setting up a dev environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,10 +100,10 @@ Setting up a Snabb development environment takes around one
 minute:
 
 ```
-$ git clone https://github.com/SnabbCo/snabbswitch
-$ cd snabbswitch
+$ git clone https://github.com/SnabbCo/snabb
+$ cd snabb
 $ make -j
-$ src/snabb --help
+$ sudo src/snabb --help
 ```
 
 The `snabb` binary is stand-alone, includes all of the applications,


### PR DESCRIPTION
The project and repo name were changed from `snabbswitch` to `snabb` but the instructions for building and setting up a build environment were not updated. Additionally, it appears that `sudo` must be used to check `--help` the first time because the `snabb` executable wants to touch `/var` on the first run.