### PR TITLE
apps.ipv4.reassemble: fix a copy paste error at end of selftest

### DIFF
--- a/src/apps/ipv4/reassemble.lua
+++ b/src/apps/ipv4/reassemble.lua
@@ -430,7 +430,7 @@ function selftest()
                       "pkt["..i.."] expected "..expected..", got "..actual)
             end
             packet.free(result)
-            link.free(reassembler.input.output, 'reassembly input')
+            link.free(reassembler.input.input, 'reassembly input')
             link.free(reassembler.output.output, 'reassembly output')
             shm.delete_frame(reassembler.shm)
          end

--- a/src/apps/ipv6/reassemble.lua
+++ b/src/apps/ipv6/reassemble.lua
@@ -429,7 +429,7 @@ function selftest()
                       "pkt["..i.."] expected "..expected..", got "..actual)
             end
             packet.free(result)
-            link.free(reassembler.input.output, 'reassembly input')
+            link.free(reassembler.input.input, 'reassembly input')
             link.free(reassembler.output.output, 'reassembly output')
             shm.delete_frame(reassembler.shm)
          end


### PR DESCRIPTION
Fixes a copy paste error at end of apps.ipv4.reassemble’s selftest.