### PR TITLE
[EXPERIMENT] Add FNV hash

### DIFF
--- a/src/lib/hash/fnv.dasl
+++ b/src/lib/hash/fnv.dasl
@@ -40,15 +40,16 @@ local function gen_hash(size)
       -- rdi stores the buffer address
       -- rax stores the hash
       -- rcx is the loop index
-      | mov rcx, 0
+      | mov rcx, size
       | mov eax, basis
+      | mov r8, FNVp
 
       -- main loop
       |1:
-      | xor al, byte [rdi+rcx]
-      | imul eax, FNVp
-      | inc rcx
-      | cmp rcx, size
+      | xor al, byte [rdi]
+      | mul r8
+      | inc rdi
+      | dec rcx
       | jnz <1
 
       -- shift hash by one

--- a/src/lib/hash/fnv.dasl
+++ b/src/lib/hash/fnv.dasl
@@ -40,17 +40,15 @@ local function gen_hash(size)
       -- rdi stores the buffer address
       -- rax stores the hash
       -- rcx is the loop index
-      | mov rcx, size
       | mov eax, basis
       | mov r8, FNVp
 
-      -- main loop
-      |1:
-      | xor al, byte [rdi]
-      | mul r8
-      | inc rdi
-      | dec rcx
-      | jnz <1
+      for i=1,size do
+         -- main loop
+         | xor al, byte [rdi]
+         | mul r8
+         | inc rdi
+      end
 
       -- shift hash by one
       | shl eax, 1

--- a/src/lib/hash/fnv.dasl
+++ b/src/lib/hash/fnv.dasl
@@ -1,0 +1,112 @@
+-- -*- lua -*-
+-- This module constructs hash functions for flow keys using dynasm
+
+module(..., package.seeall)
+
+local bit  = require("bit")
+local dasm = require("dasm")
+local ffi  = require("ffi")
+
+local debug = false
+
+-- constants for 32-bit FNV hashing
+-- see http://www.isthe.com/chongo/tech/comp/fnv/index.html
+local basis = 216613626ULL
+local FNVp  = 16777619ULL
+
+|.arch x64
+|.actionlist actions
+
+-- the definitions here (anchor, assemble, gen) are borrowed from lwaftr
+-- (see multi_copy.lua)
+__anchor = {}
+
+local function assemble (name, prototype, generator)
+   local Dst = dasm.new(actions)
+   generator(Dst)
+   local mcode, size = Dst:build()
+   table.insert(__anchor, mcode)
+   if debug then
+      print("mcode dump: "..name)
+      dasm.dump(mcode, size)
+   end
+   return ffi.cast(prototype, mcode)
+end
+
+-- this is a straightforward transcription of the FNV algorithm into
+-- assembly, see the Lua version below
+local function gen_hash(size)
+   local function gen(Dst)
+      -- rdi stores the buffer address
+      -- rax stores the hash
+      -- rcx is the loop index
+      | mov rcx, 0
+      | mov eax, basis
+
+      -- main loop
+      |1:
+      | xor al, byte [rdi+rcx]
+      | imul eax, FNVp
+      | inc rcx
+      | cmp rcx, size
+      | jnz <1
+
+      -- shift hash by one
+      | shl eax, 1
+      | ret
+   end
+
+   return gen
+end
+
+function make_fnv_hash(size)
+   return assemble("make_fnv_hash",
+                   ffi.typeof("uint32_t (*)(void*)"),
+                   gen_hash(size))
+end
+
+-- lua version for corectness comparison
+local uint32_cast = ffi.new('uint32_t[1]')
+local bxor, lshift = bit.bxor, bit.lshift
+local function make_lua_hash(size)
+   return function(key)
+      local octets = ffi.cast("uint8_t*", key)
+      local hash = basis
+      for i=0, size-1 do
+         hash = bxor(hash, octets[i])
+         hash = hash * FNVp
+      end
+
+      -- see ctable.lua for why we do this
+      local i32 = lshift(hash, 1)
+      uint32_cast[0] = i32
+      return uint32_cast[0]
+   end
+end
+
+function selftest()
+   -- test that the lua and dasm versions produce the same output
+   local function test(size)
+      local dasm_hash = make_fnv_hash(size)
+      local lua_hash = make_lua_hash(size)
+      assert(size < 10)
+
+      for i=0, 255 do
+         -- note: the behavior can be wrong if we pass a short
+         --       (e.g., len 1) array here probably due to calling
+         --       convention so be careful
+         local buf = ffi.new("uint8_t[10]")
+         for j=0, size-1 do
+            buf[j] = i
+         end
+         local h1 = dasm_hash(buf)
+         local h2 = lua_hash(buf)
+         assert(h1 == h2, string.format("%d: %d != %d", size, h1, h2))
+      end
+   end
+
+   test(1)
+   test(2)
+
+   print("selftest ok")
+end

