### PR TITLE
[sketch] Share links between processes, balance packets using global freelist

### DIFF
--- a/src/core/app.lua
+++ b/src/core/app.lua
@@ -137,6 +137,16 @@ function configure (new_config)
    counter.add(configs)
 end
 
+-- XXX - Shared links mud, wax off
+function attach_input (app, port, path)
+   link_table[path] = link.open(path)
+   app_table[app].input[port] = link_table[path]
+end
+function attach_output (app, port, path)
+   link_table[path] = link.open(path)
+   app_table[app].output[port] = link_table[path]
+end
+
 -- Removes the claim on a name, freeing it for other programs.
 --
 -- This relinquish a claim on a name if one exists. if the name does not

--- a/src/core/app.lua
+++ b/src/core/app.lua
@@ -485,6 +485,8 @@ function breathe ()
    -- Commit counters at a reasonable frequency
    if counter.read(breaths) % 100 == 0 then counter.commit() end
    running = false
+   -- Rebalance freelist
+   packet.rebalance()
 end
 
 function report (options)

--- a/src/core/app.lua
+++ b/src/core/app.lua
@@ -139,12 +139,18 @@ end
 
 -- XXX - Shared links mud, wax off
 function attach_input (app, port, path)
-   link_table[path] = link.open(path)
-   app_table[app].input[port] = link_table[path]
+   local l = link.open(path)
+   link_table[path] = l
+   local app = app_table[app]
+   app.input[port] = l
+   table.insert(app.input, l)
 end
 function attach_output (app, port, path)
-   link_table[path] = link.open(path)
-   app_table[app].output[port] = link_table[path]
+   local l = link.open(path)
+   link_table[path] = l
+   local app = app_table[app]
+   app.output[port] = l
+   table.insert(app.output, l)
 end
 
 -- Removes the claim on a name, freeing it for other programs.

--- a/src/core/app.lua
+++ b/src/core/app.lua
@@ -470,6 +470,9 @@ function breathe ()
          zone(app.zone)
          with_restart(app, app.pull)
          zone()
+         for _, r in ipairs(app.output) do
+            link.produce(r)
+         end
       end
    end
    -- Exhale: push work out through the app network
@@ -479,6 +482,12 @@ function breathe ()
          zone(app.zone)
          with_restart(app, app.push)
          zone()
+         for _, r in ipairs(app.input) do
+            link.consume(r)
+         end
+         for _, r in ipairs(app.output) do
+            link.produce(r)
+         end
       end
    end
    counter.add(breaths)
@@ -553,8 +562,8 @@ function report_links ()
    table.sort(names)
    for i, name in ipairs(names) do
       l = link_table[name]
-      local txpackets = counter.read(l.stats.txpackets)
-      local txdrop = counter.read(l.stats.txdrop)
+      local txpackets = counter.read(l.txpackets)
+      local txdrop = counter.read(l.txdrop)
       print(("%20s sent on %s (loss rate: %d%%)"):format(
             lib.comma_value(txpackets), name, loss_rate(txdrop, txpackets)))
    end

--- a/src/core/counter.lua
+++ b/src/core/counter.lua
@@ -56,10 +56,10 @@ function create (name, initval)
    return private[n]
 end
 
-function open (name)
+function open (name, readonly)
    if numbers[name] then return private[numbers[name]] end
    local n = #public+1
