### PR TITLE
Driver independence

### DIFF
--- a/src/apps/intel/intel10g.lua
+++ b/src/apps/intel/intel10g.lua
@@ -189,9 +189,7 @@ do
    end
 end
 
-function M_sf:ingress_packet_drops ()
-   return self.qs.QPRDC[0]()
-end
+function M_sf:rxdrop () return self.qs.QPRDC[0]() end
 
 function M_sf:global_reset ()
    local reset = bits{LinkReset=3, DeviceReset=26}
@@ -1004,9 +1002,7 @@ function M_vf:set_tx_rate (limit, priority)
    return self
 end
 
-function M_vf:ingress_packet_drops ()
-   return self.pf.qs.QPRDC[self.rxstats]()
-end
+function M_vf:rxdrop () return self.pf.qs.QPRDC[self.rxstats]() end
 
 rxdesc_t = ffi.typeof [[
    union {

--- a/src/apps/intel/intel_app.lua
+++ b/src/apps/intel/intel_app.lua
@@ -160,8 +160,8 @@ function Intel82599:pull ()
    end
 end
 
-function Intel82599:ingress_packet_drops ()
-   return self.dev:ingress_packet_drops()
+function Intel82599:rxdrop ()
+   return self.dev:rxdrop()
 end
 
 function Intel82599:add_receive_buffers ()

--- a/src/apps/intel/intel_app.lua
+++ b/src/apps/intel/intel_app.lua
@@ -25,7 +25,8 @@ Intel82599 = {
       rxcounter  = {default=0},
       txcounter  = {default=0},
       rate_limit = {default=0},
-      priority   = {default=1.0}
+      priority   = {default=1.0},
+      ring_buffer_size = {default=intel10g.ring_buffer_size()}
    }
 }
 Intel82599.__index = Intel82599
@@ -52,6 +53,10 @@ end
 function Intel82599:new (conf)
    local self = {}
 
+   -- FIXME: ring_buffer_size is really a global variable for this
+   -- driver; taking the parameter as an initarg is just to make the
+   -- intel_mp transition easier.
+   intel10g.ring_buffer_size(conf.ring_buffer_size)
    if conf.vmdq then
       if devices[conf.pciaddr] == nil then
          local pf = intel10g.new_pf(conf):open()

--- a/src/apps/intel_mp/intel_mp.lua
+++ b/src/apps/intel_mp/intel_mp.lua
@@ -482,6 +482,7 @@ function Intel:init_rx_q ()
       self.r.RXCTRL:set(bits{ RXEN=0 })
       self.r.DCA_RXCTRL:clr(bits{RxCTRL=12})
       if self.vmdq then
+         -- enable packet reception for this pool/VF (4.6.10.1.4)
          self.r.PFVFRE[math.floor(self.poolnum/32)]:set(bits{VFRE=self.poolnum%32})
       end
    elseif self.driver == "Intel1g" then
@@ -569,12 +570,14 @@ function Intel:push ()
    if not self.txq then return end
    local li = self.input["input"]
    if li == nil then return end
---   assert(li, "intel_mp:push: no input link")
 
    while not empty(li) and self:ringnext(self.tdt) ~= self.tdh do
       local p = receive(li)
-      -- NB: see comment in intel10g for why this is commented out,
-      --     the rest of the loop body goes in an else branch
+      -- NB: the comment below is taken from intel_mp.lua, which disables
+      -- this check for the same reason.
+      --   We must not send packets that are bigger than the MTU.  This
+      --   check is currently disabled to satisfy some selftests until
+      --   agreement on this strategy is reached.
       --if p.length > self.mtu then
       --   packet.free(p)
       --   counter.add(self.shm.txdrop)
@@ -610,7 +613,6 @@ function Intel:pull ()
    if not self.rxq then return end
    local lo = self.output["output"]
    if lo == nil then return end
---   assert(lo, "intel_mp:pull: output link required")
 
    local pkts = 0
    while band(self.rxdesc[self.rdt].status, 0x01) == 1 and pkts < engine.pull_npackets do

--- a/src/apps/intel_mp/intel_mp.lua
+++ b/src/apps/intel_mp/intel_mp.lua
@@ -274,7 +274,7 @@ EEC       0x00010 -            RW EEPROM-Mode Control Register
 Intel = {
    config = {
       pciaddr = {required=true},
-      ndescriptors = {default=2048},
+      ring_buffer_size = {default=2048},
       vmdq = {default=false},
       macaddr = {},
       poolnum = {},
@@ -316,7 +316,7 @@ function Intel:new (conf)
       r = {},
       pciaddress = conf.pciaddr,
       path = pci.path(conf.pciaddr),
-      ndesc = conf.ndescriptors,
+      ndesc = conf.ring_buffer_size,
       txq = conf.txq,
       rxq = conf.rxq,
       mtu = conf.mtu,

--- a/src/apps/intel_mp/testrecv.lua
+++ b/src/apps/intel_mp/testrecv.lua
@@ -17,13 +17,11 @@ function test(pciaddr, qno, vmdq, poolno, macaddr, vlan)
                    vmdq=true,
                    poolnum=poolno,
                    rxq = qno,
-                   ndescriptors = 2048,
                    wait_for_link=true })
    else
       config.app(c, "nic", intel.Intel,
                  { pciaddr=pciaddr,
                    rxq = qno,
-                   ndescriptors = 2048,
                    wait_for_link=true })
    end
    config.app(c, "sink", basic.Sink)

--- a/src/apps/intel_mp/testsend.snabb
+++ b/src/apps/intel_mp/testsend.snabb
@@ -11,7 +11,8 @@ local C = require("ffi").C
 
 local c = config.new()
 config.app(c, "pcap", pcap.PcapReader, pcapfile)
-config.app(c, "nic", intel.Intel, {pciaddr=pciaddr, txq = qno, ndescriptors=2048, wait_for_link = true})
+config.app(c, "nic", intel.Intel,
+           {pciaddr=pciaddr, txq=qno, wait_for_link=true})
 
 if os.getenv("SNABB_SEND_BLAST") then
 	local basic = require("apps.basic.basic_apps")

--- a/src/apps/intel_mp/testup.snabb
+++ b/src/apps/intel_mp/testup.snabb
@@ -12,7 +12,6 @@ local function new_intel (arg)
    return intel.Intel:new(parse(arg, intel.Intel.config))
 end
 
-local nic = new_intel(
-   { pciaddr=pciaddr, rxq = qno, ndescriptors = 2048, wait_for_link = true })
+local nic = new_intel({ pciaddr=pciaddr, rxq = qno, wait_for_link = true })
 print(nic:link_status())
 main.exit(0)

--- a/src/apps/intel_mp/testvlan.snabb
+++ b/src/apps/intel_mp/testvlan.snabb
@@ -23,7 +23,6 @@ config.app(c, "pcap", pcap.PcapReader, pcapfile)
 config.app(c, "nic1", intel.Intel,
            {pciaddr=pciaddr1,
             txq = 0,
-            ndescriptors=2048,
             wait_for_link = true})
 config.app(c, "nic2", intel.Intel,
            {pciaddr=pciaddr2,
@@ -32,7 +31,6 @@ config.app(c, "nic2", intel.Intel,
             vlan = 1,
             poolnum = 0,
             rxq = 0,
-            ndescriptors=2048,
             wait_for_link = true})
 
 -- use pflua to filter based on presence of vlan tag

--- a/src/apps/intel_mp/testvmdqtx.snabb
+++ b/src/apps/intel_mp/testvmdqtx.snabb
@@ -29,14 +29,12 @@ config.app(c, "nic1", intel.Intel,
              txq = 0,
              txcounter = 1,
              vlan = 1,
-             ndescriptors=2048,
              wait_for_link = true })
 
 -- nic2 just receives packets so we can check them
 config.app(c, "nic2", intel.Intel,
            { pciaddr=pciaddr2,
              rxq = 0,
-             ndescriptors=2048,
              wait_for_link = true })
 
 config.app(c, "pcap", pcap.PcapReader, pcapfile)

--- a/src/lib/hardware/pci.lua
+++ b/src/lib/hardware/pci.lua
@@ -43,6 +43,7 @@ function device_info (pciaddress)
    info.model = which_model(info.vendor, info.device)
    info.driver = which_driver(info.vendor, info.device)
    if info.driver then
+      info.rx, info.tx = which_link_names(info.driver)
       info.interface = lib.firstfile(p.."/net")
       if info.interface then
          info.status = lib.firstline(p.."/net/"..info.interface.."/operstate")
@@ -84,6 +85,12 @@ local cards = {
    },
 }
 
+local link_names = {
+   ['apps.solarflare.solarflare'] = { "rx", "tx" },
+   ['apps.intel_mp.intel_mp']     = { "input", "output" },
+   ['apps.intel.intel_app']       = { "rx", "tx" }
+}
+
 -- Return the name of the Lua module that implements support for this device.
 function which_driver (vendor, device)
    local card = cards[vendor] and cards[vendor][device]
@@ -93,6 +100,10 @@ end
 function which_model (vendor, device)
    local card = cards[vendor] and cards[vendor][device]
    return card and card.model
+end
+
+function which_link_names (driver)
+   return unpack(assert(link_names[driver]))
 end
 
 --- ### Device manipulation.

--- a/src/lib/io/virtual_ether_mux.lua
+++ b/src/lib/io/virtual_ether_mux.lua
@@ -13,8 +13,7 @@ function configure (c, ports, io)
    local links
    if io and io.pci then
       local device = pci.device_info(io.pci)
-      if device and (device.driver == 'apps.intel.intel_app'
-                  or device.driver == 'apps.solarflare.solarflare') then
+      if device and device.driver then
          links = configureVMDq(c, device, ports)
       else
          error("Unknown device: "..io.pci)
@@ -91,7 +90,8 @@ function configureVMDq (c, device, ports)
                   vmdq = vmdq,
                   macaddr = port.mac_address,
                   vlan = port.vlan})
