### PR TITLE
Fix out-of-bounds write in ctable test suite

### DIFF
--- a/src/lib/ctable.lua
+++ b/src/lib/ctable.lua
@@ -682,7 +682,8 @@ function selftest()
          -- keep references to avoid GCing too early
          local handle = {}
          local function read(size)
-            local buf = ffi.new('uint8_t[?]', size, file:read(size))
+            local buf = ffi.new('uint8_t[?]', size)
+            ffi.copy(buf, file:read(size), size)
             table.insert(handle, buf)
             return buf
          end


### PR DESCRIPTION
This is another instance of the bug from commit 93ef6bdbbd92eab4b96790f825cefec3988dc65a.  We didn't see any issue on upstream Snabb's test suites, but with RaptorJIT's new LJ_GC64 usage did manifest itself as intermittent heap corruption.

Fixes https://github.com/snabbco/snabb/issues/1307.

See https://github.com/Igalia/snabb/pull/659 for a previous iteration of this problem in which I was also the culprit.  Aaaaaggghhhh!!!!!