### PR TITLE
core/memory: log segfault details for unhandled SIGSEGV

### DIFF
--- a/src/core/memory.c
+++ b/src/core/memory.c
@@ -23,6 +23,7 @@
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <sys/ucontext.h>
 #include <unistd.h>
 
 // See memory.lua for pointer tagging scheme.
@@ -36,7 +37,7 @@ static char path_template[PATH_MAX];
 // the SIGSEGV handler.
 int memory_demand_mappings;
 
-static void memory_sigsegv_handler(int sig, siginfo_t *si, void *unused);
+static void memory_sigsegv_handler(int sig, siginfo_t *si, void *uc);
 
 // Install signal handler
 static void set_sigsegv_handler()
@@ -48,7 +49,7 @@ static void set_sigsegv_handler()
   assert(sigaction(SIGSEGV, &sa, NULL) != -1);
 }
 
-static void memory_sigsegv_handler(int sig, siginfo_t *si, void *unused)
+static void memory_sigsegv_handler(int sig, siginfo_t *si, void *uc)
 {
   int fd = -1;
   struct stat st;
@@ -81,9 +82,15 @@ static void memory_sigsegv_handler(int sig, siginfo_t *si, void *unused)
   set_sigsegv_handler();
   return;
  punt:
-  // Log useful details
-  fprintf(stderr, "snabb[%d]: segfault at %p code %d\n",
-          getpid(), si->si_addr, si->si_code);
+  // Log useful details, including instruction and stack pointers.
+  // See https://stackoverflow.com/a/7102867
+  fprintf(stderr, "snabb[%d]: segfault at %p ip %p sp %p code %d errno %d\n",
+          getpid(),
+          si->si_addr,
+          (void *)((ucontext_t *)uc)->uc_mcontext.gregs[REG_RIP],
+          (void *)((ucontext_t *)uc)->uc_mcontext.gregs[REG_RSP],
+          si->si_code,
+          si->si_errno);
   fflush(stderr);
   // Fall back to the default SEGV behavior by resending the signal
   // now that the handler is disabled.

--- a/src/core/memory.c
+++ b/src/core/memory.c
@@ -81,6 +81,10 @@ static void memory_sigsegv_handler(int sig, siginfo_t *si, void *unused)
   set_sigsegv_handler();
   return;
  punt:
+  // Log useful details
+  fprintf(stderr, "snabb[%d]: segfault at %p code %d\n",
+          getpid(), si->si_addr, si->si_code);
+  fflush(stderr);
   // Fall back to the default SEGV behavior by resending the signal
   // now that the handler is disabled.
   // See https://www.cons.org/cracauer/sigint.html


### PR DESCRIPTION
This logs a message (similar to what appears in `dmesg` if a procces receives a `SIGSEGV`) when snabb encounters a segmentation fault.

It looks like this:

```
$ sudo ./snabb snsh -e 'require("ffi").cast("int*", 1234)[0] = 42'
snabb[3723]: segfault at 0x4d2 ip 0x446f93 sp 0x7ffc6de72da0 code 1 errno 0
Segmentation fault (core dumped)
$ 
```

Interpreting possible `si_code` and `si_errno` usually requires some digging into `/usr/include`.

Cc @lukego 