### PR TITLE
Disable lwAFTR property-based tests unless SNABB_ENABLE_FLAKY_TESTS is set

### DIFF
--- a/src/program/lwaftr/tests/propbased/selftest.sh
+++ b/src/program/lwaftr/tests/propbased/selftest.sh
@@ -6,6 +6,9 @@ SKIPPED_CODE=43
 
 if [ -z $SNABB_PCI0 ]; then exit $SKIPPED_CODE; fi
 
+# FIXME: Once these tests are passing reliably again, remove this.
+if [ -z $SNABB_ENABLE_FLAKY_TESTS ]; then exit $SKIPPED_CODE; fi
+
 ./snabb lwaftr quickcheck program.lwaftr.tests.propbased.prop_nocrash $SNABB_PCI0
 ./snabb lwaftr quickcheck program.lwaftr.tests.propbased.prop_nocrash_state $SNABB_PCI0
 ./snabb lwaftr quickcheck program.lwaftr.tests.propbased.prop_sameval $SNABB_PCI0


### PR DESCRIPTION
Sadly, these tests are flaky and its failures are gating merges of
unrelated patches.  We'll work on fixing these tests on Igalia's lwaftr
branch.