### PR TITLE
Fix case in which lib.randomseed didn't do its job

### DIFF
--- a/src/core/lib.lua
+++ b/src/core/lib.lua
@@ -735,7 +735,6 @@ function randomseed (seed)
    if seed then
       local msg = 'Using deterministic random numbers, SNABB_RANDOM_SEED=%d.\n'
       io.stderr:write(msg:format(seed))
-      math.randomseed(seed)
       -- When setting a seed, use deterministic random bytes.
       random_bytes = random_bytes_from_math_random
    else
@@ -743,6 +742,7 @@ function randomseed (seed)
       seed = ffi.cast('uint32_t*', random_bytes_from_dev_urandom(4))[0]
       random_bytes = random_bytes_from_dev_urandom
    end
+   math.randomseed(seed)
    return seed
 end
 


### PR DESCRIPTION
Embarrassingly I made a half-change and `lib.randomseed` didn't do what it said it would in the default case!  This patch fixes the error.  It won't change the property-based tests which actually do specify a seed.