### PR TITLE
core.link: free any packets left in link when freeing link

### DIFF
--- a/src/core/link.lua
+++ b/src/core/link.lua
@@ -36,6 +36,9 @@ function new (name)
 end
 
 function free (r, name)
+   while not empty(r) do
+      packet.free(receive(r))
+   end
    for _, c in ipairs(provided_counters) do
       counter.delete("links/"..name.."/"..c..".counter")
    end


### PR DESCRIPTION
Due to how the engine works, the case that a link is non-empty between
breaths is rare (specifically, it should only occur when an app pushes
to a “slow” output interface). That’s probably why this went unnoticed
until now. I don’t even have a case that triggers this bug, it just came
to me.

Sidenote / only related in spirit: this is somewhat of a foreshadowing of problems that will need to be solved in #1185 (integrated inter-process links) and are sidestepped in #1186 (specialized inter-process links/apps). Specifically, the need to synchronize process-shared link creation and destruction. 

Vita currently uses the specialized inter-process links/apps which depend on one side of the link being explicitly promoted to take care of creating and freeing the link resource. This creates an implicit dependency of the order in which the processes are started/configured, i.e. the process that creates the link needs to do so before another process wants to read from a link, and the consuming process needs to stop reading from the link before the link can be safely freed.

As Vita splits into even more processes (next up is a dedicated process for key exchange and management) this kind of dependency will get into its way. I suspect this will have to be solved by a mix of tricky synchronization logic with regard to shared memory links (especially setup/teardown seem hairy) and well-defined re-configuration graph semantics provided by i.e. `snabb ptree`.