### PR TITLE
snabb top: minor formatting fixes

### DIFF
--- a/src/program/top/top.lua
+++ b/src/program/top/top.lua
@@ -69,7 +69,7 @@ function list_shm (pid, object)
    table.sort(sorted)
    for _, name in ipairs(sorted) do
       if name ~= 'path' and name ~= 'specs' and  name ~= 'readonly' then
-         print_row({30, 30}, {name, tostring(frame[name])})
+         print_row({30, 47}, {name, tostring(frame[name])})
       end
    end
    shm.delete_frame(frame)
@@ -195,14 +195,14 @@ function print_link_metrics (new_stats, last_stats)
    end
 end
 
-function pad_str (s, n)
+function pad_str (s, n, no_pad)
    local padding = math.max(n - s:len(), 0)
-   return ("%s%s"):format(s:sub(1, n), (" "):rep(padding))
+   return ("%s%s"):format(s:sub(1, n), (no_pad and "") or (" "):rep(padding))
 end
 
 function print_row (spec, args)
    for i, s in ipairs(args) do
-      io.write((" %s"):format(pad_str(s, spec[i])))
+      io.write((" %s"):format(pad_str(s, spec[i], i == #args)))
    end
    io.write("\n")
 end


### PR DESCRIPTION
1. Widen the value column in list_shm a bit.
2. Do not emit trailing whitespace for trailing columns.