### PR TITLE
apps.socket.unix: Rewrote pull/push to avoid select()

### DIFF
--- a/src/apps/socket/unix.lua
+++ b/src/apps/socket/unix.lua
@@ -16,8 +16,7 @@ local modes = {stream = "stream", packet = "dgram"}
 
 function UnixSocket:new (arg)
 
-   --process args
-
+   -- Process args
    assert(arg, "filename or options expected")
 
    local file, listen, mode
@@ -31,8 +30,7 @@ function UnixSocket:new (arg)
    mode = assert(modes[mode or "stream"], "invalid mode")
    assert(file, "filename expected")
 
-   --open/close socket
-
+   -- Open/close socket
    local open, close
 
    if listen then --server mode
@@ -65,6 +63,7 @@ function UnixSocket:new (arg)
             csock:close()
             close0()
          end
+         assert(csock:nonblock())
          return csock
       end
 
@@ -88,76 +87,52 @@ function UnixSocket:new (arg)
 
    end
 
-   --send/receive packets
-
+   -- Get connected socket
    local sock
    local function connect()
       sock = sock or open()
       return sock
    end
 
-   local function can_receive()
-      if not connect() then return end
-      local t, err = S.select({readfds = {sock}}, 0)
-      while not t and (err.AGAIN or err.INTR) do
-         t, err = S.select({readfds = {sock}}, 0)
-      end
-      assert(t, err)
-      return t.count == 1
-   end
-
-   local function can_send()
-      if not connect() then return end
-      local t, err = S.select({writefds = {sock}}, 0)
-      while not t and (err.AGAIN or err.INTR) do
-         t, err = S.select({writefds = {sock}}, 0)
-      end
-      assert(t, err)
-      return t.count == 1
-   end
-
-   local function receive()
-      local p = packet.allocate()
-      local maxsz = ffi.sizeof(p.data)
-      local len, err = S.read(sock, p.data, maxsz)
-      if len == 0 then return end
-      if not len then
-         assert(nil, err)
-      end
-      p.length = len
-      return p
-   end
-
-   local function send(p)
-      local sz, err = S.write(sock, p.data, p.length)
-      assert(sz, err)
-      assert(sz == p.length)
-   end
-
-   --app object
-
+   -- App object
    local self = setmetatable({}, self)
 
+   -- Preallocated buffer for the next packet.
+   local rxp = packet.allocate()
+   -- Try to read payload into rxp.
+   -- Return true on success or false if no data is available.
+   local function try_read ()
+      local bytes = S.read(sock, rxp.data, packet.max_payload)
+      if bytes then
+         rxp.length = bytes
+         return true
+      else
+         return false
+      end
+   end
    function self:pull()
+      connect()
       local l = self.output.tx
-      if l == nil then return end
       local limit = engine.pull_npackets
-      while limit > 0 and can_receive() do
-         limit = limit - 1
-         local p = receive()
-         if p then
-            link.transmit(l, p) --link owns p now so we mustn't free it
+      if sock and l ~= nil then
+         while limit > 0 and try_read() do
+            link.transmit(l, rxp)
+            rxp = packet.allocate()
+            limit = limit - 1
          end
       end
    end
 
    function self:push()
       local l = self.input.rx
-      if l == nil then return end
-      while not link.empty(l) and can_send() do
-         local p = link.receive(l) --we own p now so we must free it
-         send(p)
-         packet.free(p)
+      if l ~= nil then
+         -- Transmit all queued packets.
+         -- Let the kernel drop them if it does not have capacity.
+         while sock and not link.empty(l) do
+            local p = link.receive(l)
+            S.write(connect(), p.data, p.length)
+            packet.free(p)
+         end
       end
    end
 
@@ -170,7 +145,7 @@ end
 
 
 function selftest ()
-
+   print("selftest: socket/unix")
    local printapp = {}
    function printapp:new (name)
       return {
@@ -214,5 +189,6 @@ function selftest ()
 
    engine.configure(c)
    engine.main({duration=0.1, report = {showlinks=true}})
+   print("selftest: done")
 end
 


### PR DESCRIPTION
Avoiding select() for two reasons.

First, the way that we were passing the fdset argument to select() - as a Lua table - is an NYI for the JIT and forces the code to run interpreted.

Second, we don't really need select(), and can instead deal with failure of read() and write().

This is to help resolve the performance issue on #1147.