### PR TITLE
VMProfile (new LuaJIT sampling profiler) engine support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ CSRC   = $(wildcard src/c/*.c)
 COBJ   = $(CSRC:.c=.o)
 PREFIX = /usr/local
 
-LUAJIT_CFLAGS := -include $(CURDIR)/gcc-preinclude.h
+LUAJIT_CFLAGS := -include $(CURDIR)/gcc-preinclude.h -DLUAJIT_VMPROFILE
 
 all: $(LUAJIT) $(SYSCALL) $(PFLUA)
 #       LuaJIT

--- a/lib/luajit/src/Makefile
+++ b/lib/luajit/src/Makefile
@@ -479,7 +479,7 @@ LJLIB_C= $(LJLIB_O:.o=.c)
 LJCORE_O= lj_gc.o lj_err.o lj_char.o lj_bc.o lj_obj.o lj_buf.o \
 	  lj_str.o lj_tab.o lj_func.o lj_udata.o lj_meta.o lj_debug.o \
 	  lj_state.o lj_dispatch.o lj_vmevent.o lj_vmmath.o lj_strscan.o \
-	  lj_strfmt.o lj_strfmt_num.o lj_api.o lj_profile.o \
+	  lj_strfmt.o lj_strfmt_num.o lj_api.o lj_profile.o lj_vmprofile.o \
 	  lj_lex.o lj_parse.o lj_bcread.o lj_bcwrite.o lj_load.o \
 	  lj_ir.o lj_opt_mem.o lj_opt_fold.o lj_opt_narrow.o \
 	  lj_opt_dce.o lj_opt_loop.o lj_opt_split.o lj_opt_sink.o \

--- a/lib/luajit/src/lib_jit.c
+++ b/lib/luajit/src/lib_jit.c
@@ -636,6 +636,34 @@ static int luaopen_jit_profile(lua_State *L)
 
 #endif
 
+/* -- jit.vmprofile module  ----------------------------------------------- */
+
+#ifdef LUAJIT_VMPROFILE
+
+#define LJLIB_MODULE_jit_vmprofile
+
+LJLIB_CF(jit_vmprofile_start)
+{
+  luaJIT_vmprofile_start(L);
+  return 0;
+}
+
+LJLIB_CF(jit_vmprofile_stop)
+{
+  luaJIT_vmprofile_stop(L);
+  return 0;
+}
+
+#include "lj_libdef.h"
+
+static int luaopen_jit_vmprofile(lua_State *L)
+{
+  LJ_LIB_REG(L, NULL, jit_vmprofile);
+  return 1;
+}
+
+#endif
+
 /* -- JIT compiler initialization ----------------------------------------- */
 
 #if LJ_HASJIT
@@ -770,6 +798,10 @@ LUALIB_API int luaopen_jit(lua_State *L)
 #if LJ_HASPROFILE
   lj_lib_prereg(L, LUA_JITLIBNAME ".profile", luaopen_jit_profile,
 		tabref(L->env));
+#endif
+#ifdef LUAJIT_VMPROFILE
+  lj_lib_prereg(L, LUA_JITLIBNAME ".vmprofile", luaopen_jit_vmprofile,
+                tabref(L->env));
 #endif
 #ifndef LUAJIT_DISABLE_JITUTIL
   lj_lib_prereg(L, LUA_JITLIBNAME ".util", luaopen_jit_util, tabref(L->env));

--- a/lib/luajit/src/lj_gc.c
+++ b/lib/luajit/src/lj_gc.c
@@ -679,6 +679,7 @@ int LJ_FASTCALL lj_gc_step(lua_State *L)
   global_State *g = G(L);
   GCSize lim;
   int32_t ostate = g->vmstate;
+  g->gcvmstate = ostate;
   setvmstate(g, GC);
   lim = (GCSTEPSIZE/100) * g->gc.stepmul;
   if (lim == 0)
@@ -731,6 +732,7 @@ void lj_gc_fullgc(lua_State *L)
 {
   global_State *g = G(L);
   int32_t ostate = g->vmstate;
+  g->gcvmstate = ostate;
   setvmstate(g, GC);
   if (g->gc.state <= GCSatomic) {  /* Caught somewhere in the middle. */
     setmref(g->gc.sweep, &g->gc.root);  /* Sweep everything (preserving it). */

--- a/lib/luajit/src/lj_obj.h
+++ b/lib/luajit/src/lj_obj.h
@@ -598,7 +598,8 @@ typedef struct global_State {
   lua_Alloc allocf;	/* Memory allocator. */
   void *allocd;		/* Memory allocator data. */
   GCState gc;		/* Garbage collector. */
-  volatile int32_t vmstate;  /* VM state or current JIT code trace number. */
+  volatile int32_t vmstate;   /* VM state or current JIT code trace number. */
+  volatile int32_t gcvmstate; /* Previous VM state (only when state is GC). */
   SBuf tmpbuf;		/* Temporary string buffer. */
   GCstr strempty;	/* Empty string. */
   uint8_t stremptyz;	/* Zero terminator of empty string. */

--- a/lib/luajit/src/lj_vmprofile.c
+++ b/lib/luajit/src/lj_vmprofile.c
@@ -1,0 +1,113 @@
+/*
+** VM profiling.
+** Copyright (C) 2016 Luke Gorrie. See Copyright Notice in luajit.h
+*/
+
+#define lj_vmprofile_c
+#define LUA_CORE
+
+#ifdef LUAJIT_VMPROFILE
+
+#define _GNU_SOURCE 1
+#include <stdio.h>
+#include <assert.h>
+#include <sys/time.h>
+#include <stdint.h>
+#include <signal.h>
+#include <ucontext.h>
+#undef _GNU_SOURCE
+
+#include "lj_obj.h"
+#include "lj_dispatch.h"
+#include "lj_jit.h"
+#include "lj_trace.h"
+#include "lj_vmprofile.h"
+
+static struct {
+  global_State *g;
+  struct sigaction oldsa;
+} state;
+
+/* -- State that the application can manage via FFI ----------------------- */
+
+static VMProfile *profile;      /* Current counters */
+
+/* How much memory to allocate for profiler counters. */
+int vmprofile_get_profile_size() {
+  return sizeof(VMProfile);
+}
+
+/* Set the memory where the next samples will be counted. 
+   Size of the memory must match vmprofile_get_profile_size(). */
+void vmprofile_set_profile(void *counters) {
+  profile = (VMProfile*)counters;
+  profile->magic = 0x1d50f007;
+  profile->major = 1;
+  profile->minor = 0;
+}
+
+/* -- Signal handler ------------------------------------------------------ */
+
+/* Signal handler: bumps one counter. */
+static void vmprofile_signal(int sig, siginfo_t *si, void *data)
+{
+  if (profile != NULL) {
+    lua_State *L = gco2th(gcref(state.g->cur_L));
+    int vmstate = state.g->vmstate;
+    /* Not in a trace */
+    if (vmstate < 0) {
+      profile->vm[~vmstate]++;
+    } else {
+      int bucket = vmstate > LJ_VMPROFILE_TRACE_MAX ? 0 : vmstate;
+      VMProfileTraceCount *count = &profile->trace[bucket];
+      GCtrace *T = traceref(L2J(L), (TraceNo)vmstate);
+      intptr_t ip = (intptr_t)((ucontext_t*)data)->uc_mcontext.gregs[REG_RIP];
+      ptrdiff_t mcposition = ip - (intptr_t)T->mcode;
+      if ((mcposition < 0) || (mcposition >= T->szmcode)) {
+        count->other++;
+      } else if ((T->mcloop != 0) && (mcposition >= T->mcloop)) {
+        count->loop++;
+      } else {
+        count->head++;
+      }
+    }
+  }
+}
+
+static void start_timer(int interval)
+{
+  struct itimerval tm;
+  struct sigaction sa;
+  tm.it_value.tv_sec = tm.it_interval.tv_sec = interval / 1000;
+  tm.it_value.tv_usec = tm.it_interval.tv_usec = (interval % 1000) * 1000;
+  setitimer(ITIMER_PROF, &tm, NULL);
+  sa.sa_flags = SA_SIGINFO | SA_RESTART;
+  sa.sa_sigaction = vmprofile_signal;
+  sigemptyset(&sa.sa_mask);
+  sigaction(SIGPROF, &sa, &state.oldsa);
+}
+
+static void stop_timer()
+{
+  struct itimerval tm;
+  tm.it_value.tv_sec = tm.it_interval.tv_sec = 0;
+  tm.it_value.tv_usec = tm.it_interval.tv_usec = 0;
+  setitimer(ITIMER_PROF, &tm, NULL);
+  sigaction(SIGPROF, NULL, &state.oldsa);
+}
+
+/* -- Lua API ------------------------------------------------------------- */
+
+LUA_API void luaJIT_vmprofile_start(lua_State *L)
+{
+  memset(&state, 0, sizeof(state));
+  state.g = G(L);
+  start_timer(1);               /* Sample every 1ms */
+}
+
+LUA_API void luaJIT_vmprofile_stop(lua_State *L)
+{
+  stop_timer();
+}
+
+#endif

--- a/lib/luajit/src/lj_vmprofile.c
+++ b/lib/luajit/src/lj_vmprofile.c
@@ -42,7 +42,7 @@ int vmprofile_get_profile_size() {
 void vmprofile_set_profile(void *counters) {
   profile = (VMProfile*)counters;
   profile->magic = 0x1d50f007;
-  profile->major = 1;
+  profile->major = 2;
   profile->minor = 0;
 }
 
@@ -54,16 +54,19 @@ static void vmprofile_signal(int sig, siginfo_t *si, void *data)
   if (profile != NULL) {
     lua_State *L = gco2th(gcref(state.g->cur_L));
     int vmstate = state.g->vmstate;
+    int trace = ~vmstate == LJ_VMST_GC ? state.g->gcvmstate : vmstate;
     /* Not in a trace */
-    if (vmstate < 0) {
+    if (trace < 0) {
       profile->vm[~vmstate]++;
     } else {
-      int bucket = vmstate > LJ_VMPROFILE_TRACE_MAX ? 0 : vmstate;
+      int bucket = trace > LJ_VMPROFILE_TRACE_MAX ? 0 : trace;
       VMProfileTraceCount *count = &profile->trace[bucket];
-      GCtrace *T = traceref(L2J(L), (TraceNo)vmstate);
+      GCtrace *T = traceref(L2J(L), (TraceNo)trace);
       intptr_t ip = (intptr_t)((ucontext_t*)data)->uc_mcontext.gregs[REG_RIP];
       ptrdiff_t mcposition = ip - (intptr_t)T->mcode;
-      if ((mcposition < 0) || (mcposition >= T->szmcode)) {
+      if (~vmstate == LJ_VMST_GC) {
+        count->gc++;
+      } else if ((mcposition < 0) || (mcposition >= T->szmcode)) {
         count->other++;
       } else if ((T->mcloop != 0) && (mcposition >= T->mcloop)) {
         count->loop++;

--- a/lib/luajit/src/lj_vmprofile.h
+++ b/lib/luajit/src/lj_vmprofile.h
@@ -1,0 +1,37 @@
+/*
+** Virtual machine profiling.
+** Copyright (C) 2017 Luke Gorrie. See Copyright Notice in luajit.h
+*/
+
+#ifndef _LJ_VMPROFILE_H
+#define _LJ_VMPROFILE_H
+
+
+/* Counters are 64-bit to avoid overflow even in long running processes. */
+typedef uint64_t VMProfileCount;
+
+/* Maximum trace number for distinct counter buckets. Traces with
+   higher numbers will be counted together in bucket zero. */
+#define LJ_VMPROFILE_TRACE_MAX 4096
+
+/* Traces have separate counters for different machine code regions. */
+typedef struct VMProfileTraceCount {
+  VMProfileCount head;          /* Head of the trace (non-looping part) */
+  VMProfileCount loop;          /* Loop of the trace */
+  VMProfileCount other;         /* Outside the trace mcode (unidentified) */
+} VMProfileTraceCount;
+
+/* Complete set of counters for VM and traces. */
+typedef struct VMProfile {
+  uint32_t magic;               /* 0x1d50f007 */
+  uint16_t major, minor;        /* 1, 0 */
+  VMProfileCount vm[LJ_VMST__MAX];
+  VMProfileTraceCount trace[LJ_VMPROFILE_TRACE_MAX+1];
+} VMProfile;
+
+/* Functions that should be accessed via FFI. */
+
+void vmprofile_set_profile(void *counters);
+int vmprofile_get_profile_size();
+
+#endif

--- a/lib/luajit/src/lj_vmprofile.h
+++ b/lib/luajit/src/lj_vmprofile.h
@@ -19,12 +19,13 @@ typedef struct VMProfileTraceCount {
   VMProfileCount head;          /* Head of the trace (non-looping part) */
   VMProfileCount loop;          /* Loop of the trace */
   VMProfileCount other;         /* Outside the trace mcode (unidentified) */
+  VMProfileCount gc;            /* Garbage collection from this trace. */
 } VMProfileTraceCount;
 
 /* Complete set of counters for VM and traces. */
 typedef struct VMProfile {
   uint32_t magic;               /* 0x1d50f007 */
-  uint16_t major, minor;        /* 1, 0 */
+  uint16_t major, minor;        /* 2, 0 */
   VMProfileCount vm[LJ_VMST__MAX];
   VMProfileTraceCount trace[LJ_VMPROFILE_TRACE_MAX+1];
 } VMProfile;

--- a/lib/luajit/src/luajit.h
+++ b/lib/luajit/src/luajit.h
@@ -73,6 +73,10 @@ LUA_API void luaJIT_profile_stop(lua_State *L);
 LUA_API const char *luaJIT_profile_dumpstack(lua_State *L, const char *fmt,
 					     int depth, size_t *len);
 
+/* VM profiling API. */
+LUA_API void luaJIT_vmprofile_start(lua_State *L);
+LUA_API void luaJIT_vmprofile_stop(lua_State *L);
+
 /* Enforce (dynamic) linker error for version mismatches. Call from main. */
 LUA_API void LUAJIT_VERSION_SYM(void);
 

--- a/src/apps/basic/basic_apps.lua
+++ b/src/apps/basic/basic_apps.lua
@@ -10,7 +10,7 @@ local transmit, receive = link.transmit, link.receive
 
 --- # `Source` app: generate synthetic packets
 
-Source = {}
+Source = {name = 'Source'}
 
 function Source:new(size)
    size = tonumber(size) or 60
@@ -33,7 +33,7 @@ end
 
 --- # `Join` app: Merge multiple inputs onto one output
 
-Join = {}
+Join = {name = 'Join'}
 
 function Join:new()
    return setmetatable({}, {__index=Join})
@@ -51,7 +51,7 @@ end
 
 -- For each input port, push packets onto outputs. When one output
 -- becomes full then continue with the next.
-Split = {}
+Split = {name = 'Split'}
 
 function Split:new ()
    return setmetatable({}, {__index=Split})
@@ -69,7 +69,7 @@ end
 
 --- ### `Sink` app: Receive and discard packets
 
-Sink = {}
+Sink = {name = 'Sink'}
 
 function Sink:new ()
    return setmetatable({}, {__index=Sink})
@@ -86,7 +86,7 @@ end
 
 --- ### `Tee` app: Send inputs to all outputs
 
-Tee = {}
+Tee = {name = 'Tee'}
 
 function Tee:new ()
    return setmetatable({}, {__index=Tee})
@@ -110,7 +110,7 @@ end
 
 --- ### `Repeater` app: Send all received packets in a loop
 
-Repeater = {}
+Repeater = {name = 'Repeater'}
 
 function Repeater:new ()
    return setmetatable({index = 1, packets = {}},
@@ -141,7 +141,7 @@ end
 
 --- # `Truncate` app: truncate or zero pad packet to length n
 
-Truncate = {}
+Truncate = {name = 'Truncate'}
 
 function Truncate:new (n)
    return setmetatable({n = n}, {__index=Truncate})
@@ -158,7 +158,7 @@ end
 
 --- # `Sample` app: let through every nth packet
 
-Sample = {}
+Sample = {name = 'Sample'}
 
 function Sample:new (n)
    return setmetatable({n = n, seen = 1}, {__index=Sample})

--- a/src/core/app.lua
+++ b/src/core/app.lua
@@ -204,7 +204,7 @@ function apply_config_actions (actions, conf)
          error(("bad return value from app '%s' start() method: %s"):format(
                   name, tostring(app)))
       end
-      local zone = app.zone or class.name or getfenv(class.new)._NAME or name
+      local zone = app.zone or (type(class.name) == 'string' and class.name) or getfenv(class.new)._NAME or name
       app.appname = name
       app.output = {}
       app.input = {}


### PR DESCRIPTION
I wrote an experimental sampling profiler for LuaJIT called VMProfile (LuaJIT/LuaJIT#290). It is very effective (although upstream didn't like it.)

This branch pulls that feature into Snabb and enables it by default. This means that each Snabb process will automatically create a small shared memory object that contains profiler samples saying which traces are hot. The samples are taken at 1ms intervals using a POSIX interval timer.

The profiler is low-level in the sense that it tells you the trace numbers that are hot. You then have to manually inspect the traces (e.g. with `-jdump`) to understand why. Sorry about that. (In the future I want to create a more efficient replacement for `-jdump` that can always be enabled and available for cross-referencing, but for now you have to do the JIT dumping yourself.)

This implementation actually creates one set of counters for the engine itself and a separate set of counters for each app class. This way you can choose whether to take a global view or whether to zoom in on particular apps.

The user interface is an external tool called [vmprofiler.R](https://github.com/studio/studio/blob/master/tools/vmprofiler/vmprofiler.R). This requires a little polish but is simple (~50 lines of code at the moment.)

- [ ] Check performance impact of the sampling (mandatory for enabled-by-default.)
- [ ] Provide simple instructions for running the `vmprofiler` frontend.

### Screenshots

Here is what the profiler can say about the `snabbmark basic1` benchmark:

Overall summary of where time is spent:

```
 profile percent
     Tee    34.7
    Sink    31.9
  Source    22.6
  engine    10.8
```

What kind of code is running? (The `head` of mcode traces, the `loop` of mcode traces, `foreign` C code, the garbage collector, the JIT assembler/recorder/etc):

```
    what percent
    loop    70.2
 foreign    16.0
    head    11.1
      gc     2.6
     asm     0.0
       c     0.0
  record     0.0
```

Where more specifically is this time being spent? (which trace numbers and which apps?)

```
 profile      where percent
    Sink    loop.20    26.3
    Sink      gc.22     2.6
    Sink    head.20     1.9
  Source    loop.13    16.4
  Source foreign.13     4.3
  Source    head.13     0.8
  Source    head.23     0.5
     Tee    loop.21    27.5
     Tee foreign.21     5.3
     Tee    head.21     0.9
  engine foreign.42     5.5
  engine    head.42     3.2
  engine    head.23     0.7
  engine    head.24     0.7
```

How about the 2.6% time spent garbage collecting?

```
 profile where percent
    Sink gc.22    99.9
```

(This makes finding & eliminating unsunk allocations as easy as shooting fish in a barrel: we can see that 99.9% of GC work is due to an allocation in trace number 22 which is being called from the `Sink` app.)