### PR TITLE
Avoid the most repetitive output in tests

### DIFF
--- a/src/apps/socket/unix.lua
+++ b/src/apps/socket/unix.lua
@@ -146,15 +146,15 @@ end
 
 function selftest ()
    print("selftest: socket/unix")
-   local printapp = {}
-   function printapp:new (name)
+   local checkapp = {}
+   function checkapp:new (name)
       return {
          push = function(self)
             local l = self.input.rx
             if l == nil then return end
             while not link.empty(l) do
                local p = link.receive(l)
-               print(name..': ', p.length, ffi.string(p.data, p.length))
+               assert(p, "No packet received")
                packet.free(p)
             end
          end
@@ -181,9 +181,9 @@ function selftest ()
    local c = config.new()
    config.app(c,  "server", UnixSocket, {filename = file, listen = true})
    config.app(c,  "client", UnixSocket, file)
-   config.app(c,  "print_client_tx", printapp, "client tx")
+   config.app(c,  "check_client_tx", checkapp, "client tx")
    config.app(c,  "say_hello", echoapp, "hello ")
-   config.link(c, "client.tx -> print_client_tx.rx")
+   config.link(c, "client.tx -> check_client_tx.rx")
    config.link(c, "say_hello.tx -> client.rx")
    config.link(c, "server.tx -> server.rx")
 
@@ -191,4 +191,3 @@ function selftest ()
    engine.main({duration=0.1, report = {showlinks=true}})
    print("selftest: done")
 end
-

--- a/src/core/lib.lua
+++ b/src/core/lib.lua
@@ -730,16 +730,12 @@ function random_bytes_from_math_random (count)
    return bytes
 end
 
-local lastseed=0
 function randomseed (seed)
    seed = tonumber(seed)
    if seed then
+      local msg = 'Using deterministic random numbers, SNABB_RANDOM_SEED=%d.\n'
+      io.stderr:write(msg:format(seed))
       -- When setting a seed, use deterministic random bytes.
-      if seed ~= lastseed then
-        lastseed = seed
-        local msg = 'Using deterministic random numbers, SNABB_RANDOM_SEED=%d.\n'
-        io.stderr:write(msg:format(seed))
-      end
       random_bytes = random_bytes_from_math_random
    else
       -- Otherwise use /dev/urandom.

--- a/src/core/lib.lua
+++ b/src/core/lib.lua
@@ -730,10 +730,16 @@ function random_bytes_from_math_random (count)
    return bytes
 end
 
+local lastseed=0
 function randomseed (seed)
    seed = tonumber(seed)
    if seed then
       -- When setting a seed, use deterministic random bytes.
+      if seed ~= lastseed then
+        lastseed = seed
+        local msg = 'Using deterministic random numbers, SNABB_RANDOM_SEED=%d.\n'
+        io.stderr:write(msg:format(seed))
+      end
       random_bytes = random_bytes_from_math_random
    else
       -- Otherwise use /dev/urandom.

--- a/src/core/lib.lua
+++ b/src/core/lib.lua
@@ -733,8 +733,6 @@ end
 function randomseed (seed)
    seed = tonumber(seed)
    if seed then
-      local msg = 'Using deterministic random numbers, SNABB_RANDOM_SEED=%d.\n'
-      io.stderr:write(msg:format(seed))
       -- When setting a seed, use deterministic random bytes.
       random_bytes = random_bytes_from_math_random
    else


### PR DESCRIPTION
The test suite output has become very long and repetitive when there are errors, so much so that Github truncates the report ([example](https://gist.github.com/lwaftr-igalia/52ef86d3ab93dd8859d0726a180f486e)). This removes the worst offender, generating hundreds of lines.