### PR TITLE
Attempt to fix apps/intel_mp/test_1g_sw_sem.snabb

### DIFF
--- a/src/apps/intel_mp/test_1g_sw_sem.snabb
+++ b/src/apps/intel_mp/test_1g_sw_sem.snabb
@@ -6,7 +6,7 @@ local parse = require("core.lib").parse
 local function new_intel (arg)
    return intel.Intel:new(parse(arg, intel.Intel.config))
 end
-local nic = new_intel({pciaddr = pci0})
+local nic = new_intel({pciaddr = pci0, rxq = false, txq = false})
 
 nic:unlock_sw_sem()
 nic:lock_sw_sem()


### PR DESCRIPTION
I think the original intent of this test was to test intel_mp without
any rxq/txq, as in test_10g_sw_sem.snabb.  However in the refactoring of
the default values of rxq/txq and how lib.parse was used to provide
defaults, rxq/txq got turned on, which prevents the test from working as
nic:stop recursively acquires the semaphore.