### PR TITLE
Remove src/core/version.lua from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,3 @@ __pycache__
 /src/programs.inc
 .images
 /lib/luajit/usr
-/src/core/version.lua


### PR DESCRIPTION
It was causing a building problem when linking the snabb binary:

```
LINK snabb
obj/version_lua.o:(.rodata+0x0): multiple definition of luaJIT_BC_core_version' obj/core/version_lua.o:(.rodata+0x0): first defined here /usr/bin/ld: Warning: size of symbolluaJIT_BC_core_version' changed from 123 in obj/core/version_lua.o to 150 in obj/version_lua.o
collect2: error: ld returned 1 exit status
Makefile:60: recipe for target 'snabb' failed
make[1]: *** [snabb] Error 1
make[1]: Leaving directory '/home/dpino/workspace/snabb/src'
Makefile:11: recipe for target 'all' failed
make: *** [all] Error 2
```
