### PR TITLE
[RFC] Use binary search for all lookups

### DIFF
--- a/src/lib/binary_search.dasl
+++ b/src/lib/binary_search.dasl
@@ -35,6 +35,8 @@ local function assemble (name, prototype, generator)
    return ffi.cast(prototype, mcode)
 end
 
+local ffi_type_cache = {}
+
 function gen(count, entry_type)
    local function gen_binary_search(Dst)
       if count == 1 then
@@ -80,8 +82,11 @@ function gen(count, entry_type)
       | mov rax, rdi
       | ret
    end
-   return assemble("binary_search_"..count,
-                   ffi.typeof("$*(*)($*, uint32_t)", entry_type, entry_type),
+   if not ffi_type_cache[entry_type] then
+      ffi_type_cache[entry_type] = ffi.typeof(
+         "$*(*)($*, uint32_t)", entry_type, entry_type)
+   end
+   return assemble("binary_search_"..count, ffi_type_cache[entry_type],
                    gen_binary_search)
 end
 

--- a/src/lib/ctable.lua
+++ b/src/lib/ctable.lua
@@ -147,6 +147,7 @@ function new(params)
    ctab.size = 0
    ctab.max_displacement = 0
    ctab.occupancy = 0
+   ctab.lookup_helpers = {}
    ctab.max_occupancy_rate = params.max_occupancy_rate
    ctab.min_occupancy_rate = params.min_occupancy_rate
    ctab = setmetatable(ctab, { __index = CTable })
@@ -221,6 +222,7 @@ function CTable:resize(size)
    self.scale = self.size / HASH_MAX
    self.occupancy = 0
    self.max_displacement = 0
+   self.lookup_helper = self:make_lookup_helper()
    self.occupancy_hi = ceil(self.size * self.max_occupancy_rate)
    self.occupancy_lo = floor(self.size * self.min_occupancy_rate)
    for i=0,self.size*2-1 do self.entries[i].hash = HASH_MAX end
@@ -260,7 +262,7 @@ function load(stream, params)
    params_copy.max_occupancy_rate = header.max_occupancy_rate
    local ctab = new(params_copy)
    ctab.occupancy = header.occupancy
-   ctab.max_displacement = header.max_displacement
+   ctab:maybe_increase_max_displacement(header.max_displacement)
    local entry_count = ctab.size + ctab.max_displacement
 
    -- Slurp the entries directly into the ctable's backing store.
@@ -280,6 +282,22 @@ function CTable:save(stream)
    stream:write_array(self.entries,
                       self.entry_type,
                       self.size + self.max_displacement)
+end
+
+function CTable:make_lookup_helper()
+   local entries_per_lookup = self.max_displacement + 1
+   local search = self.lookup_helpers[entries_per_lookup]
+   if search == nil then
+      search = binary_search.gen(entries_per_lookup, self.entry_type)
+      self.lookup_helpers[entries_per_lookup] = search
+   end
+   return search
+end
+
+function CTable:maybe_increase_max_displacement(displacement)
+   if displacement <= self.max_displacement then return end
+   self.max_displacement = displacement
+   self.lookup_helper = self:make_lookup_helper()
 end
 
 function CTable:add(key, value, updates_allowed)
@@ -324,7 +342,7 @@ function CTable:add(key, value, updates_allowed)
 
    assert(updates_allowed ~= 'required', "key not found in ctable")
 
-   self.max_displacement = max(self.max_displacement, index - start_index)
+   self:maybe_increase_max_displacement(index - start_index)
 
    if entries[index].hash ~= HASH_MAX then
       -- In a robin hood hash, we seek to spread the wealth around among
@@ -340,7 +358,7 @@ function CTable:add(key, value, updates_allowed)
       while empty > index do
          entries[empty] = entries[empty - 1]
          local displacement = empty - hash_to_index(entries[empty].hash, scale)
-         self.max_displacement = max(self.max_displacement, displacement)
+         self:maybe_increase_max_displacement(displacement)
          empty = empty - 1;
       end
    end
@@ -359,22 +377,24 @@ end
 function CTable:lookup_ptr(key)
    local hash = self.hash_fn(key)
    local entry = self.entries + hash_to_index(hash, self.scale)
+   entry = self.lookup_helper(entry, hash)
 
-   -- Fast path in case we find it directly.
-   if hash == entry.hash and self.equal_fn(key, entry.key) then
-      return entry
-   end
-
-   while entry.hash < hash do entry = entry + 1 end
-
-   while entry.hash == hash do
+   if hash == entry.hash then
+      -- Peel the first iteration of the loop; collisions will be rare.
       if self.equal_fn(key, entry.key) then return entry end
-      -- Otherwise possibly a collision.
       entry = entry + 1
+      if entry.hash ~= hash then return nil end
+      while entry.hash == hash do
+         if self.equal_fn(key, entry.key) then return entry end
+         -- Otherwise possibly a collision.
+         entry = entry + 1
+      end
+      -- Not found.
+      return nil
+   else
+      -- Not found.
+      return nil
    end
-
-   -- Not found.
-   return nil
 end
 
 function CTable:lookup_and_copy(key, entry)


### PR DESCRIPTION
@alexandergall has been seeing problems due to the branchiness of the linear probe for ctable lookups.  This branch attempts to see if using the generated binary search helpers instead of linear probe in Lua fixes this problem.

I suspect it doesn't fix the problem, as this snabbmark shows:

```
$ sudo ./snabb snabbmark ctable
No PMU available: single core cpu affinity required
hugetlb mmap failed (Cannot allocate memory), falling back.
insertion (40% occupancy): 116.82 ns per iteration (result: nil)
lookup_ptr (40% occupancy): 212.69 ns per iteration (result: cdata<struct 1461 *>: 0x7fd9e98e4ae0)
lookup_and_copy (40% occupancy): 184.19 ns per iteration (result: cdata<struct 1461>: 0x41219360)
streaming lookup, stride=1: 118.02 ns per iteration (result: -2000001)
streaming lookup, stride=2: 78.21 ns per iteration (result: -2000001)
streaming lookup, stride=4: 84.25 ns per iteration (result: -2000001)
streaming lookup, stride=8: 78.65 ns per iteration (result: -2000001)
streaming lookup, stride=16: 68.07 ns per iteration (result: -2000001)
streaming lookup, stride=32: 65.50 ns per iteration (result: -2000001)
streaming lookup, stride=64: 67.30 ns per iteration (result: -2000001)
streaming lookup, stride=128: 63.73 ns per iteration (result: -2000001)
streaming lookup, stride=256: 64.70 ns per iteration (result: -2000001)
```

Compare to the results before (see the lookup_ptr case):

```
$ sudo ./snabb snabbmark ctable
No PMU available: single core cpu affinity required
hugetlb mmap failed (Cannot allocate memory), falling back.
insertion (40% occupancy): 116.32 ns per iteration (result: nil)
lookup_ptr (40% occupancy): 149.35 ns per iteration (result: cdata<struct 1461 *>: 0x7f8ff9241040)
lookup_and_copy (40% occupancy): 107.87 ns per iteration (result: cdata<struct 1461>: 0x425bc660)
streaming lookup, stride=1: 126.87 ns per iteration (result: -2000001)
streaming lookup, stride=2: 116.42 ns per iteration (result: -2000001)
streaming lookup, stride=4: 100.83 ns per iteration (result: -2000001)
streaming lookup, stride=8: 91.41 ns per iteration (result: -2000001)
streaming lookup, stride=16: 83.98 ns per iteration (result: -2000001)
streaming lookup, stride=32: 81.41 ns per iteration (result: -2000001)
streaming lookup, stride=64: 78.14 ns per iteration (result: -2000001)
streaming lookup, stride=128: 79.53 ns per iteration (result: -2000001)
streaming lookup, stride=256: 77.88 ns per iteration (result: -2000001)
```

But, who knows!