--- a/src/program/snabbmark/snabbmark.lua
+++ b/src/program/snabbmark/snabbmark.lua
@@ -445,6 +445,7 @@ function hash (key_size)
    local function murmur_hash(v)
       return murmur:hash(v, key_size, 0ULL).u32[0]      
    end
+   local fnv_hash = require('lib.hash.fnv').make_fnv_hash(key_size)
    local lib_siphash = require('lib.hash.siphash')
    local sip_hash_1_2_opts = { size=key_size, c=1, d=2 }
    local sip_hash_2_4_opts = { size=key_size, c=2, d=4 }
@@ -491,6 +492,7 @@ function hash (key_size)
 
    test_perf(hash_tester(baseline_hash), 1e8, 'baseline')
    test_perf(hash_tester(murmur_hash), 1e8, 'murmur hash (32 bit)')
+   test_perf(hash_tester(fnv_hash), 1e8, 'fnv hash')
    for _, opts in ipairs({{c=1,d=2}, {c=2,d=4}}) do
       for _, width in ipairs({1,2,4,8}) do
          test_perf(sip_hash_tester(opts, width), 1e8,


### PR DESCRIPTION
This PR collects the FNV hash work that @takikawa did in the context of takikawa#1.  I think SipHash serves our purposes well at this point and probably we don't want to merge this, but I did want to separate it and unearth it from that PR so that we can compare in the future.

```
[wingo@snabb1:~/snabb/src]$ for i in 1 2 4 8 16; do echo -e "\n\ninput length: $i bytes\n"; sudo taskset -c 7 ./snabb snabbmark hash $i; done


input length: 1 bytes

baseline: 11.07 cycles, 3.46 ns per iteration (result: 0)
murmur hash (32 bit): 59.23 cycles, 18.52 ns per iteration (result: 1364076727)
fnv hash: 15.02 cycles, 4.70 ns per iteration (result: 2590564124)
sip hash c=1,d=2 (x1): 29.04 cycles, 9.08 ns per iteration (result: 2596645884)
sip hash c=1,d=2 (x2): 23.02 cycles, 7.19 ns per iteration (result: 2505711562)
sip hash c=1,d=2 (x4): 13.67 cycles, 4.27 ns per iteration (result: 2529291704)
sip hash c=1,d=2 (x8): 12.60 cycles, 3.94 ns per iteration (result: 235453808)
sip hash c=2,d=4 (x1): 43.56 cycles, 13.62 ns per iteration (result: 763720718)
sip hash c=2,d=4 (x2): 40.91 cycles, 12.79 ns per iteration (result: 3267088002)
sip hash c=2,d=4 (x4): 21.93 cycles, 6.86 ns per iteration (result: 628605926)
sip hash c=2,d=4 (x8): 21.42 cycles, 6.70 ns per iteration (result: 456062290)


input length: 2 bytes

baseline: 10.02 cycles, 3.14 ns per iteration (result: 0)
murmur hash (32 bit): 56.89 cycles, 17.78 ns per iteration (result: 821347078)
fnv hash: 14.03 cycles, 4.41 ns per iteration (result: 790051092)
sip hash c=1,d=2 (x1): 28.04 cycles, 8.76 ns per iteration (result: 1808599214)
sip hash c=1,d=2 (x2): 22.75 cycles, 7.11 ns per iteration (result: 1307761568)
sip hash c=1,d=2 (x4): 12.81 cycles, 4.00 ns per iteration (result: 484136952)
sip hash c=1,d=2 (x8): 12.74 cycles, 3.98 ns per iteration (result: 3690637294)
sip hash c=2,d=4 (x1): 44.44 cycles, 13.89 ns per iteration (result: 3853360532)
sip hash c=2,d=4 (x2): 40.67 cycles, 12.71 ns per iteration (result: 3450179066)
sip hash c=2,d=4 (x4): 21.75 cycles, 6.80 ns per iteration (result: 2207605528)
sip hash c=2,d=4 (x8): 21.45 cycles, 6.71 ns per iteration (result: 3823750578)


input length: 4 bytes

baseline: 9.08 cycles, 2.84 ns per iteration (result: 0)
murmur hash (32 bit): 27.03 cycles, 8.45 ns per iteration (result: 593689054)
fnv hash: 14.12 cycles, 4.41 ns per iteration (result: 3420582196)
sip hash c=1,d=2 (x1): 27.04 cycles, 8.45 ns per iteration (result: 237457866)
sip hash c=1,d=2 (x2): 22.01 cycles, 6.91 ns per iteration (result: 3472952488)
sip hash c=1,d=2 (x4): 13.00 cycles, 4.06 ns per iteration (result: 2609656356)
sip hash c=1,d=2 (x8): 12.62 cycles, 3.95 ns per iteration (result: 4104245838)
sip hash c=2,d=4 (x1): 43.24 cycles, 13.51 ns per iteration (result: 4241268186)
sip hash c=2,d=4 (x2): 39.99 cycles, 12.50 ns per iteration (result: 2000075746)
sip hash c=2,d=4 (x4): 28.11 cycles, 8.79 ns per iteration (result: 1873048260)
sip hash c=2,d=4 (x8): 21.26 cycles, 6.65 ns per iteration (result: 1727786682)


input length: 8 bytes

baseline: 8.02 cycles, 2.51 ns per iteration (result: 0)
murmur hash (32 bit): 33.68 cycles, 10.53 ns per iteration (result: 1669671676)
fnv hash: 22.03 cycles, 6.89 ns per iteration (result: 3645689972)
sip hash c=1,d=2 (x1): 26.04 cycles, 8.14 ns per iteration (result: 4251942696)
sip hash c=1,d=2 (x2): 28.56 cycles, 8.93 ns per iteration (result: 1277368270)
sip hash c=1,d=2 (x4): 12.27 cycles, 3.84 ns per iteration (result: 3168764616)
sip hash c=1,d=2 (x8): 11.73 cycles, 3.67 ns per iteration (result: 924631134)
sip hash c=2,d=4 (x1): 41.88 cycles, 13.09 ns per iteration (result: 480673392)
sip hash c=2,d=4 (x2): 41.51 cycles, 12.98 ns per iteration (result: 314562808)
sip hash c=2,d=4 (x4): 21.44 cycles, 6.70 ns per iteration (result: 2884295208)
sip hash c=2,d=4 (x8): 20.47 cycles, 6.40 ns per iteration (result: 284599334)


input length: 16 bytes

baseline: 11.04 cycles, 3.45 ns per iteration (result: 0)
murmur hash (32 bit): 374.96 cycles, 117.47 ns per iteration (result: 2167721464)
fnv hash: 42.01 cycles, 13.13 ns per iteration (result: 2754996980)
sip hash c=1,d=2 (x1): 32.05 cycles, 10.02 ns per iteration (result: 1178498982)
sip hash c=1,d=2 (x2): 29.79 cycles, 9.34 ns per iteration (result: 2506795390)
sip hash c=1,d=2 (x4): 15.86 cycles, 5.03 ns per iteration (result: 2095958168)
sip hash c=1,d=2 (x8): 15.44 cycles, 4.90 ns per iteration (result: 1206018534)
sip hash c=2,d=4 (x1): 54.75 cycles, 17.21 ns per iteration (result: 3198099154)
sip hash c=2,d=4 (x2): 53.81 cycles, 16.82 ns per iteration (result: 4138811086)
sip hash c=2,d=4 (x4): 27.88 cycles, 8.71 ns per iteration (result: 2082067170)
sip hash c=2,d=4 (x8): 31.27 cycles, 9.79 ns per iteration (result: 4173937968)
```