### PR TITLE
core.app: remove garbage when using pace_breathing

### DIFF
--- a/src/core/app.lua
+++ b/src/core/app.lua
@@ -505,9 +505,9 @@ function pace_breathing ()
       else
          sleep = math.floor(sleep/2)
       end
-      lastfrees = counter.read(frees)
-      lastfreebytes = counter.read(freebytes)
-      lastfreebits = counter.read(freebits)
+      lastfrees = tonumber(counter.read(frees))
+      lastfreebytes = tonumber(counter.read(freebytes))
+      lastfreebits = tonumber(counter.read(freebits))
    end
 end
 


### PR DESCRIPTION
The accumulators `lastfrees`, `lastfreebytes`, `lastfreebits` for the
counters `frees`, `freebytes` and `freebits` are initialized as Lua numbers
but implicitly converted to cdata objects in the assignments in
 `pace_breathing()`. This causes allocations that cannot be removed by
the sink optimizer.  Conversion to Lua numbers avoids this and reduces
GC noise.