### PR TITLE
siphash: avoid ctype diversity for hash functions

### DIFF
--- a/src/lib/hash/siphash.dasl
+++ b/src/lib/hash/siphash.dasl
@@ -74,6 +74,7 @@ local function load_initial_state(key)
 end
 
 -- Scalar x86-64 backend for the SipHash implementation.
+local fn_ptr_t = ffi.typeof("uint32_t (*)(void *)")
 local function X86_64()
    local asm = {}
    local Dst
@@ -152,7 +153,7 @@ local function X86_64()
    end
    function asm.finish(name, Dst)
       return finish(name.."_x1",
-                    ffi.typeof("uint32_t (*)(void *)"),
+                    fn_ptr_t,
                     Dst)
    end
    function asm:assemble(name, gen)


### PR DESCRIPTION
When a hash table is re-sized automatically, a new hash function is
generated and cast to a generic function pointer type. However, due to
the semantics of ffi.typeof(), a new ctype ID is allocated each time,
which causes sub-optimal transitions to side-traces in already
compiled traces.  This commit makes sure that all hash function
pointers have the same ctype ID to avoid this problem.