### PR TITLE
Load potentially 64-bit values using mov64

### DIFF
--- a/src/apps/example/asm.dasl
+++ b/src/apps/example/asm.dasl
@@ -19,7 +19,8 @@ local asm_status = ffi.new("uint32_t[1]")
 |.arch x64
 |.actionlist actions
 local Dst = dasm.new(actions)
-| mov dword [asm_status], 0xdeadbeef
+| mov64 rax, asm_status
+| mov dword [rax], 0xdeadbeef
 | ret
 code = Dst:build() -- assign to 'code' to avoid machine code being GC'd
 fptr = ffi.cast("void(*)()", code)

--- a/src/lib/hash/siphash.dasl
+++ b/src/lib/hash/siphash.dasl
@@ -172,7 +172,7 @@ local function SSE(stride)
    function asm.init(key)
       local initial_state = load_initial_state(key)
       table.insert(__anchor, initial_state)
-      | mov rax, initial_state
+      | mov64 rax, initial_state
       | movddup xmm0, [rax]
       | movddup xmm1, [rax+8]
       | movddup xmm2, [rax+16]
@@ -253,7 +253,7 @@ local function AVX2(stride)
       local initial_state = load_initial_state(key)
       table.insert(__anchor, initial_state)
       | vzeroupper
-      | mov rax, initial_state
+      | mov64 rax, initial_state
       | vbroadcastsd ymm0, qword [rax]
       | vbroadcastsd ymm1, qword [rax+8]
       | vbroadcastsd ymm2, qword [rax+16]
@@ -345,7 +345,7 @@ local function AVX2(stride)
       -- write out.
       local control = ffi.new('uint32_t[8]', 1, 3, 5, 7, 0, 0, 0, 0)
       table.insert(__anchor, control)
-      | mov rax, control
+      | mov64 rax, control
       | vmovdqu ymm5, [rax]
       | vpermd ymm(reg), ymm5, ymm(reg)
       | vpslld xmm(reg), xmm(reg), 1

--- a/src/lib/multi_copy.dasl
+++ b/src/lib/multi_copy.dasl
@@ -58,7 +58,7 @@ function gen(count, size)
          tail_mask = ffi.new("uint8_t[32]")
          for i=0,tail_size-1 do tail_mask[i]=255 end
          table.insert(anchor, tail_mask)
-         | mov rax, tail_mask
+         | mov64 rax, tail_mask
          | vmovdqu ymm15, [rax]
       end
 


### PR DESCRIPTION
When Snabb switches to LuaJIT's GC64, FFI allocations might be in the
64-bit range.  This commit adapts the memory references to immediate
addresses to account for 64-bit immediates.