### PR TITLE
core.shm: Make shm objects world-readable

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -469,8 +469,16 @@ of this process:
 - Fully qualified: `/1234/foo/bar` ⇒ `/var/run/snabb/1234/foo/bar`
 
 Behind the scenes the objects are backed by files on ram disk
-(`/var/run/snabb/<pid>`) and accessed with the equivalent of POSIX shared
-memory (`shm_overview(7)`).
+(`/var/run/snabb/<pid>`) and accessed with the equivalent of POSIX
+shared memory (`shm_overview(7)`). The files are automatically removed
+on shutdown unless the environment `SNABB_SHM_KEEP` is set. The
+location `/var/run/snabb` can be overridden by the environment
+variable `SNABB_SHM_ROOT`.
+
+Shared memory objects are created world-readable for convenient access
+by diagnostic tools. You can lock this down by setting
+`SNABB_SHM_ROOT` to a path under a directory with appropriate
+permissions.
 
 The practical limit on the number of objects that can be mapped will depend on
 the operating system limit for memory mappings. On Linux the default limit is

--- a/src/core/shm.lua
+++ b/src/core/shm.lua
@@ -30,7 +30,7 @@ local function map (name, type, readonly, create)
    if create then
       -- Create the parent directories. If this fails then so will the open().
       mkdir(path)
-      fd, err = S.open(root..'/'..path, "creat, rdwr", "rwxu")
+      fd, err = S.open(root..'/'..path, "creat, rdwr", "rusr, wusr, rgrp, roth")
    else
       fd, err = S.open(root..'/'..path, readonly and "rdonly" or "rdwr")
    end
@@ -83,7 +83,7 @@ function mkdir (name)
    -- Create sub directories
    local dir = root
    name:gsub("([^/]+)",
-             function (x) S.mkdir(dir, "rwxu")  dir = dir.."/"..x end)
+             function (x) S.mkdir(dir, "rwxu, rgrp, xgrp, roth, xoth")  dir = dir.."/"..x end)
 end
 
 -- Delete a shared object memory mapping.

--- a/src/core/shm.lua
+++ b/src/core/shm.lua
@@ -71,11 +71,10 @@ end
 -- Make directories needed for a named object.
 -- Given the name "foo/bar/baz" create /var/run/foo and /var/run/foo/bar.
 function mkdir (name)
-   -- Create root with mode "rwxrwxrwt" (R/W for all and sticky) if it
-   -- does not exist yet.
+   -- Create root with mode "rwxr-xr-x" if it does not exist yet.
    if not S.stat(root) then
       local mask = S.umask(0)
-      local status, err = S.mkdir(root, "01777")
+      local status, err = S.mkdir(root, "00755")
       assert(status or err.errno == const.E.EXIST, ("Unable to create %s: %s"):format(
                 root, tostring(err or "unspecified error")))
       S.umask(mask)


### PR DESCRIPTION
Controversial idea for discussion: Make the /var/run/snabb/* shm directories world-readable.

This is more convenient for inspection during development and testing, but less convenient if you are running Snabb on a machine with unprivileged users (e.g. they could map the DMA memory to create backdoors.)

What do we think?