### PR TITLE
snabbmark esp: prevent GC from being invoked by making local vars local

### DIFF
--- a/src/program/snabbmark/snabbmark.lua
+++ b/src/program/snabbmark/snabbmark.lua
@@ -363,9 +363,8 @@ function esp (npackets, packet_size, mode, profile)
    if mode == "encapsulate" then
       if profile then profiler.start(profile) end
       local start = C.get_monotonic_time()
-      local encapsulated
       for i = 1, npackets do
-         encapsulated = packet.clone(plain)
+         local encapsulated = packet.clone(plain)
          enc:encapsulate(encapsulated)
          packet.free(encapsulated)
       end
@@ -379,9 +378,8 @@ function esp (npackets, packet_size, mode, profile)
       enc:encapsulate(encapsulated)
       if profile then profiler.start(profile) end
       local start = C.get_monotonic_time()
-      local plain
       for i = 1, npackets do
-         plain = packet.clone(encapsulated)
+         local plain = packet.clone(encapsulated)
          dec:decapsulate(plain)
          dec.seq.no = 0
          dec.window[0] = 0


### PR DESCRIPTION
This is a small fix to a bug in the snabbmark esp micro benchmark that had noticeable negative effect on the results. See the commit message for more details.

I found this while benchmarking the (raw) ESP routines on lugano-1, here are the results with this patch:

![snabb-esp-raw](https://user-images.githubusercontent.com/4933566/27683617-eeab018a-5cc6-11e7-9db9-1d074f2afe98.png)


