### PR TITLE
Using YANG list with multiple keys

### DIFF
--- a/src/lib/yang/test-schema-v1.yang
+++ b/src/lib/yang/test-schema-v1.yang
@@ -1,0 +1,16 @@
+module test-schema-v1 {
+  namespace snabb:test;
+  prefix test;
+
+  import ietf-inet-types { prefix inet; }
+  import ietf-yang-types { prefix yang; }
+
+  container test-config {
+    container ports {
+      container port-range {
+        leaf start  {type uint16; default 1025;}
+        leaf end    {type uint16; default 32000;}
+      }
+    }
+  }
+}

--- a/src/lib/yang/test-schema-v1.yang
+++ b/src/lib/yang/test-schema-v1.yang
@@ -13,4 +13,14 @@ module test-schema-v1 {
       }
     }
   }
+
+  container test-list  {
+    list entry {
+      key "ip01 port01";
+      leaf ip01    { type inet:ipv4-address; mandatory true; }
+      leaf port01  { type uint16; mandatory true; }
+      leaf ip02    { type inet:ipv4-address; mandatory true; }
+      leaf port02  { type uint16; mandatory true; }
+    }
+  }
 }

--- a/src/program/test_yang/test_yang.json
+++ b/src/program/test_yang/test_yang.json
@@ -1,0 +1,8 @@
+test-config {
+  ports{
+    port-range{
+      start 1024;
+      end 32000;
+    }
+  }
+}

--- a/src/program/test_yang/test_yang.json
+++ b/src/program/test_yang/test_yang.json
@@ -1,8 +1,5 @@
-test-config {
-  ports{
-    port-range{
-      start 1024;
-      end 32000;
-    }
-  }
+test-list {
+  entry{ip01 192.168.1.195; port01 22; ip02 192.168.11.229; port02 22; }
+  entry{ip01 192.168.1.194; port01 80; ip02 192.168.11.230; port02 80; }
 }
+

--- a/src/program/test_yang/test_yang.lua
+++ b/src/program/test_yang/test_yang.lua
@@ -1,0 +1,14 @@
+module(..., package.seeall)
+
+local schema     = require("lib.yang.schema")
+local yang       = require('lib.yang.yang')
+
+function run (parameters)
+   local schema_name = 'test-schema-v1'
+   local schema = schema.load_schema_by_name(schema_name)
+   local conf = yang.load_configuration(parameters[1],{schema_name=schema_name, verbose = true})
+
+   local c = config.new()
+   engine.configure(c)
+   engine.main({duration=1})
+end

--- a/src/program/test_yang/test_yang.lua
+++ b/src/program/test_yang/test_yang.lua
@@ -8,6 +8,11 @@ function run (parameters)
    local schema = schema.load_schema_by_name(schema_name)
    local conf = yang.load_configuration(parameters[1],{schema_name=schema_name, verbose = true})
 
+   local test_list = conf.test_list.entry
+   for k,v in pairs(test_list) do
+      print (k)
+   end
+
    local c = config.new()
    engine.configure(c)
    engine.main({duration=1})


### PR DESCRIPTION
Hi,

My YANG config has a container defined as:

```
  container test_list  {
    list entry {
      key "ip01 port01";
      leaf ip01    { type inet:ipv4-address; mandatory true; }
      leaf port01  { type uint16; mandatory true; }
      leaf ip02    { type inet:ipv4-address; mandatory true; }
      leaf port02  { type uint16; mandatory true; }
    }
  }
```

with configuration file entries as:

```
test_list {
  entry{ip01 192.168.1.195; port01 22; ip02 192.168.11.229; port02 22; }
  entry{ip01 192.168.1.194; port01 80; ip02 192.168.11.230; port02 80; }
} 
```

The config file gets compiled in as a `ctable`, but I am not sure how to use them. specifically, how to define key and values which can be used to lookup in the `ctable`. 

The test program can be run as `sudo ./snabb test_yang program/test_yang/test_yang.json`