### PR TITLE
Integrate ARP into IPFIX exporter

### DIFF
--- a/src/apps/ipfix/README.md
+++ b/src/apps/ipfix/README.md
@@ -55,20 +55,10 @@ v9; 10 indicates RFC 7011 IPFIX.  The default is 10.
 *Optional*.  Observation domain tag to attach to all exported packets.
 The default is 256.
 
-— Key **exporter_mac**
-
-*Required*, sadly.  The Ethernet address from which to send exported
-packets.  See the to-do list below, for more discussion.
-
 — Key **exporter_ip**
 
 *Required*, sadly.  The IPv4 address from which to send exported UDP
 packets.
-
-— Key **collector_mac**
-
-*Required*, sadly.  The Ethernet address to which to send exported
-packets.  See the to-do list below, for more discussion.
 
 — Key **collector_ip**
 
@@ -117,11 +107,6 @@ should use a special-purpose data structure.
 Currently internal flow start and end times use UNIX time.  This isn't
 great for timers, but it does match what's specified in RFC 7011.
 Could we switch to monotonic time?
-
-#### Remove L2 addresses from IPFIX configuration
-
-We should use the ARP app to look up next-hop destination MAC address,
-and let the interface set the source address.
 
 #### Allow export to IPv6 collectors
 

--- a/src/apps/ipfix/ipfix.lua
+++ b/src/apps/ipfix/ipfix.lua
@@ -298,11 +298,7 @@ local ipfix_config_params = {
    -- maximum of 512 octets should be used for UDP transmission.
    mtu = { default = 512 },
    observation_domain = { default = 256 },
-   -- FIXME: Let the interface set the L2 source address.
-   exporter_mac = { required = true },
    exporter_ip = { required = true },
-   -- FIXME: Use ARP to determine the L2 destination address.
-   collector_mac = { required = true },
    collector_ip = { required = true },
    collector_port = { required = true },
    templates = { default = { template.v4, template.v6 } }
@@ -316,10 +312,8 @@ function IPFIX:new(config)
                next_template_refresh = -1,
                version = config.ipfix_version,
                observation_domain = config.observation_domain,
-               exporter_mac = config.exporter_mac,
                exporter_ip = config.exporter_ip,
                exporter_port = math.random(49152, 65535),
-               collector_mac = config.collector_mac,
                collector_ip = config.collector_ip,
                collector_port = config.collector_port }
 
@@ -384,11 +378,9 @@ function IPFIX:add_ipfix_header(pkt, count)
 end
 
 function IPFIX:add_transport_headers (pkt)
