### PR TITLE
Adjust ctable selftest to avoid assertion failure

### DIFF
--- a/src/lib/ctable.lua
+++ b/src/lib/ctable.lua
@@ -682,8 +682,12 @@ function selftest()
       end
       do
          local file = io.open(tmp, 'rb')
+         -- keep references to avoid GCing too early
+         local handle = {}
          local function read(size)
-            return ffi.new('uint8_t[?]', size, file:read(size))
+            local buf = ffi.new('uint8_t[?]', size, file:read(size))
+            table.insert(handle, buf)
+            return buf
          end
          local stream = {}
          function stream:read_ptr(type)


### PR DESCRIPTION
This PR should fix issue #1212. I tested it by running `status=0; while [ $status -eq 0 ]; do sudo ./snabb snsh -t lib.ctable; status=$?; done` and waiting for a failure. Without the commit, it fails in about a minute or so of waiting. With the commit, I've left it running for 20+ minutes.

I also tested it by adding an explicit `collectgarbage()` call to trigger the bug immediately.