-   public[n] = shm.open(name, counter_t, 'readonly')
+   public[n] = shm.open(name, counter_t, readonly)
    private[n] = public[#public] -- use counter directly
    numbers[name] = n
    return private[n]

--- a/src/core/link.h
+++ b/src/core/link.h
@@ -1,19 +1,28 @@
 /* Use of this source code is governed by the Apache 2.0 license; see COPYING. */
 
 enum { LINK_RING_SIZE    = 1024,
-       LINK_MAX_PACKETS  = LINK_RING_SIZE - 1
+       LINK_MAX_PACKETS  = LINK_RING_SIZE - 1,
+       CACHE_LINE        = 64
 };
 
 struct link {
   // this is a circular ring buffer, as described at:
   //   http://en.wikipedia.org/wiki/Circular_buffer
-  struct packet *packets[LINK_RING_SIZE];
-  struct {
-    struct counter dtime, txbytes, rxbytes, txpackets, rxpackets, txdrop;
-  } stats;
+  char pad0[CACHE_LINE];
   // Two cursors:
   //   read:  the next element to be read
   //   write: the next element to be written
   int read, write;
+  struct counter dtime;
+  char pad1[CACHE_LINE-2*sizeof(int)-sizeof(struct counter)];
+  // consumer-local cursors
+  int lwrite, nread;
+  struct counter rxbytes, rxpackets;
+  char pad2[CACHE_LINE-2*sizeof(int)-2*sizeof(struct counter)];
+  // producer-local cursors
+  int lread, nwrite;
+  struct counter txbytes, txpackets, txdrop;
+  char pad3[CACHE_LINE-2*sizeof(int)-3*sizeof(struct counter)];
+  struct packet *packets[LINK_RING_SIZE];
 };
 

--- a/src/core/link.h
+++ b/src/core/link.h
@@ -9,7 +9,7 @@ struct link {
   //   http://en.wikipedia.org/wiki/Circular_buffer
   struct packet *packets[LINK_RING_SIZE];
   struct {
-    struct counter *dtime, *txbytes, *rxbytes, *txpackets, *rxpackets, *txdrop;
+    struct counter dtime, txbytes, rxbytes, txpackets, rxpackets, txdrop;
   } stats;
   // Two cursors:
   //   read:  the next element to be read

--- a/src/core/link.lua
+++ b/src/core/link.lua
@@ -28,7 +28,7 @@ local provided_counters = {
 
 function new (name)
    local r = shm.create("links/"..name.."/link", link_t)
-   counter.set(r.stats.dtime, C.get_unix_time())
+   counter.set(r.dtime, C.get_unix_time())
    return r
 end
 
@@ -41,60 +41,89 @@ function free (r, name)
    shm.unlink("links/"..name)
 end
 
+local function NEXT (i)
+   return band(i + 1, size - 1)
+end
+
 function receive (r)
 --   if debug then assert(not empty(r), "receive on empty link") end
-   local p = r.packets[r.read]
-   r.read = band(r.read + 1, size - 1)
+   local p = r.packets[r.nread]
+   r.nread = NEXT(r.nread)
 
-   counter.add(r.stats.rxpackets)
-   counter.add(r.stats.rxbytes, p.length)
+   counter.add(r.rxpackets)
+   counter.add(r.rxbytes, p.length)
    return p
 end
 
 function front (r)
-   return (r.read ~= r.write) and r.packets[r.read] or nil
+   return (not empty(r)) and r.packets[r.nread] or nil
+end
+
+-- Return true if the ring is empty.
+function empty (r)
+   if r.nread == r.lwrite then
+      if r.nread == r.write then
+         return true
+      end
+      r.lwrite = r.write
+   end
+   return false
 end
 
 function transmit (r, p)
 --   assert(p)
    if full(r) then
-      counter.add(r.stats.txdrop)
+      counter.add(r.txdrop)
       packet.free(p)
    else
-      r.packets[r.write] = p
-      r.write = band(r.write + 1, size - 1)
-      counter.add(r.stats.txpackets)
-      counter.add(r.stats.txbytes, p.length)
+      r.packets[r.nwrite] = p
+      r.nwrite = NEXT(r.nwrite)
+      counter.add(r.txpackets)
+      counter.add(r.txbytes, p.length)
    end
-end
-
--- Return true if the ring is empty.
-function empty (r)
-   return r.read == r.write
 end
 
 -- Return true if the ring is full.
 function full (r)
-   return band(r.write + 1, size - 1) == r.read
+   local after_nwrite = NEXT(r.nwrite)
+   if after_nwrite == r.lread then
+      if after_nwrite == r.read then
+         return true
+      end
+      r.lread = r.read
+   end
+   return false
 end
 
 -- Return the number of packets that are ready for read.
 function nreadable (r)
-   if r.read > r.write then
-      return r.write + size - r.read
+   if r.nread > r.write then
+      return r.write + size - r.nread
    else
-      return r.write - r.read
+      return r.write - r.nread
    end
 end
 
-function nwritable (r)
-   return max - nreadable(r)
+function nwriteable (r)
+   if r.read > r.nwrite then
+      return max - (r.nwrite + size - r.read)
+   else
+      return max - (r.nwrite - r.read)
+   end
+end
+
+function produce (r)
+   r.write = r.nwrite
+end
+
+function consume (r)
+   r.read = r.nread
 end
 
 function stats (r)
    local stats = {}
    for _, c in ipairs(provided_counters) do
-      stats[c] = tonumber(counter.read(r.stats[c]))
+      stats[c] = tonumber(counter.read(r[c]))
    end
    return stats
 end

--- a/src/core/link.lua
+++ b/src/core/link.lua
@@ -28,27 +28,16 @@ local provided_counters = {
 
 function new (name)
    local r = shm.create("links/"..name.."/link", link_t)
-   for _, c in ipairs(provided_counters) do
-      r.stats[c] = counter.create("links/"..name.."/"..c..".counter")
-   end
    counter.set(r.stats.dtime, C.get_unix_time())
    return r
 end
 
 function open (path)
-   print("link open", path)
    local r = shm.open(path.."/link", link_t)
-   for _, c in ipairs(provided_counters) do
-      r.stats[c] = counter.open(path.."/"..c..".counter")
-      print(c, r.stats[c])
-   end
    return r
 end
 
 function free (r, name)
-   for _, c in ipairs(provided_counters) do
-      counter.delete("links/"..name.."/"..c..".counter")
-   end
    shm.unlink("links/"..name)
 end
 

--- a/src/core/link.lua
+++ b/src/core/link.lua
@@ -27,11 +27,19 @@ local provided_counters = {
 }
 
 function new (name)
-   local r = ffi.new(link_t)
+   local r = shm.create("links/"..name.."/link", link_t)
    for _, c in ipairs(provided_counters) do
       r.stats[c] = counter.create("links/"..name.."/"..c..".counter")
    end
    counter.set(r.stats.dtime, C.get_unix_time())
+   return r
+end
+
+function open (path)
+   local r = shm.open(path.."/link", link_t)
+   for _, c in ipairs(provided_counters) do
+      r.stats[c] = counter.open(path.."/"..c..".counter")
+   end
    return r
 end
 

--- a/src/core/link.lua
+++ b/src/core/link.lua
@@ -36,9 +36,11 @@ function new (name)
 end
 
 function open (path)
+   print("link open", path)
    local r = shm.open(path.."/link", link_t)
    for _, c in ipairs(provided_counters) do
       r.stats[c] = counter.open(path.."/"..c..".counter")
+      print(c, r.stats[c])
    end
    return r
 end

--- a/src/core/spinlock.dasl
+++ b/src/core/spinlock.dasl
@@ -1,0 +1,46 @@
+module(...,package.seeall)
+
+local dasm = require("dasm")
+local ffi = require("ffi")
+
+| .arch x64
+| .actionlist actions
+| .globalnames globalnames
+
+local function generate(Dst)
+   Dst:growpc(16)
+
+   | .align 16
+   |->lock:
+   -- attempt to acquire
+   | mov eax, 1
+   | xchg eax, dword [rdi]
+   | test eax, eax		-- was it 0 (unlocked)?
+   | jnz >1			-- no, go spin
+   | ret
+   -- spin
+   |1:
+   | pause
+   | cmp dword [rdi], 1		-- does it look locked?
+   | je <1			-- spin if it does
+   | jmp ->lock			-- otherwise try to acquire
+
+   | .align 16
+   |->unlock:
+   | mov dword [rdi], 0
+   | ret
+end
+
+local Dst, globals = dasm.new(actions, nil, nil, 1 + #globalnames)
+generate(Dst)
+local code, size = Dst:build()
+
+if nil then
+   dasm.dump(code, size)
+end
+
+local entry = dasm.globals(globals, globalnames)
+
+return setmetatable ({ lock = ffi.cast("void (*)(int32_t *)", entry.lock),
+		       unlock = ffi.cast("void (*)(int32_t *)", entry.unlock)
+		     }, {_anchor = code})

--- a/src/core/spinlock.dasl
+++ b/src/core/spinlock.dasl
@@ -41,6 +41,7 @@ end
 
 local entry = dasm.globals(globals, globalnames)
 
-return setmetatable ({ lock = ffi.cast("void (*)(int32_t *)", entry.lock),
+return setmetatable ({ new = function () return ffi.new("int32_t[1]") end,
+                       lock = ffi.cast("void (*)(int32_t *)", entry.lock),
 		       unlock = ffi.cast("void (*)(int32_t *)", entry.unlock)
 		     }, {_anchor = code})

--- a/src/linkshare_test.lua
+++ b/src/linkshare_test.lua
@@ -22,9 +22,11 @@ engine.configure(c)
 
 engine.attach_output("source", "output", "group/test.link")
 
+engine.busywait = true
 engine.main()
 ]])
 
+engine.busywait = true
 engine.main({duration=10, report={showlinks=true}})
 
 for w, s in pairs(worker.status()) do

--- a/src/linkshare_test.lua
+++ b/src/linkshare_test.lua
@@ -1,0 +1,35 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
+local worker = require("core.worker")
+local shm = require("core.shm")
+local Sink = require("apps.basic.basic_apps").Sink
+
+local c = config.new()
+config.app(c, "sink", Sink)
+engine.configure(c)
+
+link.new("test")
+shm.alias("group/test.link", "links/test")
+
+engine.attach_input("sink", "input", "group/test.link")
+
+worker.start("source", [[
+local Source = require("apps.basic.basic_apps").Source
+
+local c = config.new()
+config.app(c, "source", Source)
+engine.configure(c)
+
+engine.attach_output("source", "output", "group/test.link")
+
+engine.main()
+]])
+
+engine.main({duration=10, report={showlinks=true}})
+
+for w, s in pairs(worker.status()) do
+   print(("worker %s: pid=%s alive=%s status=%s"):format(
+         w, s.pid, s.alive, s.status))
+end
+local stats = link.stats(engine.app_table["sink"].input.input)
+print(stats.txpackets / 1e6 / 10 .. " Mpps")

--- a/src/linkshare_test.lua
+++ b/src/linkshare_test.lua
@@ -8,7 +8,7 @@ local c = config.new()
 config.app(c, "sink", Sink)
 engine.configure(c)
 
-link.new("test")
+local l = link.new("test")
 shm.alias("group/test.link", "links/test")
 
 engine.attach_input("sink", "input", "group/test.link")
@@ -21,18 +21,16 @@ config.app(c, "source", Source)
 engine.configure(c)
 
 engine.attach_output("source", "output", "group/test.link")
+link.transmit(engine.link_table["group/test.link"], packet.allocate())
 
 engine.main()
 ]])
 
-engine.main({duration=10})
-link.open("group/test.link")
-engine.report_links()
-engine.report_apps()
+engine.main({duration=10, report={showlinks=true}})
 
 for w, s in pairs(worker.status()) do
    print(("worker %s: pid=%s alive=%s status=%s"):format(
          w, s.pid, s.alive, s.status))
 end
-local stats = link.stats(engine.app_table["sink"].input.input)
+local stats = link.stats(l)
 print(stats.txpackets / 1e6 / 10 .. " Mpps")

--- a/src/linkshare_test.lua
+++ b/src/linkshare_test.lua
@@ -21,7 +21,6 @@ config.app(c, "source", Source)
 engine.configure(c)
 
 engine.attach_output("source", "output", "group/test.link")
-link.transmit(engine.link_table["group/test.link"], packet.allocate())
 
 engine.main()
 ]])