-      links[i] = {input = NIC..".rx", output = NIC..".tx"}
+      links[i] = {input = NIC.."."..device.rx,
+                  output = NIC.."."..device.tx}
    end
    return links
 end

--- a/src/lib/timers/ingress_drop_monitor.lua
+++ b/src/lib/timers/ingress_drop_monitor.lua
@@ -46,8 +46,8 @@ function IngressDropMonitor:sample ()
    sum[0] = 0
    for i = 1, #app_array do
       local app = app_array[i]
-      if app.ingress_packet_drops and not app.dead then
-         sum[0] = sum[0] + app:ingress_packet_drops()
+      if app.rxdrop and not app.dead then
+         sum[0] = sum[0] + app:rxdrop()
       end
    end
    if self.counter then

--- a/src/lib/virtio/net_device.lua
+++ b/src/lib/virtio/net_device.lua
@@ -34,7 +34,7 @@ local invalid_header_id = 0xffff
    - VIRTIO_NET_F_CSUM - enables the SG I/O (resulting in
       multiple chained data buffers in our TX path(self.rxring))
       Required by GSO/TSO/USO. Requires CSUM offload support in the
-      HW driver (now intel10g)
+      HW driver (now intel_mp)
 
    - VIRTIO_NET_F_MRG_RXBUF - enables multiple chained buffers in our RX path
       (self.txring). Also chnages the virtio_net_hdr to virtio_net_hdr_mrg_rxbuf

