### PR TITLE
intel_app: run selftest even though its not the default driver anymore

### DIFF
--- a/src/apps/intel/intel_app.lua
+++ b/src/apps/intel/intel_app.lua
@@ -252,13 +252,9 @@ end
 function selftest ()
    print("selftest: intel_app")
 
-   local pcideva = lib.getenv("SNABB_PCI_INTEL0") or lib.getenv("SNABB_PCI0")
-   local pcidevb = lib.getenv("SNABB_PCI_INTEL1") or lib.getenv("SNABB_PCI1")
-   if not pcideva
-      or pci.device_info(pcideva).driver ~= 'apps.intel.intel_app'
-      or not pcidevb
-      or pci.device_info(pcidevb).driver ~= 'apps.intel.intel_app'
-   then
+   local pcideva = lib.getenv("SNABB_PCI_INTEL0")
+   local pcidevb = lib.getenv("SNABB_PCI_INTEL1")
+   if not pcideva or not pcidevb then
       print("SNABB_PCI_INTEL[0|1]/SNABB_PCI[0|1] not set or not suitable.")
       os.exit(engine.test_skipped_code)
    end


### PR DESCRIPTION
intel_app’s selftest was being skipped even though the required devices were present because it is no longer the default driver.