### PR TITLE
Correct name of Intel 82599 app in docs

### DIFF
--- a/src/apps/intel/README.md
+++ b/src/apps/intel/README.md
@@ -1,19 +1,19 @@
 # Intel 82599 Ethernet Controller Apps
 
-## Intel10G (apps.intel.intel_app)
+## Intel82599 (apps.intel.intel_app)
 
-The `Intel10G` drives one port of an Intel 82599 Ethernet controller.
+The `Intel82599` drives one port of an Intel 82599 Ethernet controller.
 Packets taken from the `rx` port are transmitted onto the network.
 Packets received from the network are put on the `tx` port.
 
-    DIAGRAM: Intel10G
-              +----------+
-              |          |
-      rx ---->* Intel10G *----> tx
-              |          |
-              +----------+
+    DIAGRAM: Intel82599
+              +------------+
+              |            |
+      rx ---->* Intel82599 *----> tx
+              |            |
+              +------------+
 
-— Method **Intel10G.dev:get_rxstats**
+— Method **Intel82599.dev:get_rxstats**
 
 Returns a table with the following keys:
 
@@ -22,7 +22,7 @@ Returns a table with the following keys:
 * `dropped` - Number of packets dropped
 * `bytes` - Total bytes received
 
-— Method **Intel10G.dev:get_txstats**
+— Method **Intel82599.dev:get_txstats**
 
 Returns a table with the following keys:
 
@@ -32,7 +32,7 @@ Returns a table with the following keys:
 
 ### Configuration
 
-The `Intel10G` app accepts a table as its configuration argument. The
+The `Intel82599` app accepts a table as its configuration argument. The
 following keys are defined:
 
 — Key **pciaddr**
@@ -53,7 +53,7 @@ header.
 — Key **vmdq**
 
 *Optional*. Boolean, defaults to false. Enables interface
-virtualization. Allows to have multiple `Intel10G` apps per port. If
+virtualization. Allows to have multiple `Intel82599` apps per port. If
 enabled, *macaddr* must be specified.
 
 — Key **mirror**
@@ -78,7 +78,7 @@ the physical port.
 *Optional*. Four bit integers (0-15). If set, incoming/outgoing packets
 will be counted in the selected statistics counter respectively. Multiple
 apps can share a counter. To retrieve counter statistics use
-`Intel10G.dev:get_rxstats()` and `Intel10G.dev:get_txstats()`.
+`Intel82599.dev:get_rxstats()` and `Intel82599.dev:get_txstats()`.
 
 — Key **rate_limit**
 
@@ -105,14 +105,14 @@ Note that even a low-priority app can use the whole line rate unless other
 
 ### Performance
 
-The `Intel10G` app can transmit and receive at approximately 10 Mpps per
+The `Intel82599` app can transmit and receive at approximately 10 Mpps per
 processor core.
 
 ### Hardware limits
 
 Each physical Intel 82599 port supports the use of up to:
 
-* 64 *pools* (virtualized `Intel10G` app instances)
+* 64 *pools* (virtualized `Intel82599` app instances)
 * 127 MAC addresses (see the `macaddr` configuration option)
 * 64 VLANs (see the `vlan` configuration option)
 * 4 *mirror pools* (see the `mirror` configuration option)


### PR DESCRIPTION
The app is called `Intel82599`, not `Intel10G`.