--- a/src/program/ipfix/probe/README
+++ b/src/program/ipfix/probe/README
@@ -8,10 +8,10 @@ Available options:
                                 Defaults to 10.0.0.1.
        -c, --collector <ipaddr> The IP address of the flow collector.
                                 Defaults to 10.0.0.2.
-       -i, --input-type <type>  One of pcap, raw, tap, or intel10g. Specifies
+       -i, --input-type <type>  One of pcap, raw, tap, or pci. Specifies
                                 how to interpret the <input> argument. Interprets
                                 <input> as a pcap file path, device name, or
-                                PCI address respectively. Defaults to intel10g.
+                                PCI address respectively. Defaults to pci.
        -o, --output-type <type> Takes the same values as -i but for <output>.
        -D, --duration <seconds> Duration to run (in seconds).
        -p, --port <port>        The port on the collector to send to. Defaults

--- a/src/program/ipfix/probe/probe.lua
+++ b/src/program/ipfix/probe/probe.lua
@@ -8,6 +8,7 @@ local link     = require("core.link")
 local basic    = require("apps.basic.basic_apps")
 local arp      = require("apps.ipv4.arp")
 local ipfix    = require("apps.ipfix.ipfix")
+local pci      = require("lib.hardware.pci")
 local ipv4     = require("lib.protocol.ipv4")
 local ethernet = require("lib.protocol.ethernet")
 local numa     = require("lib.numa")
