### PR TITLE
Add 'luajit' branch for maintenance of our LuaJIT v2.1

### DIFF
--- a/src/doc/branches.md
+++ b/src/doc/branches.md
@@ -96,6 +96,18 @@ The current state of each branch with respect to master is visible here:
     Maintainer: Collectively maintained by lwAFTR application developers.
     Next hop: kbara-next
 
+#### luajit
+
+    BRANCH: luajit git://github.com/snabbco/luajit
+    LuaJIT v2.1 updates branch.
+
+    - Pulls changes from LuaJIT v2.1 upstream.
+    - Pulls special features & fixes needed by Snabb.
+    - Resolves conflicts due to upstream rebases of PRs.
+
+    Maintainer: Luke Gorrie <luke@snabb.co>
+    Next hop: next
+
 #### mellanox
 
     BRANCH: mellanox git://github.com/lukego/snabbswitch


### PR DESCRIPTION
I propose a new branch `snabbco/snabb#luajit` for landing changes to LuaJIT. I volunteer to maintain this -- but would be more than happy for somebody else to do that if they like.

From the branch description:

- Pulls changes from LuaJIT v2.1 upstream.
- Pulls special features & fixes needed by Snabb.
- Resolves conflicts due to upstream rebases of PRs.

Just now I have suggested that the `luajit` branch will feed directly into the `next` branch. This means that I will be doing all the merges myself without a second pair of eyes. If this becomes a problem then the solution would be for somebody else to maintain the `luajit` branch. (However, if you don't like a change that I merge onto `next` you can always PR a correction there before it is released.)

Just somewhat relatedly, I have privately created a fork of LuaJIT called [RaptorJIT](https://github.com/raptorjit/raptorjit). This has no direct connection to Snabb but will be a place to incubate new features that can be ported onto the LuaJIT fork in Snabb.