### PR TITLE
Make supervisor setup more reliable

### DIFF
--- a/src/core/main.lua
+++ b/src/core/main.lua
@@ -225,23 +225,23 @@ end
 -- Fork a child process that monitors us and performs cleanup actions
 -- when we terminate.
 local snabbpid = S.getpid()
+local lockfile = os.tmpname()
+local lock = S.open(lockfile, "wronly")
+S.unlink(lockfile)
+S.sigprocmask("block", "hup, int, quit, term")
+lock:lockf("lock", 0)
 if assert(S.fork()) ~= 0 then
-   -- parent process: run snabb
+   -- Parent process; run Snabb.
+   S.sigprocmask("unblock", "hup, int, quit, term")
    xpcall(main, handler)
+   -- Lock will be released however the process exits.
 else
-   -- child process: supervise parent & perform cleanup
-   -- Subscribe to SIGHUP on parent death
+   -- Child process: Supervise parent & perform cleanup.  Lock not
+   -- inherited from parent.
    S.prctl("set_name", "[snabb sup]")
-   S.prctl("set_pdeathsig", "hup")
-   -- Trap relevant signals to a file descriptor
-   local exit_signals = "hup, int, quit, term"
-   local signalfd = S.signalfd(exit_signals)
-   S.sigprocmask("block", exit_signals)
-   -- wait until we receive a signal
-   local signals
-   repeat signals = assert(S.util.signalfd_read(signalfd)) until #signals > 0
-   -- cleanup after parent process
+   -- Wait for parent to release lock.
+   lock:lockf("lock", 0)
+   -- Finally, clean up after parent process.
    shutdown(snabbpid)
-   -- exit with signal-appropriate status
-   os.exit(128 + signals[1].signo)
+   os.exit(128)
 end


### PR DESCRIPTION
There was a race condition when setting up the supervisor such that in
some cases it was possible to miss a signal when the parent process
died.  We could reproduce this with by running a "snabb lwaftr bench",
but only on our test machine with two NUMA nodes and only when setting
--cpu on the lwaftr.  In that case the problem would appear when
running "snabb lwaftr monitor" on the lwaftr; the monitor process
would hang reading from the signalfd.  Because the monitor process
still had stdout open, then when piping its output to "grep", the grep
process would hang because the write side of its stdin pipe would
still be open as well.

This patch fixes this error by making cleanup reliable.  It does so by
taking a POSIX lock on an unnamed file in the parent, then taking
another lock from the supervisor child process.  In this way we avoid
some of the more arcane parts of Linux.