@@ -41,13 +42,13 @@ function in_apps.tap (device)
 end
 out_apps.tap = in_apps.tap
 
-function in_apps.intel10g (device)
+function in_apps.pci (device)
+   local device_info = pci.device_info(device)
    local conf = { pciaddr = device }
-   return { input = "rx",
-            output = "tx" },
-          { require("apps.intel.intel_app").Intel82599, conf }
+   return { input = device_info.rx, output = device_info.tx },
+          { require(device_info.driver).driver, conf }
 end
-out_apps.intel10g = in_apps.intel10g
+out_apps.pci = in_apps.pci
 
 local long_opts = {
    help = "h",
@@ -67,7 +68,7 @@ local long_opts = {
 function run (args)
    local duration
 
-   local input_type, output_type = "intel10g", "intel10g"
+   local input_type, output_type = "pci", "pci"
 
    local host_mac
    local host_ip = '10.0.0.1' -- Just to have a default.

--- a/src/program/lisper/dev-env-perftest/baseline.lua
+++ b/src/program/lisper/dev-env-perftest/baseline.lua
@@ -6,22 +6,24 @@ local ffi      = require("ffi")
 local app      = require("core.app")
 local lib      = require("core.lib")
 local packet   = require("core.packet")
-local intel    = require("apps.intel.intel_app")
+local pci      = require("lib.hardware.pci")
 
 local c = config.new()
 
-config.app(c, "e0", intel.Intel82599, {
-	pciaddr = "0000:01:00.0",
+local e0, e1 = pci.device_info("01:00.0"), pci.device_info("03:00.0")
+
+config.app(c, "e0", require(e0.driver).driver, {
+	pciaddr = e0.pciaddress,
 	macaddr = "00:00:00:00:01:01",
 })
 
-config.app(c, "e1", intel.Intel82599, {
-	pciaddr = "0000:03:00.0",
+config.app(c, "e1", require(e1.driver).driver, {
+	pciaddr = e1.pciaddress,
 	macaddr = "00:00:00:00:01:02",
 })
 
-config.link(c, "e0.tx -> e1.rx")
-config.link(c, "e1.tx -> e0.rx")
+config.link(c, "e0."..e0.tx.." -> e1."..e1.rx)
+config.link(c, "e1."..e1.tx.." -> e0."..e0.rx)
 
 engine.configure(c)
 engine.main({report = {showlinks=true}})

--- a/src/program/lisper/dev-env-perftest/count.lua
+++ b/src/program/lisper/dev-env-perftest/count.lua
@@ -6,7 +6,7 @@ local ffi      = require("ffi")
 local app      = require("core.app")
 local lib      = require("core.lib")
 local packet   = require("core.packet")
-local intel    = require("apps.intel.intel_app")
+local pci      = require("lib.hardware.pci")
 
 _NAME = ""
 local Counter = {}
@@ -37,12 +37,14 @@ local c = config.new()
 
 config.app(c, "count", Counter)
 
-config.app(c, "eth", intel.Intel82599, {
-	pciaddr = "0000:03:00.1",
+local eth = pci.device_info("03:00.1")
+
+config.app(c, "eth", require(eth.driver).driver, {
+	pciaddr = eth.pciaddress,
 	macaddr = "00:00:00:00:02:02",
 })
 
-config.link(c, "eth.tx -> count.rx")
+config.link(c, "eth."..eth.tx.." -> count.rx")
 
 engine.configure(c)
 engine.main({report = {showlinks=true}})

--- a/src/program/lisper/lisper.lua
+++ b/src/program/lisper/lisper.lua
@@ -722,7 +722,7 @@ function run(args)
             pciaddr = iface.pci,
             macaddr = macstr(iface.mac),
             vlan = iface.vlan_id,
-            vmdq = iface.vlan_id and true or nil,
+            vmdq = true,
          })
       else
          config.app(c, "if_"..ifname, raw.RawSocket, ifname)

--- a/src/program/lisper/lisper.lua
+++ b/src/program/lisper/lisper.lua
@@ -8,6 +8,7 @@ local app      = require("core.app")
 local lib      = require("core.lib")
 local packet   = require("core.packet")
 local usage    = require("program.lisper.README_inc")
+local pci      = require("lib.hardware.pci")
 local ipv6     = require("lib.protocol.ipv6")
 local ethernet = require("lib.protocol.ethernet")
 local esp      = require("lib.ipsec.esp")
@@ -16,7 +17,6 @@ local raw      = require("apps.socket.raw")
 local nd       = require("apps.ipv6.nd_light")
 local pcap     = require("apps.pcap.pcap")
 local basic    = require("apps.basic.basic_apps")
-local intel    = require("apps.intel.intel_app")
 local json     = require("lib.json")
 local timer    = require("core.timer")
 
@@ -716,16 +716,20 @@ function run(args)
    config.app(c, "lisper", Lisper)
 
    for ifname, iface in pairs(ifs) do
+      local rx, tx
 
       if iface.pci then
-         config.app(c, "if_"..ifname, intel.Intel82599, {
-            pciaddr = iface.pci,
+         local device = pci.device_info(iface.pci)
+         config.app(c, "if_"..ifname, require(device.driver).driver, {
+            pciaddr = device.pciaddress,
             macaddr = macstr(iface.mac),
             vlan = iface.vlan_id,
             vmdq = true,
          })
+         rx, tx = device.rx, device.tx
       else
          config.app(c, "if_"..ifname, raw.RawSocket, ifname)
+         rx, tx = "input", "output"
       end
 
       local function needs_nd(exits)
@@ -744,16 +748,16 @@ function run(args)
             next_hop = ip6str(exit.next_hop),
          })
 
-         config.link(c, _("nd_%s.south -> if_%s.rx", ifname, ifname))
-         config.link(c, _("if_%s.tx -> nd_%s.south", ifname, ifname))
+         config.link(c, _("nd_%s.south -> if_%s.%s", ifname, ifname, rx))
+         config.link(c, _("if_%s.%s -> nd_%s.south", ifname, tx, ifname))
 
          config.link(c, _("lisper.%s -> nd_%s.north", ifname, ifname))
          config.link(c, _("nd_%s.north -> lisper.%s", ifname, ifname))
 
       else -- phy -> lisper
 
-         config.link(c, _("lisper.%s -> if_%s.rx", ifname, ifname))
-         config.link(c, _("if_%s.tx -> lisper.%s", ifname, ifname))
+         config.link(c, _("lisper.%s -> if_%s.%s", ifname, ifname, rx))
+         config.link(c, _("if_%s.%s -> lisper.%s", ifname, tx, ifname))
 
       end
 

--- a/src/program/lwaftr/loadtest/loadtest.lua
+++ b/src/program/lwaftr/loadtest/loadtest.lua
@@ -206,7 +206,7 @@ function run(args)
          ret[stream.nic_tx_id] = {
             tx = read_counters(tx_nic.input.rx),
             rx = read_counters(rx_nic.output.tx),
-            drop = rx_nic:ingress_packet_drops()
+            drop = rx_nic:rxdrop()
          }
       end
       return ret

--- a/src/program/packetblaster/lwaftr/lwaftr.lua
+++ b/src/program/packetblaster/lwaftr/lwaftr.lua
@@ -212,7 +212,7 @@ function run (args)
       if device_info then
          config.app(c, "nic", require(device_info.driver).driver,
          {pciaddr = pciaddr, vmdq = true, macaddr = src_mac, mtu = 9500})
-         input, output = "nic.rx", "nic.tx"
+         input, output = "nic."..device_info.rx, "nic."..device_info.tx
       else
          fatal(("Couldn't find device info for PCI or tap device %s"):format(pciaddr))
       end

--- a/src/program/packetblaster/lwaftr/lwaftr.lua
+++ b/src/program/packetblaster/lwaftr/lwaftr.lua
@@ -211,7 +211,7 @@ function run (args)
       end
       if device_info then
          config.app(c, "nic", require(device_info.driver).driver,
-         {pciaddr = pciaddr, vmdq = false, macaddr = src_mac, mtu = 9500})
+         {pciaddr = pciaddr, vmdq = true, macaddr = src_mac, mtu = 9500})
          input, output = "nic.rx", "nic.tx"
       else
          fatal(("Couldn't find device info for PCI or tap device %s"):format(pciaddr))

--- a/src/program/snabbmark/snabbmark.lua
+++ b/src/program/snabbmark/snabbmark.lua
@@ -289,8 +289,8 @@ receive_device.interface= "rx1GE"
    config.app(c, receive_device.interface, Intel1gNic, {pciaddr=pciaddr1, rxburst=512})
    config.app(c, "sink", basic_apps.Sink)
 
-   config.link(c, "source.tx -> " .. send_device.interface .. ".rx")
-   config.link(c, receive_device.interface .. ".tx -> sink.rx")
+   config.link(c, "source.tx -> " .. send_device.interface .. ".input")
+   config.link(c, receive_device.interface .. ".output -> sink.rx")
 
    engine.configure(c)
 

--- a/src/program/snabbnfv/fuzz/fuzz.lua
+++ b/src/program/snabbnfv/fuzz/fuzz.lua
@@ -76,7 +76,7 @@ function random_uint (nbits, min)
 end
 
 function random_vlan ()
-   -- Twelve bit integer, see Intel10G (apps.intel.intel_app)
+   -- Twelve bit integer, see apps.intel_mp.intel_mp
    return random_uint(12)
 end
 

--- a/src/program/snabbnfv/traffic/traffic.lua
+++ b/src/program/snabbnfv/traffic/traffic.lua
@@ -124,7 +124,8 @@ function bench (pciaddr, confpath, sockpath, npackets)
    -- From designs/nfv
    local start, packets, bytes = 0, 0, 0
    local done = function ()
-      local input = link.stats(engine.app_table[nic].input.rx)
+      local inputs = link.stats(engine.app_table[nic].input)
+      local _, input = next(inputs)
       if start == 0 and input.rxpackets > 0 then
          -- started receiving, record time and packet count
          packets = input.rxpackets
@@ -150,7 +151,8 @@ function bench (pciaddr, confpath, sockpath, npackets)
 
    local runtime = finish - start
    local breaths = tonumber(counter.read(engine.breaths))
-   local input = link.stats(engine.app_table[nic].input.rx)
+   local inputs = link.stats(engine.app_table[nic].input)
+   local _, input = next(inputs)
    packets = input.rxpackets - packets
    bytes = input.rxbytes - bytes
    engine.report()

--- a/src/program/snabbvmx/lwaftr/lwaftr.lua
+++ b/src/program/snabbvmx/lwaftr/lwaftr.lua
@@ -3,7 +3,6 @@ module(..., package.seeall)
 local config = require("core.config")
 local constants = require("apps.lwaftr.constants")
 local ingress_drop_monitor = require("lib.timers.ingress_drop_monitor")
-local intel10g = require("apps.intel.intel10g")
 local lib = require("core.lib")
 local lwcounter = require("apps.lwaftr.lwcounter")
 local lwtypes = require("apps.lwaftr.lwtypes")
@@ -136,8 +135,6 @@ function run(args)
       end
    end
 
-   intel10g.ring_buffer_size(ring_buffer_size)
-
    if id then engine.claim_name(id) end
 
    local vlan = false
@@ -157,6 +154,7 @@ function run(args)
       mtu = mtu,
       vlan = vlan,
       mirror_id = mirror_id,
+      ring_buffer_size = ring_buffer_size,
    }
 
    local c = config.new()

--- a/src/program/snabbvmx/lwaftr/setup.lua
+++ b/src/program/snabbvmx/lwaftr/setup.lua
@@ -37,7 +37,7 @@ end
 
 local function load_driver (pciaddr)
    local device_info = pci.device_info(pciaddr)
-   return require(device_info.driver).driver
+   return require(device_info.driver), device_info.rx, device_info.tx
 end
 
 local function load_virt (c, nic_id, lwconf, interface)
@@ -45,7 +45,7 @@ local function load_virt (c, nic_id, lwconf, interface)
    local internal_interface = lwconf.softwire_config.internal_interface
    assert(type(interface) == 'table')
    assert(nic_exists(interface.pci), "Couldn't find NIC: "..interface.pci)
-   local driver = assert(load_driver(interface.pci))
+   local driver, rx, tx = assert(load_driver(interface.pci))
 
    print("Different VLAN tags: load two virtual interfaces")
    print(("%s ether %s"):format(nic_id, interface.mac_address))
@@ -61,6 +61,7 @@ local function load_virt (c, nic_id, lwconf, interface)
       vmdq = interface.vlan and true,
       vlan = interface.vlan and interface.vlan.v4_vlan_tag,
       macaddr = ethernet:ntop(external_interface.mac),
+      ring_buffer_size = interface.ring_buffer_size,
       mtu = v4_mtu })
    local v6_mtu = internal_interface.mtu + constants.ethernet_header_size
    if internal_interface.vlan_tag then
@@ -72,9 +73,12 @@ local function load_virt (c, nic_id, lwconf, interface)
       vmdq = interface.vlan and true,
       vlan = interface.vlan and interface.vlan.v6_vlan_tag,
       macaddr = ethernet:ntop(internal_interface.mac),
+      ring_buffer_size = interface.ring_buffer_size,
       mtu = v6_mtu})
 