-   -- TODO: support IPv6, also obtain the MAC of the dst via ARP
-   --       and use the correct src MAC (this is ok for use on the
-   --       loopback device for now).
-   local eth_h = ether:new({ src = ether:pton(self.exporter_mac),
-                             dst = ether:pton(self.collector_mac),
+   -- TODO: Support IPv6.
+   local eth_h = ether:new({ src = ether:pton('00:00:00:00:00:00'),
+                             dst = ether:pton('00:00:00:00:00:00'),
                              type = 0x0800 })
    local ip_h  = ipv4:new({ src = ipv4:pton(self.exporter_ip),
                             dst = ipv4:pton(self.collector_ip),
@@ -454,9 +446,7 @@ function selftest()
    local consts = require("apps.lwaftr.constants")
    local ethertype_ipv4 = consts.ethertype_ipv4
    local ethertype_ipv6 = consts.ethertype_ipv6
-   local ipfix = IPFIX:new({ exporter_mac = "00:11:22:33:44:55",
-                             exporter_ip = "192.168.1.2",
-                             collector_mac = "55:44:33:22:11:00",
+   local ipfix = IPFIX:new({ exporter_ip = "192.168.1.2",
                              collector_ip = "192.168.1.1",
                              collector_port = 4739 })
 

--- a/src/program/ipfix/README.md
+++ b/src/program/ipfix/README.md
@@ -1,0 +1,25 @@
+### ipfix probe
+
+The `ipfix probe` program runs an IPFIX meter and exporter on the
+packets coming in on an interface.  It can be invoked like so:
+
+```
+./snabb ipfix probe [options] <input> <output>
+```
+
+The *input* argument names an interface on which to read traffic, and
+*output* indicates the interface on which to send exported UDP
+packets.  For example, to take input from the Intel 82599 card at PCI
+address `03:00.0`, send output to `03:00.1`, and bind to the CPU 2, do:
+
+```
+./snabb ipfix probe --cpu 2 03:00.0 03:00.1
+```
+
+Usually you want to run `ipfix probe` using an input interface that
+receives a mirror of your "main" traffic flow.
+
+See `./snabb ipfix probe --help` for more documentation on options to
+pass to `snabb ipfix probe`, including options to set the IPv4
+addresses of the exporter and collector (which default to 10.0.0.1 and
+10.0.0.2, respectively).

--- a/src/program/ipfix/probe/README
+++ b/src/program/ipfix/probe/README
@@ -1,12 +1,13 @@
 Usage: snabb ipfix probe [options] <input> <output>
        snabb ipfix probe --help
 
-Mandatory arguments:
+Available options:
        -m, --host-mac <macaddr> The MAC address of the host running the exporter.
+                                Defaults to a randomly generated MAC.
        -a, --host-ip  <ipaddr>  The IP address of the host running the exporter.
+                                Defaults to 10.0.0.1.
        -c, --collector <ipaddr> The IP address of the flow collector.
-
-Optional arguments:
+                                Defaults to 10.0.0.2.
        -i, --input-type <type>  One of pcap, raw, or intel10g. Specifies
                                 how to interpret the <input> argument. Interprets
                                 <input> as a pcap file path, device name, or
@@ -23,3 +24,5 @@ Optional arguments:
        --transport <proto>      The transport protocol to use to communicate to
                                 the flow collector. Valid values depend on whether
                                 IPFIX or Netflow V9 is used.
+       --cpu <cpu>              Bind to the given CPU.  See the Snabb
+                                performance guide for more details.

--- a/src/program/ipfix/probe/probe.lua
+++ b/src/program/ipfix/probe/probe.lua
@@ -38,7 +38,6 @@ local long_opts = {
    duration = "D",
    port = "p",
    transport = 1,
-   stats = "s",
    ["host-ip"] = "a",
    ["input-type"] = "i",
    ["output-type"] = "o",
@@ -114,7 +113,7 @@ function run (args)
       end
    }
 
-   args = lib.dogetopt(args, opt, "hsD:i:o:p:m:a:c:M:", long_opts)
+   args = lib.dogetopt(args, opt, "hD:i:o:p:m:a:c:", long_opts)
    if #args ~= 2 then
       print(require("program.ipfix.probe.README_inc"))
       main.exit(1)

--- a/src/program/ipfix/probe/probe.lua
+++ b/src/program/ipfix/probe/probe.lua
@@ -7,6 +7,8 @@ local lib      = require("core.lib")
 local link     = require("core.link")
 local arp      = require("apps.ipv4.arp")
 local ipfix    = require("apps.ipfix.ipfix")
+local ipv4     = require("lib.protocol.ipv4")
+local ethernet = require("lib.protocol.ethernet")
 local numa     = require("lib.numa")
 
 -- apps that can be used as an input or output for the exporter

--- a/src/program/ipfix/probe/probe.lua
+++ b/src/program/ipfix/probe/probe.lua
@@ -37,7 +37,6 @@ local long_opts = {
    port = "p",
    transport = 1,
    stats = "s",
-   ["host-mac"] = "m",
    ["host-ip"] = "a",
    ["input-type"] = "i",
    ["output-type"] = "o",
@@ -53,15 +52,15 @@ function run (args)
 
    local input_type, output_type = "intel10g", "intel10g"
 
-   local host_mac, host_ip
-   local collector_mac, colletor_ip
+   local host_mac
+   local host_ip = '10.0.0.1' -- Just to have a default.
+   local collector_ip = '10.0.0.2' -- Likewise.
    local port = 4739
 
    local active_timeout, idle_timeout
    local ipfix_version = 10
 
    local cpu
-   local report = false
 
    -- TODO: better input validation
    local opt = {
@@ -83,9 +82,6 @@ function run (args)
       p = function (arg)
          port = assert(tonumber(arg), "expected number for port")
       end,
-      s = function (arg)
-         report = true
-      end,
       m = function (arg)
          host_mac = arg
       end,
@@ -94,10 +90,6 @@ function run (args)
       end,
       c = function (arg)
          collector_ip = arg
-      end,
-      -- TODO: this should probably be superceded by using ARP
-      M = function (arg)
-         collector_mac = arg
       end,
       ["active-timeout"] = function (arg)
          active_timeout =
@@ -126,23 +118,16 @@ function run (args)
       main.exit(1)
    end
 
-   assert(host_mac, "--host-mac argument required")
-   assert(host_ip, "--host-ip argument required")
-   assert(collector_ip, "--collector argument required")
-
    local in_link, in_app   = in_out_apps[input_type](args[1])
    local out_link, out_app = in_out_apps[output_type](args[2])
 
-   local arp_config    = { self_mac = host_mac,
-                           self_ip = host_ip,
-                           next_mac = collector_mac,
-                           next_ip = collector_ip }
+   local arp_config    = { self_mac = host_mac and ethernet:pton(self_mac),
+                           self_ip = ipv4:pton(host_ip),
+                           next_ip = ipv4:pton(collector_ip) }
    local ipfix_config    = { active_timeout = active_timeout,
                              idle_timeout = idle_timeout,
                              ipfix_version = ipfix_version,
-                             exporter_mac = host_mac,
                              exporter_ip = host_ip,
-                             collector_mac = collector_mac,
                              collector_ip = collector_ip,
                              collector_port = port }
    local c = config.new()
@@ -164,21 +149,20 @@ function run (args)
       end
    end
 
-   local start_time = now()
+   local t1 = now()
    if cpu then numa.bind_to_cpu(cpu) end
 
    engine.configure(c)
    engine.busywait = true
    engine.main({ duration = duration, done = done })
 
-   if report then
-      local end_time = now()
-      local stats = link.stats(engine.app_table.ipfix.input.input)
-      print("IPFIX probe stats:")
-      print(string.format("bytes: %s packets: %s bps: %s Mpps: %s",
-                          lib.comma_value(stats.rxbytes),
-                          lib.comma_value(stats.rxpackets),
-                          lib.comma_value(math.floor((stats.rxbytes * 8) / (end_time - start_time))),
-                          lib.comma_value(stats.rxpackets / ((end_time - start_time) * 1000000))))
-  end
+   local t2 = now()
+   local stats = link.stats(engine.app_table.ipfix.input.input)
+   print("IPFIX probe stats:")
+   local comma = lib.comma_value
+   print(string.format("bytes: %s packets: %s bps: %s Mpps: %s",
+                       comma(stats.rxbytes),
+                       comma(stats.rxpackets),
+                       comma(math.floor((stats.rxbytes * 8) / (t2 - t1))),
+                       comma(stats.rxpackets / ((t2 - t1) * 1000000))))
 end

--- a/src/program/ipfix/tests/bench.sh
+++ b/src/program/ipfix/tests/bench.sh
@@ -26,7 +26,7 @@ function benchmark {
   for (( i=1; i<=$ITERS; i++ ))
   do
     # run the probe
-    ./snabb ipfix probe --cpu $CPU -s -i intel10g -o intel10g -m 00:11:22:33:44:55 -a 192.168.1.2 -M 55:44:33:22:11:00 -c 192.168.1.3 -p 2100 -D $DURATION $PCI1 $PCI3 > $output &
+    ./snabb ipfix probe --cpu $CPU -D $DURATION $PCI1 $PCI3 > $output &
     # blast with pcap traffic
     ./snabb packetblaster replay -D $DURATION $pcap $PCI2 > /dev/null &
     wait


### PR DESCRIPTION
This branch merges in the new ARP app to the IPFIX exporter, so that you don't have to specify MAC addresses when running the VNF.  It also adds some minimal `ipfix probe` documentation.