### PR TITLE
Improve tracebacks for errors in snsh scripts

### DIFF
--- a/src/core/main.lua
+++ b/src/core/main.lua
@@ -146,7 +146,7 @@ end
 
 function handler (reason)
    print(reason)
-   print(debug.traceback())
+   print(STP.stacktrace())
    if debug_on_error then debug.debug() end
    os.exit(1)
 end

--- a/src/program/snsh/snsh.lua
+++ b/src/program/snsh/snsh.lua
@@ -84,11 +84,7 @@ end
 function run_script (parameters)
    local command = table.remove(parameters, 1)
    main.parameters = parameters -- make remaining args available to script
-   local r, error = pcall(dofile, command)
-   if not r then
-      print(error)
-      main.exit(1)
-   end
+   dofile(command)
 end
 
 -- This is a simple REPL similar to LuaJIT's built-in REPL. It can only
@@ -140,5 +136,3 @@ function hook_sigquit (action)
                             1e4,
                             'repeating'))
 end
-
-


### PR DESCRIPTION
The main program runner has better error handling than snsh: it prints a full traceback, and even allows for debugging, while snsh just prints out the error message.  Therefore, allow errors to propagate back to main instead of catching them in snsh.  This is especially helpful when the error manifests first inside snabb's code instead of in the script.

Before:

```
# snabb snsh script.lua 
core/link.lua:74: attempt to index local 'r' (a nil value)
```

After (without STP):
```
# snabb snsh script.lua
core/link.lua:74: attempt to index local 'r' (a nil value)
stack traceback:
	core/main.lua:149: in function '__index'
	core/link.lua:74: in function 'empty'
	apps/pcap/pcap.lua:49: in function 'method'
	core/app.lua:96: in function 'with_restart'
	core/app.lua:515: in function 'thunk'
	core/histogram.lua:98: in function 'breathe'
	core/app.lua:461: in function 'main'
	script.lua:14: in main chunk
	[C]: in function 'dofile'
	program/snsh/snsh.lua:87: in function 'run_script'
	program/snsh/snsh.lua:71: in function 'run'
	core/main.lua:67: in function <core/main.lua:43>
	[C]: in function 'xpcall'
	core/main.lua:211: in main chunk
	[C]: at 0x0044fc00
	[C]: in function 'pcall'
	core/startup.lua:3: in main chunk
	[C]: in function 'require'
	[string "require "core.startup""]:1: in main chunk
```

After (with STP):
```
# snabb snsh script.lua 
core/link.lua:74: attempt to index local 'r' (a nil value)
file not found: apps/pcap/pcap.lua: No such file or directory
file not found: core/lib.lua: No such file or directory
file not found: core/histogram.lua: No such file or directory
file not found: core/main.lua: No such file or directory

Stack Traceback
===============
(1) Lua metamethod '__index' at file 'core/main.lua:149'
	Local variables:
	 reason = string: "core/link.lua:74: attempt to index local 'r' (a nil value)"
	 (*temporary) = C function: print
(2) Lua field 'empty' at file 'core/link.lua:74'
	Local variables:
	 r = nil
	 (*temporary) = boolean: true
	 (*temporary) = string: "attempt to index local 'r' (a nil value)"
(3) Lua local 'method' at file 'apps/pcap/pcap.lua:49'
	Local variables:
	 self = table: 0x41affb20  {input:table: 0x41affd00, file:file (0x01fe5040), output:table: 0x41affd98 (more...)}
(4) Lua global 'with_restart' at file 'core/app.lua:96'
	Local variables:
	 app = table: 0x41affb20  {input:table: 0x41affd00, file:file (0x01fe5040), output:table: 0x41affd98 (more...)}
	 method = Lua function '?' (defined at line 48 of chunk apps/pcap/pcap.lua)
	 status = nil
	 result = nil
	 (*temporary) = boolean: true
(5) Lua upvalue 'thunk' at file 'core/app.lua:515'
	Local variables:
	 (for index) = number: 2
	 (for limit) = number: 2
	 (for step) = number: 1
	 i = number: 2
	 app = table: 0x41affb20  {input:table: 0x41affd00, file:file (0x01fe5040), output:table: 0x41affd98 (more...)}
(6) Lua local 'breathe' at file 'core/histogram.lua:98'
	Local variables:
	 start = number: 55497.6
(7) Lua field 'main' at file 'core/app.lua:461'
	Local variables:
	 options = table: 0x40bc9b08  {duration:1, report:table: 0x40bc9b68}
	 done = Lua function '?' (defined at line 274 of chunk core/lib.lua)
	 no_timers = nil
	 breathe = Lua function '?' (defined at line 96 of chunk core/histogram.lua)
(8) main chunk of file 'script.lua' at line 14
(9) global C function 'dofile'
(10) Lua global 'run_script' at file 'program/snsh/snsh.lua:87'
	Local variables:
	 parameters = table: 0x41aeb320  {}
	 command = string: "script.lua"
(11) Lua field 'run' at file 'program/snsh/snsh.lua:71'
	Local variables:
	 parameters = table: 0x41aeb320  {}
	 profiling = boolean: false
	 traceprofiling = boolean: false
	 start_repl = boolean: false
	 noop = boolean: true
	 program = nil
	 opt = table: 0x419c1e40  {t:function: 0x419c3280, q:function: 0x419c3308, P:function: 0x41aeb1e8 (more...)}
(12) Lua function '?' at file 'core/main.lua:67' (best guess)
	Local variables:
	 program = string: "snsh"
	 args = table: 0x402de4f0  {1:script.lua (more...)}
(13) global C function 'xpcall'
(14) main chunk of file 'core/main.lua' at line 211
(15)  C function 'require'
(16) global C function 'pcall'
(17) main chunk of file 'core/startup.lua' at line 3
(18) global C function 'require'
(19) main chunk of [string "require "core.startup""] at line 1
	nil
```