-   return v4_nic_name, v6_nic_name
+   local v4_in, v4_out = v4_nic_name.."."..rx, v4_nic_name.."."..tx
+   local v6_in, v6_out = v6_nic_name.."."..rx, v6_nic_name.."."..tx
+   return v4_in, v4_out, v6_in, v6_out
 end
 
 local function load_phy (c, nic_id, interface)
@@ -83,7 +87,7 @@ local function load_phy (c, nic_id, interface)
    local chain_input, chain_output
 
    if nic_exists(interface.pci) then
-      local driver = load_driver(interface.pci)
+      local driver, rx, tx = load_driver(interface.pci)
       vlan = interface.vlan and tonumber(interface.vlan)
       print(("%s network ether %s mtu %d"):format(nic_id, interface.mac_address, interface.mtu))
       if vlan then
@@ -94,8 +98,9 @@ local function load_phy (c, nic_id, interface)
          vmdq = true,
          vlan = vlan,
          macaddr = interface.mac_address,
+         ring_buffer_size = interface.ring_buffer_size,
          mtu = interface.mtu})
-      chain_input, chain_output = nic_id .. ".rx", nic_id .. ".tx"
+      chain_input, chain_output = nic_id.."."..rx, nic_id.."."..tx
    elseif net_exists(interface.pci) then
       print(("%s network interface %s mtu %d"):format(nic_id, interface.pci, interface.mtu))
       if vlan then
