### PR TITLE
Stabilize breathe order

### DIFF
--- a/src/apps/basic/basic_apps.lua
+++ b/src/apps/basic/basic_apps.lua
@@ -117,7 +117,7 @@ function Repeater:new ()
                        {__index=Repeater})
 end
 
-function Repeater:pull ()
+function Repeater:push ()
    local i, o = self.input.input, self.output.output
    for _ = 1, link.nreadable(i) do
       local p = receive(i)

--- a/src/apps/lwaftr/loadgen.lua
+++ b/src/apps/lwaftr/loadgen.lua
@@ -36,7 +36,7 @@ function RateLimitedRepeater:set_rate (bit_rate)
    self.rate = math.max(bit_rate, 0)
 end
 
-function RateLimitedRepeater:pull ()
+function RateLimitedRepeater:push ()
    local i, o = self.input.input, self.output.output
    for _ = 1, link.nreadable(i) do
       local p = receive(i)


### PR DESCRIPTION
This PR stabilizes the run-to-run breathe order for graphs that have cycles.  It is also pushed to `wingo/optimize` so that Hydra will have a go at it.