### PR TITLE
engine: Fix selftest() method for link topology change

### DIFF
--- a/src/core/app.lua
+++ b/src/core/app.lua
@@ -494,7 +494,7 @@ function selftest ()
    print("empty -> c1")
    configure(c1)
    assert(#breathe_pull_order == 0)
-   assert(#breathe_push_order == 2)
+   assert(#breathe_push_order == 1)
    assert(app_table.app1 and app_table.app2)
    local orig_app1 = app_table.app1
    local orig_app2 = app_table.app2
@@ -521,7 +521,7 @@ function selftest ()
    assert(app_table.app1 ~= orig_app1) -- should be restarted
    assert(app_table.app2 == orig_app2) -- should be the same
    assert(#breathe_pull_order == 0)
-   assert(#breathe_push_order == 2)
+   assert(#breathe_push_order == 1)
    print("c1 -> empty")
    configure(config.new())
    assert(#breathe_pull_order == 0)


### PR DESCRIPTION
@wingo could you please ACK/NACK this change in a comment before I merge onto next?

Background: The latest link topology change from @wingo brings new semantics: now the pull() method of an app is only called for apps that actually have some input links. This seems reasonable since the purpose of push() is to process packets queued on input links.

This fix simply updates the expectation of how many apps the engine will push() to count only the ones with input links rather than all apps.