@@ -138,9 +143,8 @@ function lwaftr_app(c, conf, lwconf, sock_path)
 
    local use_splitter = requires_splitter(internal_interface, external_interface)
    if not use_splitter then
-      local v4, v6 = load_virt(c, phy_id, lwconf, conf.interface)
-      v4_output, v6_output = v4..".tx", v6..".tx"
-      v4_input, v6_input   = v4..".rx", v6..".rx"
+      v4_input, v4_output, v6_input, v6_output =
+         load_virt(c, phy_id, lwconf, conf.interface)
    else
       chain_input, chain_output = load_phy(c, phy_id, conf.interface)
    end

--- a/src/program/snabbvmx/lwaftr/setup.lua
+++ b/src/program/snabbvmx/lwaftr/setup.lua
@@ -37,7 +37,7 @@ end
 
 local function load_driver (pciaddr)
    local device_info = pci.device_info(pciaddr)
-   return require(device_info.driver), device_info.rx, device_info.tx
+   return require(device_info.driver).driver, device_info.rx, device_info.tx
 end
 
 local function load_virt (c, nic_id, lwconf, interface)

--- a/src/program/wall/common.lua
+++ b/src/program/wall/common.lua
@@ -1,6 +1,8 @@
 -- Use of this source code is governed by the Apache 2.0 license; see COPYING.
 module(..., package.seeall)
 
