### PR TITLE
Include IPV4/IPV6 in GRE inner protocol list

### DIFF
--- a/src/lib/protocol/gre.lua
+++ b/src/lib/protocol/gre.lua
@@ -28,7 +28,11 @@ ffi.cdef[[
 -- Class variables
 gre._name = "gre"
 gre._ulp = {
-   class_map = { [0x6558] = "lib.protocol.ethernet" },
+   class_map = {
+                  [0x6558] = "lib.protocol.ethernet",
+                  [0x0800] = "lib.protocol.ipv4",
+                  [0x86dd] = "lib.protocol.ipv6",
+                },
    method    = 'protocol' }
 gre:init(
    {


### PR DESCRIPTION
The protocol field for GRE should be an ether type; an implementation receiving a packet containing a Protocol Type which is not an ether type should discard the packet (RFC 2784, 2.4). GRE's inner protocol list (_ulp) should thus be the same as Ethernet's, so that GRE:upper_layer() behaves correctly.