### PR TITLE
Fixes for IPFIX v9 mode

### DIFF
--- a/src/apps/ipfix/ipfix.lua
+++ b/src/apps/ipfix/ipfix.lua
@@ -363,7 +363,7 @@ function IPFIX:add_ipfix_header(pkt, count)
 
    header.version = htons(self.version)
    if self.version == 9 then
-      header.count = htons(count)
+      header.record_count = htons(count)
       header.uptime = htonl(to_milliseconds(engine.now() - self.boot_time))
    elseif self.version == 10 then
       header.byte_length = htons(pkt.length)

--- a/src/program/ipfix/tests/collector-test.sh
+++ b/src/program/ipfix/tests/collector-test.sh
@@ -5,35 +5,53 @@
 # export process with an actual flow collector.
 
 DURATION=10
-FLOWDIR=`mktemp -d`
 PCAP=program/wall/tests/data/http.cap
 
+if [ -z "$SNABB_PCI0" ]; then
+  echo "SNABB_PCI0 must be set"
+  exit 1
+fi
+
 # tap interface setup
+echo "setting up tap interface"
 ip tuntap add tap-snabb-ipfix mode tap
 ip addr add 10.0.0.2 dev tap-snabb-ipfix
 ip link set dev tap-snabb-ipfix up
 
-# Run the flow collector, output in $FLOWDIR
-nfcapd -b 10.0.0.2 -p 4739 -l $FLOWDIR &
-CAPD=$!
+function teardown {
+  echo "shutting down tap interface"
+  ip link del tap-snabb-ipfix
+}
 
-# Run probe first
-./snabb ipfix probe -D $DURATION -a 10.0.0.1 -c 10.0.0.2\
-  --active-timeout 5 --idle-timeout 5 -o tap $SNABB_PCI0 tap-snabb-ipfix &
-sleep 0.5
+trap teardown EXIT
 
-# ... then feed it some packets
-./snabb packetblaster replay -D $DURATION --no-loop $PCAP $SNABB_PCI1 > /dev/null
+# a function that runs the test, takes the version flag as an argument
+function test_probe {
+  flowdir=`mktemp -d`
+  version_flag=$1
 
-kill $CAPD
+  # Run the flow collector, output in $flowdir
+  nfcapd -b 10.0.0.2 -p 4739 -l $flowdir &
+  capd=$!
 
-# Analyze with nfdump
-DUMPFILE=`ls -1 $FLOWDIR | head -n 1`
-nfdump -r $FLOWDIR/$DUMPFILE | grep "total flows: 6, total bytes: 24609, total packets: 43" > /dev/null
-STATUS=$?
+  # Run probe first
+  ./snabb ipfix probe -D $DURATION -a 10.0.0.1 -c 10.0.0.2\
+    $version_flag --active-timeout 5 --idle-timeout 5 -o tap $SNABB_PCI0 tap-snabb-ipfix &
+  sleep 0.5
 
-# teardown
-ip link del tap-snabb-ipfix
-rm -r $FLOWDIR
+  # ... then feed it some packets
+  ./snabb packetblaster replay -D $DURATION --no-loop $PCAP $SNABB_PCI1 > /dev/null
 
-exit $STATUS
+  kill $capd
+
+  # Analyze with nfdump
+  dumpfile=`ls -1 $flowdir | head -n 1`
+  nfdump -r $flowdir/$dumpfile | grep "total flows: 6, total bytes: 24609, total packets: 43" > /dev/null
+  status=$?
+
+  rm -r $flowdir
+  [ $status -eq 0 ] || exit 1
+}
+
+test_probe "--netflow-v9"
+test_probe "--ipfix"


### PR DESCRIPTION
This PR fixes a bug in the IPFIX app's netflow v9 mode. It also updates the collector test to be more robust and also test both v9 and v10 modes.

(I meant to include the fix in the previous PR but I overlooked it)