### PR TITLE
lj_record.c: Record IFUNC/IFUNCV the same as FUNC/FUNCV

### DIFF
--- a/lib/luajit/src/lj_record.c
+++ b/lib/luajit/src/lj_record.c
@@ -2411,8 +2411,6 @@ void lj_record_ins(jit_State *J)
   case BC_IFORL:
   case BC_IITERL:
   case BC_ILOOP:
-  case BC_IFUNCF:
-  case BC_IFUNCV:
     lj_trace_err(J, LJ_TRERR_BLACKL);
     break;
 
@@ -2424,6 +2422,7 @@ void lj_record_ins(jit_State *J)
   /* -- Function headers -------------------------------------------------- */
 
   case BC_FUNCF:
+  case BC_IFUNCF:
     rec_func_lua(J);
     break;
   case BC_JFUNCF:
@@ -2431,6 +2430,7 @@ void lj_record_ins(jit_State *J)
     break;
 
   case BC_FUNCV:
+  case BC_IFUNCV:
     rec_func_vararg(J);
     rec_func_lua(J);
     break;


### PR DESCRIPTION
Record calls to blacklisted functions the same way as calls to
uncompiled functions. This allows for the possibility that a
blacklisted function can be successfully recorded as part of a larger
trace.

This is specifically intended to fix the problem where a tiny utility
function somewhere, such as `ntohs`, is not able to be compiled in
isolation for some reason and that ends up preventing all of its
callers from compiling too.

This has tended to happen for obscure reasons like "the utility
function ends with a tail-call to a C library routine" and with this
patch we should not need to worry about such minutiae anymore. (We
should be able to retire the "wrap in parenthesis to prevent a
tailcall" trick that some people are familiar with.)

More background:

- How the trace recorder treats function calls: raptorjit/raptorjit#118.
- Why this can be a problem: raptorjit/raptorjit#119.
- More on this specific solution: raptorjit/raptorjit#120.