### PR TITLE
engine: Separate JIT traces for each app callback

### DIFF
--- a/lib/luajit/src/lib_jit.c
+++ b/lib/luajit/src/lib_jit.c
@@ -141,6 +141,12 @@ LJLIB_CF(jit_attach)
   return 0;
 }
 
+/* Calling this forces a trace stitch. */
+LJLIB_CF(jit_tracebarrier)
+{
+  return 0;
+}
+
 LJLIB_PUSH(top-5) LJLIB_SET(os)
 LJLIB_PUSH(top-4) LJLIB_SET(arch)
 LJLIB_PUSH(top-3) LJLIB_SET(version_num)

--- a/src/core/app.lua
+++ b/src/core/app.lua
@@ -82,6 +82,7 @@ end
 -- Run app:methodname() in protected mode (pcall). If it throws an
 -- error app will be marked as dead and restarted eventually.
 function with_restart (app, method)
+   jit.tracebarrier() -- don't mix engine and apps in traces
    local status, result
    if use_restart then
       -- Run fn in protected mode using pcall.

--- a/src/core/app.lua
+++ b/src/core/app.lua
@@ -96,6 +96,7 @@ function with_restart (app, method)
    else
       status, result = true, method(app)
    end
+   jit.tracebarrier()
    return status, result
 end
 


### PR DESCRIPTION
This branch makes the engine ensure that JIT traces never cross between the engine and app callbacks. This is intended both to make JIT trace dumps more readable (don't mix engine and apps in the same trace) and to limit the impact of issues like JIT blacklistings (prevent problems in one app from propagating into other apps or the engine.)

This is achieved using a new primitive function `jit.tracebarrier()` that JIT traces cannot cross. During recording, a call to `jit.tracebarrier()` will immediately finish the current trace and then start a new root trace. This appears as a "trace stitch" in the log.

This branch makes the engine execute such a trace barrier immediately before and after each call to an app.

Performance impact needs to be evaluated. See also raptorjit/raptorjit#115.