### PR TITLE
Support AVX-only architectures in multi_copy.dasl

### DIFF
--- a/src/lib/multi_copy.dasl
+++ b/src/lib/multi_copy.dasl
@@ -92,10 +92,10 @@ function gen(count, size)
 
          if to_copy > 0 then
             for i = 0, stride-1 do
-               | vpmaskmovd ymm(i), ymm15, [Rq(8+i)]
+               | vmaskmovps ymm(i), ymm15, [Rq(8+i)]
             end
             for i = 0, stride-1 do
-               | vpmaskmovd [rdi + i*size], ymm15, ymm(i)
+               | vmaskmovps [rdi + i*size], ymm15, ymm(i)
             end
             | add rdi, to_copy
             to_copy = 0

--- a/src/lib/multi_copy.dasl
+++ b/src/lib/multi_copy.dasl
@@ -16,8 +16,13 @@ module(..., package.seeall)
 
 local debug = false
 
+local lib = require("core.lib")
 local ffi = require("ffi")
 local C = ffi.C
+
+local cpuinfo = lib.readfile("/proc/cpuinfo", "*a")
+assert(cpuinfo, "failed to read /proc/cpuinfo for hardware check")
+local have_avx2 = cpuinfo:match("avx2")
 
 local dasm = require("dasm")
 
@@ -92,10 +97,18 @@ function gen(count, size)
 
          if to_copy > 0 then
             for i = 0, stride-1 do
-               | vmaskmovps ymm(i), ymm15, [Rq(8+i)]
+               if have_avx2 then
+                  | vpmaskmovd ymm(i), ymm15, [Rq(8+i)]
+               else
+                  | vmaskmovps ymm(i), ymm15, [Rq(8+i)]
+               end
             end
             for i = 0, stride-1 do
-               | vmaskmovps [rdi + i*size], ymm15, ymm(i)
+               if have_avx2 then
+                  | vpmaskmovd [rdi + i*size], ymm15, ymm(i)
+               else
+                  | vmaskmovps [rdi + i*size], ymm15, ymm(i)
+               end
             end
             | add rdi, to_copy
             to_copy = 0

--- a/src/lib/multi_copy.dasl
+++ b/src/lib/multi_copy.dasl
@@ -16,13 +16,8 @@ module(..., package.seeall)
 
 local debug = false
 
-local lib = require("core.lib")
 local ffi = require("ffi")
 local C = ffi.C
-
-local cpuinfo = lib.readfile("/proc/cpuinfo", "*a")
-assert(cpuinfo, "failed to read /proc/cpuinfo for hardware check")
-local have_avx2 = cpuinfo:match("avx2")
 
 local dasm = require("dasm")
 
@@ -97,18 +92,10 @@ function gen(count, size)
 
          if to_copy > 0 then
             for i = 0, stride-1 do
-               if have_avx2 then
-                  | vpmaskmovd ymm(i), ymm15, [Rq(8+i)]
-               else
-                  | vmaskmovps ymm(i), ymm15, [Rq(8+i)]
-               end
+               | vmaskmovps ymm(i), ymm15, [Rq(8+i)]
             end
             for i = 0, stride-1 do
-               if have_avx2 then
-                  | vpmaskmovd [rdi + i*size], ymm15, ymm(i)
-               else
-                  | vmaskmovps [rdi + i*size], ymm15, ymm(i)
-               end
+               | vmaskmovps [rdi + i*size], ymm15, ymm(i)
             end
             | add rdi, to_copy
             to_copy = 0


### PR DESCRIPTION
Fixes #1143.

Explanation: double-words and single-precision floats have the same size (4-bytes). When it comes to moves and bitwise operations the type of data doesn't matter. That makes possible to replace `vpmaskmovd` (works on packed double-words) for `vmaskmovps` (workd on packed single-precision floats).

I made the PR 2 separated commits to check the AVX-only code works in an AVX2 architecture.

I didn't check performance of both versions. If there's no difference maybe is worth to use the AVX version only.