### PR TITLE
lib.numa: selftest fails on non-NUMA systems

### DIFF
--- a/src/lib/numa.lua
+++ b/src/lib/numa.lua
@@ -109,6 +109,7 @@ function unbind_numa_node ()
 end
 
 function bind_to_numa_node (node)
+   if not has_numa() then return end
    if node == bound_numa_node then return end
    if not node then return unbind_numa_node() end
    assert(not bound_numa_node, "already bound")
@@ -128,9 +129,6 @@ function prevent_preemption(priority)
 end
 
 function selftest ()
-   if not has_numa() then
-      os.exit(engine.test_skipped_code)
-   end
 
    function test_cpu(cpu)
       local node = cpu_get_numa_node(cpu)
@@ -138,11 +136,11 @@ function selftest ()
       assert(bound_cpu == cpu)
       assert(bound_numa_node == node)
       assert(S.getcpu().cpu == cpu)
-      assert(S.getcpu().node == node)
+      assert(not has_numa() or S.getcpu().node == node)
       bind_to_cpu(nil)
       assert(bound_cpu == nil)
       assert(bound_numa_node == node)
-      assert(S.getcpu().node == node)
+      assert(not has_numa() or S.getcpu().node == node)
       bind_to_numa_node(nil)
       assert(bound_cpu == nil)
       assert(bound_numa_node == nil)

--- a/src/lib/numa.lua
+++ b/src/lib/numa.lua
@@ -128,6 +128,9 @@ function prevent_preemption(priority)
 end
 
 function selftest ()
+   if not has_numa() then
+      os.exit(engine.test_skipped_code)
+   end
 
    function test_cpu(cpu)
       local node = cpu_get_numa_node(cpu)


### PR DESCRIPTION
As per https://github.com/snabbco/snabb/pull/1267#issuecomment-361235782

I still believe this to be expected behavior and possibly the correct fix (I have included an alternative approach that attempts to be... progressive), unless `has_numa` is supposed to behave differently than I expected. Let me explain:

I observe a difference in behavior on a system that has only a single NUMA node, and a system which has no NUMA at all. E.g.

Single NUMA node:
```
$ numactl -H
available: 1 nodes (0)
node 0 cpus: 0 1 2 3 4 5 6 7
node 0 size: 15943 MB
node 0 free: 13209 MB
node distances:
node   0 
  0:  10 
$ numactl -m 0 echo hello
hello
```

No NUMA support:
```
$ numactl -H
No NUMA available on this system
$ numactl -m 0 echo hello
numactl: This system does not support NUMA policy
```

On both of those systems `has_numa` returns false (maybe that is a bug in itself?). Without knowing too much about the subject matter, I had intuitively assumed that calling `bind_to_numa_node` can’t possibly work on a system that has no concept of NUMA nodes. I.e., `assert(S.set_mempolicy('bind', node))` will fail. I think this is different for systems with only a single NUMA node, where you can very well bind to the only node (maybe `has_numa` should return true on those?).

On the non-NUMA system the selftest of `lib.numa` will fail like so:

```
→ numactl -H
No NUMA available on this system
→ sudo ./snabb snsh -t lib.numa
selftest: numa
core/main.lua:26: Function not implemented

Stack Traceback
===============
(1) Lua function 'handler' at file 'core/main.lua:168' (best guess)
	Local variables:
	 reason = string: "core/main.lua:26: Function not implemented"
	 (*temporary) = C function: print
(2) global C function 'error'
(3) Lua global 'assert' at file 'core/main.lua:26'
	Local variables:
	 v = nil
(4) Lua global 'bind_to_numa_node' at file 'lib/numa.lua:116'
	Local variables:
	 node = number: 0
(5) Lua global 'bind_to_cpu' at file 'lib/numa.lua:103'
	Local variables:
	 cpu = number: 0
	 cpu_and_node = table: 0x419eb8c8  {cpu:0, node:0}
(6) Lua global 'test_cpu' at file 'lib/numa.lua:134'
	Local variables:
	 cpu = number: 0
	 node = nil
(7) Lua field 'selftest' at file 'lib/numa.lua:152'
	Local variables:
	 (for index) = number: 0
	 (for limit) = number: 1023
	 (for step) = number: 1
	 cpuid = number: 0
(8) Lua function 'opt' at file 'program/snsh/snsh.lua:31' (best guess)
	Local variables:
	 arg = string: "lib.numa"
(9) Lua field 'dogetopt' at file 'core/lib.lua:425'
	Local variables:
	 args = table: 0x4062b8d8  {1:-t, 2:lib.numa}
	 actions = table: 0x40754520  {t:function: 0x40e89798, q:function: 0x40754568, P:function: 0x40626f78 (more...)}
	 opts = string: "hl:p:t:die:j:P:q:"
	 long_opts = table: 0x40628810  {jit:j, help:h, program:p, test:t, load:l, package-path:P, debug:d, sigquit:q (more...)}
	 opts = table: 0x419e9460  {1:t}
	 optind = number: 3
	 optarg = table: 0x406288d8  {1:lib.numa}
	 (for generator) = C function: builtin#6
	 (for state) = table: 0x419e9460  {1:t}
	 (for control) = number: 1
	 i = number: 1
	 v = string: "t"
(10) Lua field 'run' at file 'program/snsh/snsh.lua:65'
	Local variables:
	 parameters = table: 0x4062b8d8  {1:-t, 2:lib.numa}
	 profiling = boolean: false
	 traceprofiling = boolean: false
	 start_repl = boolean: false
	 noop = boolean: true
	 program = nil
	 opt = table: 0x40754520  {t:function: 0x40e89798, q:function: 0x40754568, P:function: 0x40626f78 (more...)}
(11) Lua function 'main' at file 'core/main.lua:67' (best guess)
	Local variables:
	 program = string: "snsh"
	 args = table: 0x4062b8d8  {1:-t, 2:lib.numa}
(12) global C function 'xpcall'
(13) main chunk of file 'core/main.lua' at line 230
(14)  C function 'require'
(15) global C function 'pcall'
(16) main chunk of file 'core/startup.lua' at line 3
(17) global C function 'require'
(18) main chunk of [string "require "core.startup""] at line 1
	nil
```

Cc @wingo 