### PR TITLE
Fix Unix socket EOF handling

### DIFF
--- a/src/apps/socket/unix.lua
+++ b/src/apps/socket/unix.lua
@@ -103,12 +103,20 @@ function UnixSocket:new (arg)
    -- Return true on success or false if no data is available.
    local function try_read ()
       local bytes = S.read(sock, rxp.data, packet.max_payload)
-      if bytes then
-         rxp.length = bytes
-         return true
-      else
+
+      -- Error, likely EAGAIN
+      if not bytes then
          return false
       end
+
+      -- EOF, reset sock
+      if bytes == 0 then
+         sock = nil
+         return false
+      end
+
+      rxp.length = bytes
+      return true
    end
    function self:pull()
       connect()


### PR DESCRIPTION
Hi @lukego, It looks like during the unix socket rewrite to remove `select()` a couple of months ago, the check for `local bytes = S.read()` returning 0 (EOF) was removed, and changed to `if not bytes`, which only catches errors, as ljsyscall converts -1 to a nil return value, and 0 is true.

This means EOF is not caught, so when the socket is terminated from the remote side, the app goes into a loop returning empty allocated packets.

This PR keeps handling for errors (`not bytes`) which includes EAGAIN and re-adds the `bytes == 0` check for EOF - resetting the socket.
