### PR TITLE
Randomly seed hash function used by ctables

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -898,6 +898,11 @@ integers *n* respectively. Unsigned.
 Network to host byte order conversion functions for 32 and 16 bit
 integers *n* respectively. Unsigned.
 
+— Function **lib.random_bytes** *count*
+
+Return a fresh array of *count* random bytes.  Suitable for
+cryptographic usage.
+
 — Function **lib.parse** *arg*, *config*
 
 Validates *arg* against the specification in *config*, and returns a fresh

--- a/src/README.md
+++ b/src/README.md
@@ -816,9 +816,36 @@ commas. Example:
 comma_value(1000000) => "1,000,000"
 ```
 
-— Function **lib.random_data** *length*
+— Function **lib.random_bytes_from_dev_urandom** *length*
 
-Returns a string of *length* bytes of random data.
+Return *length* bytes of random data, as a byte array, taken from
+`/dev/urandom`.  Suitable for cryptographic usage.
+
+— Function **lib.random_bytes_from_math_random** *length*
+
+Return *length* bytes of random data, as a byte array, where each byte
+was taken from `math.random(0, 255)`.  *Not* suitable for cryptographic
+usage.
+
+— Function **lib.random_bytes** *length*
+— Function **lib.randomseed** *seed*
+
+Initialize Snabb's random number generation facility.  If *seed* is nil,
+then the Lua `math.random()` function will be seeded from
+`/dev/urandom`, and `lib.random_bytes` will be initialized to
+`lib.random_bytes_from_dev_urandom`.  This is Snabb's default mode of
+operation.
+
+Sometimes it's useful to make Snabb use deterministic random numbers.
+In that case, pass a seed to **lib.randomseed**; Snabb will set
+`lib.random_bytes` to `lib.random_bytes_from_math_random`, and also
+print out a message to stderr indicating that we are using lower-quality
+deterministic random numbers.
+
+As part of its initialization process, Snabb will call `lib.randomseed`
+with the value of the `SNABB_RANDOM_SEED` environment variable (if
+any).  Set this environment variable to enable deterministic random
+numbers.
 
 — Function **lib.bounds_checked** *type*, *base*, *offset*, *size*
 

--- a/src/apps/bridge/mac_table.lua
+++ b/src/apps/bridge/mac_table.lua
@@ -553,7 +553,6 @@ function selftest ()
       local info = t:info()
       assert(info.size == s)
       assert(info.mask == info.buckets-1)
-      math.randomseed(0)
       local macs = {}
       local n = 0
       while true do

--- a/src/apps/config/action_codec.lua
+++ b/src/apps/config/action_codec.lua
@@ -98,12 +98,9 @@ local extra = "0123456789_-"
 local alphabet = table.concat({lower_case, upper_case, extra})
 assert(#alphabet == 64)
 local function random_file_name()
-   local f = io.open('/dev/urandom', 'rb')
    -- 22 bytes, but we only use 2^6=64 bits from each byte, so total of
    -- 132 bits of entropy.
-   local bytes = f:read(22)
-   assert(#bytes == 22)
-   f:close()
+   local bytes = lib.random_data(22)
    local out = {}
    for i=1,#bytes do
       table.insert(out, alphabet:byte(bytes:byte(i) % 64 + 1))

--- a/src/apps/intel_mp/intel_mp.lua
+++ b/src/apps/intel_mp/intel_mp.lua
@@ -255,7 +255,6 @@ Intel = {
       txq = {},
       rxq = {},
       mtu = {default=9014},
-      rssseed = {default=314159},
       linkup_wait = {default=120},
       wait_for_link = {default=false},
       master_stats = {default=true},
@@ -289,7 +288,6 @@ function Intel:new (conf)
       txq = conf.txq,
       rxq = conf.rxq,
       mtu = conf.mtu or self.config.mtu.default,
-      rssseed = conf.rssseed or self.config.mtu.default,
       linkup_wait = conf.linkup_wait or self.config.linkup_wait.default,
       wait_for_link = conf.wait_for_link
    }
@@ -554,7 +552,6 @@ function Intel:rss_enable ()
    self:rss_key()
 end
 function Intel:rss_key ()
-   math.randomseed(self.rssseed)
    for i=0,9,1 do
       self.r.RSSRK[i](math.random(2^32))
    end

--- a/src/apps/lwaftr/ctable_wrapper.lua
+++ b/src/apps/lwaftr/ctable_wrapper.lua
@@ -40,8 +40,6 @@ end
 function new(params)
    local ctab = ctable.new(params)
    ctab.add_with_random_ejection = add_with_random_ejection
-   -- Not local-ized because it's called once
-   math.randomseed(bxor(os.time(), S.getpid()))
    return ctab
 end
 

--- a/src/apps/lwaftr/ctable_wrapper.lua
+++ b/src/apps/lwaftr/ctable_wrapper.lua
@@ -47,14 +47,11 @@ end
 
 function selftest()
    local ffi = require("ffi")
-   local hash_32 = ctable.hash_32
-
    local occupancy = 4
    -- 32-byte entries 
    local params = {
       key_type = ffi.typeof('uint32_t'),
       value_type = ffi.typeof('int32_t[6]'),
-      hash_fn = hash_32,
       max_occupancy_rate = 0.4,
       initial_size = ceil(occupancy / 0.4)
    }

--- a/src/apps/lwaftr/fragmentv6_hardened.lua
+++ b/src/apps/lwaftr/fragmentv6_hardened.lua
@@ -37,7 +37,6 @@ constants.o_ipv6_frag_offset, constants.o_ipv6_frag_id,
 constants.o_ipv6_payload_len, constants.ipv6_frag_header_size,
 constants.o_ipv6_next_header
 
-local hash_32 = ctable.hash_32
 local rd16, rd32 = lwutil.rd16, lwutil.rd32
 local uint32_ptr_t = ffi.typeof("uint32_t*")
 local bxor, band = bit.bxor, bit.band
@@ -226,18 +225,6 @@ local function packet_to_reassembly_buffer(pkt)
    return reassembly_buf
 end
 
--- The key is 288 bits: source IPv6 address, destination IPv6 address, and
--- the identification field from the IPv6 fragmentation header.
-local function hash_ipv6(key)
-   local hash = 0
-   local to_hash = ffi.cast(uint32_ptr_t, key)
-   for i=0,8 do
-      local current = to_hash[i]
-      hash = hash_32(bxor(hash, hash_32(current)))
-   end
-   return hash
-end
-
 function initialize_frag_table(max_fragmented_packets, max_pkt_frag)
    -- Initialize module-scoped variables
    max_frags_per_packet = max_pkt_frag
@@ -260,7 +247,6 @@ function initialize_frag_table(max_fragmented_packets, max_pkt_frag)
    local params = {
       key_type = ffi.typeof(ipv6_fragment_key_t),
       value_type = ffi.typeof(ipv6_reassembly_buffer_t),
-      hash_fn = hash_ipv6,
       initial_size = math.ceil(max_fragmented_packets / max_occupy),
       max_occupancy_rate = max_occupy,
    }

--- a/src/core/lib.lua
+++ b/src/core/lib.lua
@@ -706,6 +706,13 @@ function getenv (name)
    else return nil end
 end
 
+-- Wrapper around execve.
+function execv(path, argv)
+   local env = {}
+   for k, v in pairs(syscall.environ()) do table.insert(env, k.."="..v) end
+   return syscall.execve(path, argv or {}, env)
+end
+
 -- Return an array of random bytes.
 function random_bytes_from_dev_urandom (count)
    local bytes = ffi.new(ffi.typeof('uint8_t[$]', count))

--- a/src/core/lib.lua
+++ b/src/core/lib.lua
@@ -224,15 +224,6 @@ function comma_value(n) -- credit http://richard.warburton.it
    return left..(num:reverse():gsub('(%d%d%d)','%1,'):reverse())..right
 end
 
-function random_data(length)
-   result = ""
-   math.randomseed(os.time())
-   for i=1,length do
-      result = result..string.char(math.random(0, 255))
-   end
-   return result
-end
-
 -- Return a table for bounds-checked array access.
 function bounds_checked (type, base, offset, size)
    type = ffi.typeof(type)
@@ -716,7 +707,7 @@ function getenv (name)
 end
 
 -- Return an array of random bytes.
-function random_bytes(count)
+function random_bytes_from_dev_urandom (count)
    local bytes = ffi.new(ffi.typeof('uint8_t[$]', count))
    local f = syscall.open('/dev/urandom', 'rdonly')
    local written = 0
@@ -724,6 +715,32 @@ function random_bytes(count)
       written = written + assert(f:read(bytes, count-written))
    end
    return bytes
+end
+
+function random_bytes_from_math_random (count)
+   local bytes = ffi.new(ffi.typeof('uint8_t[$]', count))
+   for i = 0,count-1 do bytes[i] = math.random(0, 255) end
+   return bytes
+end
+
+function randomseed (seed)
+   seed = tonumber(seed)
+   if seed then
+      local msg = 'Using deterministic random numbers, SNABB_RANDOM_SEED=%d.\n'
+      io.stderr:write(msg:format(seed))
+      math.randomseed(seed)
+      -- When setting a seed, use deterministic random bytes.
+      random_bytes = random_bytes_from_math_random
+   else
+      -- Otherwise use /dev/urandom.
+      seed = ffi.cast('uint32_t*', random_bytes_from_dev_urandom(4))[0]
+      random_bytes = random_bytes_from_dev_urandom
+   end
+   return seed
+end
+
+function random_data (length)
+   return ffi.string(random_bytes(length), length)
 end
 
 -- Compiler barrier.

--- a/src/core/lib.lua
+++ b/src/core/lib.lua
@@ -715,6 +715,17 @@ function getenv (name)
    else return nil end
 end
 
+-- Return an array of random bytes.
+function random_bytes(count)
+   local bytes = ffi.new(ffi.typeof('uint8_t[$]', count))
+   local f = syscall.open('/dev/urandom', 'rdonly')
+   local written = 0
+   while written < count do
+      written = written + assert(f:read(bytes, count-written))
+   end
+   return bytes
+end
+
 -- Compiler barrier.
 -- Prevents LuaJIT from moving load/store operations over this call.
 -- Any FFI call is sufficient to achieve this, see:

--- a/src/core/main.lua
+++ b/src/core/main.lua
@@ -134,6 +134,7 @@ function initialize ()
    require("core.lib")
    require("core.clib_h")
    require("core.lib_h")
+   lib.randomseed(tonumber(lib.getenv("SNABB_RANDOM_SEED")))
    -- Global API
    _G.config = require("core.config")
    _G.engine = require("core.app")

--- a/src/core/worker.lua
+++ b/src/core/worker.lua
@@ -43,11 +43,7 @@ function start (name, luacode)
       S.setenv("SNABB_PROGRAM_LUACODE", luacode, true)
       -- Restart the process with execve().
       -- /proc/$$/exe is a link to the same Snabb executable that we are running
-      local env = {}
-      for key, value in pairs(S.environ()) do
-         table.insert(env, key.."="..value)
-      end
-      S.execve(("/proc/%d/exe"):format(S.getpid()), {}, env)
+      lib.execv(("/proc/%d/exe"):format(S.getpid()), {})
    else
       -- Parent process
       children[name] = { pid = pid }

--- a/src/lib/hash/siphash.dasl
+++ b/src/lib/hash/siphash.dasl
@@ -45,18 +45,8 @@ local function finish (name, prototype, Dst)
    return ffi.cast(prototype, mcode)
 end
 
-local function random_bytes(count)
-   local bytes = ffi.new(ffi.typeof('uint8_t[$]', count))
-   local f = S.open('/dev/urandom', 'rdonly')
-   local written = 0
-   while written < count do
-      written = written + assert(f:read(bytes, count-written))
-   end
-   return bytes
-end
-
 function random_sip_hash_key()
-   return random_bytes(16)
+   return lib.random_bytes(16)
 end
 
 function reference_sip_hash_key()
@@ -631,7 +621,7 @@ function selftest()
       local size = opts.size
       local reference_hash = make_reference_sip_hash(opts)
       local hash1 = make_hash(opts)
-      local test_input = random_bytes(size)
+      local test_input = lib.random_bytes(size)
 
       local ref_result = reference_hash(test_input)
 

--- a/src/lib/hash/siphash.dasl
+++ b/src/lib/hash/siphash.dasl
@@ -49,9 +49,10 @@ function random_sip_hash_key()
    return lib.random_bytes(16)
 end
 
-function reference_sip_hash_key()
-   return ffi.new('uint8_t[16]',
-                  0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
+function sip_hash_key_from_seed(seed)
+   local res = ffi.new('uint8_t[16]')
+   ffi.cast('uint32_t*', res)[0] = assert(tonumber(seed))
+   return res
 end
 
 local function load_initial_state(key)
@@ -63,7 +64,7 @@ local function load_initial_state(key)
                            0x7465646279746573ULL })
 
    -- Mix key into state constants.
-   key = ffi.cast('uint64_t*', key or reference_sip_hash_key())
+   key = ffi.cast('uint64_t*', key or random_sip_hash_key())
    state[0] = bit.bxor(state[0], key[0])
    state[1] = bit.bxor(state[1], key[1])
    state[2] = bit.bxor(state[2], key[0])
@@ -422,7 +423,7 @@ local function Simulator()
 end
 
 local sip_hash_config = {
-   size={required=true}, stride={}, key={default=reference_sip_hash_key()},
+   size={required=true}, stride={}, key={default=false},
    c={default=2}, d={default=4}, as_specified={default=false}, width={default=1}
 }
 local function make_sip_hash(assembler, opts)

--- a/src/lib/hash/siphash.dasl
+++ b/src/lib/hash/siphash.dasl
@@ -46,7 +46,7 @@ local function finish (name, prototype, Dst)
 end
 
 local function random_bytes(count)
-   local bytes = ffi.new('uint8_t[?]', count)
+   local bytes = ffi.new(ffi.typeof('uint8_t[$]', count))
    local f = S.open('/dev/urandom', 'rdonly')
    local written = 0
    while written < count do

--- a/src/lib/yang/binary.lua
+++ b/src/lib/yang/binary.lua
@@ -12,7 +12,7 @@ local ctable = require('lib.ctable')
 local cltable = require('lib.cltable')
 
 local MAGIC = "yangconf"
-local VERSION = 0x00003000
+local VERSION = 0x00005000
 
 local header_t = ffi.typeof([[
 struct {

--- a/src/program/config/bench/bench.lua
+++ b/src/program/config/bench/bench.lua
@@ -95,7 +95,7 @@ function run(args)
       assert(S.dup2(output_write, 1))
       input_read:close()
       output_write:close()
-      S.execve(("/proc/%d/exe"):format(S.getpid()), argv, {})
+      lib.execv(("/proc/%d/exe"):format(S.getpid()), argv)
    end
    input_read:close()
    output_write:close()

--- a/src/program/lwaftr/quickcheck/quickcheck.lua
+++ b/src/program/lwaftr/quickcheck/quickcheck.lua
@@ -61,6 +61,12 @@ local function initialize_property (name, args)
    return prop, prop.handle_prop_args(args)
 end
 
+local function random_bytes_from_math_random(count)
+   local bytes = ffi.new(ffi.typeof('uint8_t[$]', count))
+   for i = 0,count-1 do bytes[i] = math.random(0, 255) end
+   return bytes
+end
+
 function run (args)
    local opts, prop_name, prop_args = parse_args(args)
    local rerun_usage = function (i)
@@ -68,7 +74,9 @@ function run (args)
             format(program_name, opts.seed, i + 1,
                    prop_name, table.concat(prop_args, " ")))
    end
+
    math.randomseed(opts.seed)
+   lib.random_bytes = random_bytes_from_math_random
 
    local prop, prop_info = initialize_property(prop_name, prop_args)
    for i=1,opts.iterations do

--- a/src/program/lwaftr/quickcheck/quickcheck.lua
+++ b/src/program/lwaftr/quickcheck/quickcheck.lua
@@ -71,8 +71,7 @@ function run (args)
    local opts, prop_name, prop_args = parse_args(args)
    local rerun_usage = function (i)
       print(("Rerun as: snabb lwaftr quickcheck --seed=%s --iterations=%s %s %s"):
-            format(program_name, opts.seed, i + 1,
-                   prop_name, table.concat(prop_args, " ")))
+            format(opts.seed, i + 1, prop_name, table.concat(prop_args, " ")))
    end
 
    math.randomseed(opts.seed)

--- a/src/program/lwaftr/quickcheck/quickcheck.lua
+++ b/src/program/lwaftr/quickcheck/quickcheck.lua
@@ -10,23 +10,19 @@ end
 
 local function parse_args (args)
    local handlers = {}
-   local opts = {
-      iterations = 100,
-   }
+   local opts = { iterations = 100 }
    function handlers.h() show_usage(0) end
-   handlers["seed"] = function (arg)
-      opts["seed"] = assert(tonumber(arg), "seed must be a number")
+   function handlers.seed(arg)
+      opts.seed = assert(tonumber(arg), "seed must be a number")
    end
-   handlers["iterations"] = function (arg)
-		opts["iterations"] = assert(tonumber(arg), "iterations must be a number")
+   function handlers.iterations(arg)
+      opts.iterations = assert(tonumber(arg), "iterations must be a number")
    end
-   args = lib.dogetopt(args, handlers, "h",
-      { help="h", ["seed"] = 0, ["iterations"] = 0 })
+   args = lib.dogetopt(args, handlers, "h", {help="h", seed=1, iterations=1})
    if #args == 0 then show_usage(1) end
    if not opts.seed then
-      local seed = math.floor(utils.gmtime() * 1e6) % 10^9
-      print("Using time as seed: "..seed)
-      opts.seed = seed
+      local bytes = lib.random_bytes_from_dev_urandom(4)
+      opts.seed = require('ffi').cast('uint32_t*', bytes)[0]
    end
    local prop_name = table.remove(args, 1)
 
@@ -61,12 +57,6 @@ local function initialize_property (name, args)
    return prop, prop.handle_prop_args(args)
 end
 
-local function random_bytes_from_math_random(count)
-   local bytes = ffi.new(ffi.typeof('uint8_t[$]', count))
-   for i = 0,count-1 do bytes[i] = math.random(0, 255) end
-   return bytes
-end
-
 function run (args)
    local opts, prop_name, prop_args = parse_args(args)
    local rerun_usage = function (i)
@@ -74,8 +64,8 @@ function run (args)
             format(opts.seed, i + 1, prop_name, table.concat(prop_args, " ")))
    end
 
-   math.randomseed(opts.seed)
-   lib.random_bytes = random_bytes_from_math_random
+   lib.randomseed(opts.seed)
+   require('syscall').setenv("SNABB_RANDOM_SEED", tostring(opts.seed), true)
 
    local prop, prop_info = initialize_property(prop_name, prop_args)
    for i=1,opts.iterations do

--- a/src/program/lwaftr/tests/propbased/common.lua
+++ b/src/program/lwaftr/tests/propbased/common.lua
@@ -3,6 +3,7 @@ module(..., package.seeall)
 -- common definitions for property-based tests for snabb config
 
 local S = require("syscall")
+local lib = require("core.lib")
 local pci = require("lib.hardware.pci")
 
 function make_handle_prop_args(name, duration, pidbox)
@@ -21,11 +22,7 @@ function make_handle_prop_args(name, duration, pidbox)
         local cmdline = {"snabb", "lwaftr", "run", "-D", tostring(duration),
             "--conf", "program/lwaftr/tests/data/icmp_on_fail.conf",
             "--reconfigurable", "--on-a-stick", pci_addr}
-        -- preserve PATH variable because the get-state test relies on
-        -- this variable being set to print useful results
-        local pth = os.getenv("PATH")
-        local env = { ("PATH=%s"):format(pth) }
-        S.execve(("/proc/%d/exe"):format(S.getpid()), cmdline, env)
+        lib.execv(("/proc/%d/exe"):format(S.getpid()), cmdline)
      else
         pidbox[1] = pid
         S.sleep(0.1)

--- a/src/program/lwaftr/tests/propbased/prop_sameval.lua
+++ b/src/program/lwaftr/tests/propbased/prop_sameval.lua
@@ -56,6 +56,10 @@ function property()
 
       if results ~= results2 then
          print("Running the same config command twice produced different outputs")
+         print("\n\n\nFirst output:")
+         print(results)
+         print("\n\n\nSecond output:")
+         print(results2)
          return false
       end
    end

--- a/src/program/snabbnfv/neutron_sync_agent/neutron_sync_agent.lua
+++ b/src/program/snabbnfv/neutron_sync_agent/neutron_sync_agent.lua
@@ -39,9 +39,6 @@ function run (args)
    function opt.i (arg) conf["SYNC_INTERVAL"] = arg end
    function opt.H (arg) print(usage) main.exit(1)   end
    args = lib.dogetopt(args, opt, "d:s:t:h:P:p:i:H", long_opts)
-   local env = {}
-   for key, value in pairs(conf) do
-      table.insert(env, key.."="..value) 
-   end
-   syscall.execve("/bin/bash", {"/bin/bash", "-c", script}, env)
+   for key, value in pairs(conf) do S.setenv(key, value, true) end
+   lib.execv("/bin/bash", {"/bin/bash", "-c", script})
 end

--- a/src/program/snabbnfv/neutron_sync_master/neutron_sync_master.lua
+++ b/src/program/snabbnfv/neutron_sync_master/neutron_sync_master.lua
@@ -47,9 +47,6 @@ function run (args)
    function opt.i (arg) conf["SYNC_INTERVAL"]     = arg end
    function opt.h (arg) print(usage) main.exit(1)       end
    args = lib.dogetopt(args, opt, "u:p:t:i:d:m:M:l:L:D:h", long_opts)
-   local env = {}
-   for key, value in pairs(conf) do
-      table.insert(env, key.."="..value) 
-   end
-   syscall.execve("/bin/bash", {"/bin/bash", "-c", script}, env)
+   for key, value in pairs(conf) do S.setenv(key, value, true) end
+   lib.execv("/bin/bash", {"/bin/bash", "-c", script})
 end


### PR DESCRIPTION
This PR changes ctable to randomly seed its SipHash hash functions.  This has two benefits: we prevent some kinds of DOS attacks if the user is able to programmatically make hash collisions, and we fix an accidentally-quadratic behavior if we incrementally populate a ctable from a sequence of entries that were serialized in hash order (https://github.com/Igalia/snabb/issues/654).