+local pci = require('lib.hardware.pci')
+
 -- This module provides some common definitions for snabbwall programs
 
 inputs = {}
@@ -17,12 +19,9 @@ function inputs.tap (kind, device)
    return "output", { require("apps.tap.tap").Tap, device }
 end
 
-function inputs.intel10g (kind, device)
-   local conf = { pciaddr = device }
-   return "tx", { require("apps.intel.intel_app").Intel82599, conf }
-end
-
-function inputs.intel1g (kind, device)
-   local conf = { pciaddr = device }
-   return "tx", { require("apps.intel.intel1g").Intel1g, conf }
+function inputs.pci (kind, device)
+   local info = pci.device_info(device)
+   assert(info.usable == 'yes', "Unusable PCI device: "..device)
+   local conf = { pciaddr = info.pciaddress }
+   return info.tx, { require(info.driver).driver, conf }
 end

--- a/src/program/wall/filter/README
+++ b/src/program/wall/filter/README
@@ -2,8 +2,7 @@ Usage:
   snabb wall filter [options] pcap <input.pcap>
   snabb wall filter [options] raw <device>
   snabb wall filter [options] tap <device>
-  snabb wall filter [options] intel10g <pci-address>
-  snabb wall filter [options] intel1g <pci-address>
+  snabb wall filter [options] pci <pci-address>
   snabb wall filter --help
 
 Filters packets from the given source (e.g., a .pcap file) using the

