### PR TITLE
Intel driver unbinds PCI device from Linux before mapping

### DIFF
--- a/src/apps/intel_mp/intel_mp.lua
+++ b/src/apps/intel_mp/intel_mp.lua
@@ -356,6 +356,7 @@ function Intel:new (conf)
    self.max_q = byid.max_q
 
    -- Setup device access
+   pci.unbind_device_from_linux(self.pciaddress)
    self.base, self.fd = pci.map_pci_memory_unlocked(self.pciaddress, 0)
    self.master = self.fd:flock("ex, nb")
 
@@ -1119,7 +1120,6 @@ function Intel1g:unlock_fw_sem()
 end
 function Intel1g:init ()
    if not self.master then return end
-   pci.unbind_device_from_linux(self.pciaddress)
    pci.set_bus_master(self.pciaddress, true)
    pci.disable_bus_master_cleanup(self.pciaddress)
 
@@ -1311,7 +1311,6 @@ vmdq_enabled_t = ffi.typeof("struct { uint8_t enabled; }")
 
 function Intel82599:init ()
    if not self.master then return end
-   pci.unbind_device_from_linux(self.pciaddress)
    pci.set_bus_master(self.pciaddress, true)
    pci.disable_bus_master_cleanup(self.pciaddress)
 


### PR DESCRIPTION
Since Linux 4.5, devices that are bound to a kernel driver can't have
their memory mapped by userspace under the default configuration of
CONFIG_IO_STRICT_DEVMEM=y.

Should fix https://github.com/snabbco/snabb/issues/1286.