### PR TITLE
Add an integration test for ipfix probe using an ipfix collector

### DIFF
--- a/src/apps/ipv4/arp.lua
+++ b/src/apps/ipv4/arp.lua
@@ -196,17 +196,15 @@ function ARP:push()
       end
    end
 
-   for _ = 1, link.nreadable(inorth) do
-      local p = receive(inorth)
-      if not self.next_mac then
-         -- drop all southbound packets until the next hop's ethernet address is known
-         packet.free(p)
-      else
-         local e = ffi.cast(ether_header_ptr_t, p.data)
-         e.dhost = self.next_mac
-         e.shost = self.self_mac
-         transmit(osouth, p)
-      end
+   -- don't read southbound packets until the next hop's ethernet address is known
+   if self.next_mac then
+     for _ = 1, link.nreadable(inorth) do
+        local p = receive(inorth)
+        local e = ffi.cast(ether_header_ptr_t, p.data)
+        e.dhost = self.next_mac
+        e.shost = self.self_mac
+        transmit(osouth, p)
+     end
    end
 end
 

--- a/src/program/ipfix/probe/README
+++ b/src/program/ipfix/probe/README
@@ -8,7 +8,7 @@ Available options:
                                 Defaults to 10.0.0.1.
        -c, --collector <ipaddr> The IP address of the flow collector.
                                 Defaults to 10.0.0.2.
-       -i, --input-type <type>  One of pcap, raw, or intel10g. Specifies
+       -i, --input-type <type>  One of pcap, raw, tap, or intel10g. Specifies
                                 how to interpret the <input> argument. Interprets
                                 <input> as a pcap file path, device name, or
                                 PCI address respectively. Defaults to intel10g.

--- a/src/program/ipfix/probe/README
+++ b/src/program/ipfix/probe/README
@@ -16,6 +16,10 @@ Available options:
        -D, --duration <seconds> Duration to run (in seconds).
        -p, --port <port>        The port on the collector to send to. Defaults
                                 to port 4739.
+       --active-timeout <secs>  The timeout period for flows that are still receiving
+                                packets (in seconds).
+       --idle-timeout <secs>    The timeout period for flows with no recent activity
+                                (in seconds).
        --netflow-v9             Use the Netflow V9 protocol to communicate to the
                                 flow collector.
        --ipfix                  Use IPFIX to communicate with the flow collector.

--- a/src/program/ipfix/probe/probe.lua
+++ b/src/program/ipfix/probe/probe.lua
@@ -130,7 +130,7 @@ function run (args)
    local in_link, in_app   = in_apps[input_type](args[1])
    local out_link, out_app = out_apps[output_type](args[2])
 
-   local arp_config    = { self_mac = host_mac and ethernet:pton(self_mac),
+   local arp_config    = { self_mac = host_mac and ethernet:pton(host_mac),
                            self_ip = ipv4:pton(host_ip),
                            next_ip = ipv4:pton(collector_ip) }
    local ipfix_config    = { active_timeout = active_timeout,

--- a/src/program/ipfix/probe/probe.lua
+++ b/src/program/ipfix/probe/probe.lua
@@ -34,6 +34,13 @@ function in_apps.raw (device)
 end
 out_apps.raw = in_apps.raw
 
+function in_apps.tap (device)
+   return { input = "input",
+            output = "output" },
+          { require("apps.tap.tap").Tap, device }
+end
+out_apps.tap = in_apps.tap
+
 function in_apps.intel10g (device)
    local conf = { pciaddr = device }
    return { input = "rx",

--- a/src/program/ipfix/tests/collector-test.sh
+++ b/src/program/ipfix/tests/collector-test.sh
@@ -1,0 +1,39 @@
+#! /usr/bin/env nix-shell
+#! nix-shell -i bash -p nfdump
+#
+# This is a test script for the IPFIX probe program that tests the
+# export process with an actual flow collector.
+
+DURATION=10
+FLOWDIR=`mktemp -d`
+PCAP=program/wall/tests/data/http.cap
+
+# tap interface setup
+ip tuntap add tap-snabb-ipfix mode tap
+ip addr add 10.0.0.2 dev tap-snabb-ipfix
+ip link set dev tap-snabb-ipfix up
+
+# Run the flow collector, output in $FLOWDIR
+nfcapd -b 10.0.0.2 -p 4739 -l $FLOWDIR &
+CAPD=$!
+
+# Run probe first
+./snabb ipfix probe -D $DURATION -a 10.0.0.1 -c 10.0.0.2\
+  --active-timeout 5 --idle-timeout 5 -o tap $SNABB_PCI0 tap-snabb-ipfix &
+sleep 0.5
+
+# ... then feed it some packets
+./snabb packetblaster replay -D $DURATION --no-loop $PCAP $SNABB_PCI1 > /dev/null
+
+kill $CAPD
+
+# Analyze with nfdump
+DUMPFILE=`ls -1 $FLOWDIR | head -n 1`
+nfdump -r $FLOWDIR/$DUMPFILE | grep "total flows: 6, total bytes: 24609, total packets: 43" > /dev/null
+STATUS=$?
+
+# teardown
+ip link del tap-snabb-ipfix
+rm -r $FLOWDIR
+
+exit $STATUS


### PR DESCRIPTION
This PR fixes a few minor issues with `ipfix probe` and also adds an integration test that uses `nfcapd` from the `nfdump` suite to test the app with a real IPFIX collector program. It checks that the collector sees the right number of flows & packets from a short run of the probe & collector on test traffic.

The modifications include:

  * change ARP app to not read any incoming packets until the next hop MAC is resolved (to avoid losing template packets that the probe sends)
  * allow `tap` devices in `ipfix probe`

BTW: it doesn't matter for this test, but I noticed that if the `ipfix` app gets support for exporting over TCP/SCTP then it may need another input link for incoming responses from the collector.

Also, should the test script be a `selftest.sh` so it's automatically run? Wasn't sure if the dependency on `nfdump` would be a problem there.