### PR TITLE
Set mask.size equals to MAX_NUMNODES if lower

### DIFF
--- a/lib/ljsyscall/syscall/linux/syscalls.lua
+++ b/lib/ljsyscall/syscall/linux/syscalls.lua
@@ -457,9 +457,28 @@ function S.sched_setaffinity(pid, mask, len) -- note len last as rarely used
   return retbool(C.sched_setaffinity(pid or 0, len or s.cpu_set, mktype(t.cpu_set, mask)))
 end
 
+local function get_max_numnodes()
+  local name = "/proc/self/status"
+  local fd, err = S.open(name, c.O.RDONLY)
+  if not fd then return nil, err end
+  local content, err = S.read(fd, nil, 8192)
+  fd:close()
+  for line in content:gmatch("[^\n]+") do
+    if line:match("^Mems_allowed:") then
+      line = line:gsub("^Mems_allowed:%s+", "")
+      return math.floor(((#line+1)/9)*32)
+    end
+  end
+end
+
 function S.get_mempolicy(mode, mask, addr, flags)
   mode = mode or t.int1()
   mask = mktype(t.bitmask, mask)
+  local max_numnodes = get_max_numnodes()
+  -- Check mask.size is at least equals to the number of max_numnodes.
+  if mask.size < max_numnodes then
+    mask.size = max_numnodes
+  end
   local ret, err = C.get_mempolicy(mode, mask.mask, mask.size, addr or 0, c.MPOL_FLAG[flags])
   if ret == -1 then return nil, t.error(err or errno()) end
   return { mode=mode[0], mask=mask }

--- a/lib/ljsyscall/syscall/linux/syscalls.lua
+++ b/lib/ljsyscall/syscall/linux/syscalls.lua
@@ -2,7 +2,7 @@
 
 local require, error, assert, tonumber, tostring,
 setmetatable, pairs, ipairs, unpack, rawget, rawset,
-pcall, type, table, string = 
+pcall, type, table, string =
 require, error, assert, tonumber, tostring,
 setmetatable, pairs, ipairs, unpack, rawget, rawset,
 pcall, type, table, string
@@ -458,31 +458,29 @@ function S.sched_setaffinity(pid, mask, len) -- note len last as rarely used
 end
 
 local function get_maxnumnodes()
-   local function filesize(fd)
-      local size = 0
+   local function readfile (filename)
+      local ret = {}
       local bufsz = 1024
       local buf = ffi.new("uint8_t[?]", bufsz)
-      while true do
-         local len, err = S.read(fd, buf, bufsz)
-         size = size + len
-         if len ~= bufsz then break end
-      end
-      fd:seek(0, "set")
-      return size
-   end
-   local function read(filename)
       local fd, errno = S.open(filename, 0)
       if not fd then error(errno) end
-      local content, errno = S.read(fd, nil, filesize(fd))
-      if not content then error(errno) end
+      while true do
+         local len = S.read(fd, buf, bufsz)
+         table.insert(ret, ffi.string(buf, len))
+         if len ~= bufsz then break end
+      end
       fd:close()
-      return content
+      return table.concat(ret)
    end
-   local content = read("/proc/self/status")
+   local content = readfile("/proc/self/status")
    for line in content:gmatch("[^\n]+") do
      if line:match("^Mems_allowed:") then
        line = line:gsub("^Mems_allowed:%s+", "")
-       return(math.floor(((#line+1)/9)*32))
+       -- In Mems_allowed each 9 characters (8 digit plus comma) represents
+       -- a 32-bit mask.  Total number of maxnumnodes is the total sum of
+       -- the masks multiplied by 32.  Line length is increased by one since
+       -- there's no comma at the end of line.
+       return math.floor(((#line+1)/9)*32)
      end
    end
 end


### PR DESCRIPTION
Fixes #1200.

`get_mempolicy` syscall returns an EINVAL if argument maxnode is lower than the value of MAX_NUMNODES defined in the system:

```
int get_mempolicy(int *mode, unsigned long *nodemask,
                         unsigned long maxnode, void *addr,
                         unsigned long flags);
```

In ljsyscall `S.get_mempolicy` the argument maxnode is mask.size. What the patch does is to check the value of mask.size is lower than MAX_NUMNODES and in that case set mask.size to MAX_NUMNODES.

That fixes the call to `get_mempolicy` in Ubuntu 17.04. I think to properly know if this fix works, the right thing to do is to run the lwAFTR on such system (I cannot since I lack a 10Gb NIC).