--- a/src/program/wall/spy/README
+++ b/src/program/wall/spy/README
@@ -2,8 +2,7 @@ Usage:
   snabb wall spy [options] pcap <input.pcap>
   snabb wall spy [options] raw <device>
   snabb wall spy [options] tap <device>
-  snabb wall spy [options] intel10g <pci-address>
-  snabb wall spy [options] intel1g <pci-address>
+  snabb wall spy [options] pci <pci-address>
   snabb wall spy --help
 
 Analyzes traffic from .pcap capture file (in "pcap" mode), or live from a

--- a/src/program/wall/tests/bench.sh
+++ b/src/program/wall/tests/bench.sh
@@ -19,7 +19,7 @@ function benchmark {
   for (( i=1; i<=$ITERS; i++ ))
   do
     # run the filter
-    ./snabb wall filter --cpu $CPU -p -e "{ BITTORRENT = 'drop', default = 'accept' }" -D $DURATION -4 192.168.0.1 -m "01:23:45:67:89:ab" intel10g $PCI1 > $output &
+    ./snabb wall filter --cpu $CPU -p -e "{ BITTORRENT = 'drop', default = 'accept' }" -D $DURATION -4 192.168.0.1 -m "01:23:45:67:89:ab" pci $PCI1 > $output &
     # blast with pcap traffic
     ./snabb packetblaster replay -D $DURATION program/wall/tests/data/$1 $PCI2 > /dev/null
     grep "bytes:.*packets:.*bps:" $output


### PR DESCRIPTION
This PR is a reworking of #1199 which tries to first adapt network functions to be agnostic as far as whether they are using the old intel10g driver or the new intel_mp driver.  It does this by adding `rx` and `tx` fields to the PCI driver info structure, letting network functions know what link names to use.  It renames the `ndescriptors` property of `intel_mp` to `ring_buffer_size`, and adds a corresponding initarg to the old intel10g driver.  Finally it enables VMDq whereever network functions were setting a MAC address; see #749.

I have a few more unpushed commits to make corresponding changes to the lwAFTR and the changes that @teknico and @takikawa made to the packetblaster / firehose, and the commit that actually changes over the `pci.device_info()` function to prefer `intel_mp`, but every patch in this series should work and cause no regressions, so it should be a safe merge on all downstreams of `wingo-next` (including `lwaftr`).