### PR TITLE
Initial support for aarch64

### DIFF
--- a/src/doc/branches.md
+++ b/src/doc/branches.md
@@ -146,3 +146,10 @@ The current state of each branch with respect to master is visible here:
 
     Maintainer: Domen Kožar <domen@dev.si>
 
+#### aarch64
+
+    BRANCH: aarch64 git://github.com/jialiu02/snabb
+    Development branch for ARM aarch64 platform.
+
+    Maintainer: Jianbo Liu <jianbo.liu@linaro.org>
+


### PR DESCRIPTION
Hi,
It's the initial support for aarch64 platform.
Please note that the latest 2.1.0 luajit is needed to run on ARM.

Thanks!