--- a/src/linkshare_test.lua
+++ b/src/linkshare_test.lua
@@ -25,7 +25,10 @@ engine.attach_output("source", "output", "group/test.link")
 engine.main()
 ]])
 
-engine.main({duration=10, report={showlinks=true}})
+engine.main({duration=10})
+link.open("group/test.link")
+engine.report_links()
+engine.report_apps()
 
 for w, s in pairs(worker.status()) do
    print(("worker %s: pid=%s alive=%s status=%s"):format(


### PR DESCRIPTION
This is a proof of concept implementation of the ideas described in #772, using the spin-lock implementation of said PR.

To summarize, plain old links are allocated in shared memory and shared between snabb processes to interchange packets. This works because `struct link` is an inherently MP-safe single-producer/single-consumer queue. Packets are fed back into starved processes via a global freelist protected by a spin-lock.

We expect to be able to lift the performance to a practical level by optimizing `struct link` for multi-threaded using techniques borrowed from the MCRingBuffer described in the paper linked in #772.

This PR can be tested like so (only lightly tested so far):

```
$ sudo ./snabb snsh linkshare_test.lua
link report:
          11,679,306 sent on group/test.link (loss rate: 0%)
worker source: pid=21814 alive=true status=nil
1.1679306 Mpps
```

Notable issues regarding the implementation include:

- this PoC adds silly `attach_input`/`attach_output` functions to connect apps to inter-process links that should be replaced by a nicer extension to the configuration language
- apps connected to inter-process links need some special attention in `compute_breathe_order`, this PoC reverts the recent topological pull order changes instead
- the link structure currently includes pointers to its counters, this needlessly complicates the implementation (this PoC embeds the counters directly) and needs to be cleaned up