### PR TITLE
[ipsec] add tunnel mode esp app

### DIFF
--- a/src/apps/ipsec/README.md
+++ b/src/apps/ipsec/README.md
@@ -1,21 +1,21 @@
 # IPsec Apps
 
-## AES128gcm (apps.ipsec.esp)
+## ESP Transport6 and Tunnel6 (apps.ipsec.esp)
 
-The `AES128gcm` implements ESP in transport mode using the AES-GCM-128
-cipher. It encrypts packets received on its `decapsulated` port and transmits
-them on its `encapsulated` port, and vice-versa. Packets arriving on the
-`decapsulated` port must have an IPv6 header, and packets arriving on the
-`encapsulated` port must have an IPv6 header followed by an ESP header,
-otherwise they will be discarded.
+The `Transport6` and `Tunnel6` apps implement ESP in transport and tunnel mode
+respectively. they encrypts packets received on their `decapsulated` port and
+transmit them on their `encapsulated` port, and vice-versa. Packets arriving on
+the `decapsulated` port must have Ethernet and IPv6 headers, and packets
+arriving on the `encapsulated` port must have an Ethernet and IPv6 headers
+followed by an ESP header, otherwise they will be discarded.
 
-    DIAGRAM: AES128gcm
-                   +-----------+
-    encapsulated   |           |
-              ---->* AES128gcm *<----
-              <----*           *---->
-                   |           |   decapsulated
-                   +-----------+
+    DIAGRAM: Transport6
+                   +------------+
+    encapsulated   |            |
+              ---->* Transport6 *<----
+              <----*  Tunnel6   *---->
+                   |            |   decapsulated
+                   +------------+
     
     encapsulated
               --------\   /----------
@@ -28,8 +28,21 @@ References:
 
 ### Configuration
 
-The `AES128gcm` app accepts a table as its configuration argument. The
-following keys are defined:
+The `Transport6` and `Tunnel6` apps accepts a table as its configuration
+argument. The following keys are defined:
+
+— Key **self_ip** (`Tunnel6` only)
+
+*Required*. Source address of the encapsulating IPv6 header.
+
+— Key **nexthop_ip** (`Tunnel6` only)
+
+*Required*. Destination address of the encapsulating IPv6 header.
+
+— Key **aead**
+
+*Optional*. The AEAD to use for encryption and authentication. For now, only
+the default `"aes-gcm-128-12"` is supported.
 
 — Key **spi**
 

--- a/src/apps/ipsec/esp.lua
+++ b/src/apps/ipsec/esp.lua
@@ -6,11 +6,13 @@
 module(..., package.seeall)
 local esp = require("lib.ipsec.esp")
 local counter = require("core.counter")
-local C = require("ffi").C
+local ethernet = require("lib.protocol.ethernet")
+local ipv6 = require("lib.protocol.ipv6")
 
-AES128gcm = {
+Transport6 = {
    config = {
       spi = {required=true},
+      aead = {default="aes-gcm-128-12"},
       transmit_key = {required=true},
       transmit_salt =  {required=true},
       receive_key = {required=true},
@@ -25,17 +27,17 @@ AES128gcm = {
    }
 }
 
-function AES128gcm:new (conf)
+function Transport6:new (conf)
    local self = {}
    assert(conf.transmit_salt ~= conf.receive_salt,
           "Refusing to operate with transmit_salt == receive_salt")
    self.encrypt = esp.encrypt:new{
-      mode = "aes-gcm-128-12",
+      mode = conf.aead,
       spi = conf.spi,
       key = conf.transmit_key,
       salt = conf.transmit_salt}
    self.decrypt = esp.decrypt:new{
-      mode = "aes-gcm-128-12",
+      mode = conf.aead,
       spi = conf.spi,
       key = conf.receive_key,
       salt = conf.receive_salt,
@@ -43,10 +45,10 @@ function AES128gcm:new (conf)
       resync_threshold = conf.resync_threshold,
       resync_attempts = conf.resync_attempts,
       auditing = conf.auditing}
-   return setmetatable(self, {__index = AES128gcm})
+   return setmetatable(self, {__index = Transport6})
 end
 
-function AES128gcm:push ()
+function Transport6:push ()
    -- Encapsulation path
    local input = self.input.decapsulated
    local output = self.output.encapsulated
@@ -73,4 +75,133 @@ function AES128gcm:push ()
          counter.add(self.shm.rxerrors)
       end
    end
+end
+
+Tunnel6 = {
+   config = {
+      self_ip = {required=true},
+      nexthop_ip = {required=true},
+      spi = {required=true},
+      aead = {default="aes-gcm-128-12"},
+      transmit_key = {required=true},
+      transmit_salt =  {required=true},
+      receive_key = {required=true},
+      receive_salt =  {required=true},
+      receive_window = {},
+      resync_threshold = {},
+      resync_attempts = {},
+      auditing = {},
+      selftest = {default=false}
+   },
+   shm = {
+      txerrors = {counter}, rxerrors = {counter}
+   },
+   -- https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml
+   NextHeaderIPv6 = 41
+}
+
+function Tunnel6:new (conf)
+   local self = {}
+   assert(conf.selftest or conf.transmit_salt ~= conf.receive_salt,
+          "Refusing to operate with transmit_salt == receive_salt")
+   self.encrypt = esp.encrypt:new{
+      mode = conf.aead,
+      spi = conf.spi,
+      key = conf.transmit_key,
+      salt = conf.transmit_salt
+   }
+   self.decrypt = esp.decrypt:new{
+      mode = conf.aead,
+      spi = conf.spi,
+      key = conf.receive_key,
+      salt = conf.receive_salt,
+      window_size = conf.receive_window,
+      resync_threshold = conf.resync_threshold,
+      resync_attempts = conf.resync_attempts,
+      auditing = conf.auditing
+   }
+   self.eth = ethernet:new{
+      type = 0x86dd -- IPv6
+   }
+   self.ip = ipv6:new{
+      src = ipv6:pton(conf.self_ip),
+      dst = ipv6:pton(conf.nexthop_ip),
+      next_header = esp.PROTOCOL,
+      hop_limit = 64
+   }
+   return setmetatable(self, {__index = Tunnel6})
+end
+
+function Tunnel6:push ()
+   -- Encapsulation path
+   local input = self.input.decapsulated
+   local output = self.output.encapsulated
+   while not link.empty(input) do
+      local p = link.receive(input)
+      if p.length >= ethernet:sizeof() then
+         -- Strip Ethernet header
+         p = packet.shiftleft(p, ethernet:sizeof())
+         -- Encrypt payload
+         local p_enc = self.encrypt:encapsulate_tunnel(p, self.NextHeaderIPv6)
+         -- Slap on IPv6 and Ethernet headers
+         self.ip:payload_length(p_enc.length)
+         p_enc = packet.prepend(p_enc, self.ip:header(), ipv6:sizeof())
+         p_enc = packet.prepend(p_enc, self.eth:header(), ethernet:sizeof())
+         link.transmit(output, p_enc)
+      else
+         packet.free(p)
+         counter.add(self.shm.txerrors)
+      end
+   end
+   -- Decapsulation path
+   local input = self.input.encapsulated
+   local output = self.output.decapsulated
+   while not link.empty(input) do
+      local p = link.receive(input)
+      if p.length >= ethernet:sizeof() + ipv6:sizeof() then
+         -- Strip Ethernet and IPv6 headers
+         p = packet.shiftleft(p, ethernet:sizeof() + ipv6:sizeof())
+         -- Decrypt payload
+         local p_dec, nh = self.decrypt:decapsulate_tunnel(p)
+         if p_dec and nh == self.NextHeaderIPv6 then
+            -- Slap on new Ethernet header
+            p_dec = packet.prepend(p_dec, self.eth:header(), ethernet:sizeof())
+            link.transmit(output, p_dec)
+            goto next
+         end
+      end
+      -- Handle error
+      packet.free(p)
+      counter.add(self.shm.rxerrors)
+      ::next::
+   end
+end
+
+function selftest ()
+   -- Only testing Tunnel6 because Transport6 is mostly covered in the selftest
+   -- of lib.ipsec.esp.
+   local basic_apps = require("apps.basic.basic_apps")
+   local c = config.new()
+   config.app(c, "source", basic_apps.Source)
+   config.app(c, "sink", basic_apps.Sink)
+   config.app(c, "tunnel", Tunnel6, {
+      self_ip = "fc00::1",
+      nexthop_ip = "fc00::2",
+      spi = 0xdeadbeef,
+      transmit_key = "00112233445566778899AABBCCDDEEFF",
+      transmit_salt = "00112233",
+      receive_key = "00112233445566778899AABBCCDDEEFF",
+      receive_salt = "00112233",
+      auditing = true,
+      selftest = true
+   })
+   config.link(c, "source.output -> tunnel.decapsulated")
+   config.link(c, "tunnel.encapsulated -> tunnel.encapsulated")
+   config.link(c, "tunnel.decapsulated -> sink.input")
+   engine.configure(c)
+   engine.main{duration=0.0001}
+   engine.report_links()
+   assert(counter.read(engine.app_table.tunnel.shm.rxerrors) == 0,
+          "Decapsulation error!")
+   print("OK")
 end

--- a/src/apps/ipsec/selftest.sh
+++ b/src/apps/ipsec/selftest.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
-#set -x
+set -e
 
 SKIPPED_CODE=43
 
+# Requires test_env with Linux guest featuring ipsec/ESN support.
 if [ "$SNABB_IPSEC_SKIP_E2E_TEST" = yes ]; then
     exit $SKIPPED_CODE
 fi
@@ -12,77 +13,7 @@ if [ -z "$SNABB_TELNET0" ]; then
     echo "Defaulting to SNABB_TELNET0=$SNABB_TELNET0"
 fi
 
-SPI=2953575118
-
-SRC=fc00:feed:face:dead::1
-DST=fc00:feed:face:dead::2
-
-IP=$DST
-MAC=52:54:01:00:00:
-
-TKEY=d4d61fec2861b3b806d0654eeea02ede
-TSALT=df3ddb99
-TKS=$TKEY$TSALT
-
-RKEY=c4d61fec2861b3b806d0654eeea02ede
-RSALT=cf3ddb99
-RKS=$RKEY$RSALT
-
-SPORT=60122
-DPORT=60123
-
-if ! source program/snabbnfv/test_env/test_env.sh; then
-    echo "Could not load test_env."; exit 1
-fi
-
-./snabb snsh apps/ipsec/selftest.lua ${MAC}01 ${MAC}00 $SRC $DST $SPORT $DPORT $SPI $TKEY $TSALT $RKEY $RSALT 3 ping &
-snabb_pid=$!
-
-if ! qemu soft esp.sock $SNABB_TELNET0; then
-    echo "Could not start qemu."; exit $SKIPPED_CODE
-fi
-
-wait_vm_up $SNABB_TELNET0
-run_telnet $SNABB_TELNET0 "systemctl stop dhcpcd.service &>/dev/console" >/dev/null
-run_telnet $SNABB_TELNET0 "ifconfig eth0 down &>/dev/console" >/dev/null
-run_telnet $SNABB_TELNET0 "ip -6 neigh flush dev eth0 &>/dev/console" >/dev/null
-run_telnet $SNABB_TELNET0 "ip -6 neigh add $SRC lladdr ${MAC}01 dev eth0 &>/dev/console" >/dev/null
-run_telnet $SNABB_TELNET0 "ip -6 addr add $DST/7 dev eth0 &>/dev/console" >/dev/null
-run_telnet $SNABB_TELNET0 "ifconfig eth0 up &>/dev/console" >/dev/null
-run_telnet $SNABB_TELNET0 "ncat -lkuc cat $DPORT &>/dev/console &" >/dev/null
-
-
-#---------------------------------------------------------
-
-#      |-------------key--------------||-SALT-|
-#KEY=0x`dd if=/dev/urandom count=32 bs=1 2> /dev/null| xxd -p -c 64`
-SPI_ID=0xb00bface
-#SPI_ID=0x`dd if=/dev/urandom count=4 bs=1 2> /dev/null| xxd -p -c 8`
-
-SPISTR="spi $SPI_ID"
-PROTO="proto esp"
-
-SD_FWD="src $SRC dst $DST"
-SD_REV="src $DST dst $SRC"
-
-SDP_FWD="$SD_FWD $PROTO"
-SDP_REV="$SD_REV $PROTO"
-
-ID_FWD="$SDP_FWD $SPISTR"
-ID_REV="$SDP_REV $SPISTR"
-
-MODE="mode transport"
-REPLAY="replay-window 128"
-FLAG="flag esn"
-RALGO="aead rfc4106\(gcm\(aes\)\) 0x$RKS 96"
-TALGO="aead rfc4106\(gcm\(aes\)\) 0x$TKS 96"
-
-cmd="echo 'spdflush; flush;' | setkey -c"
-cmd="$cmd; ip xfrm state add   $ID_FWD  $MODE  $REPLAY  $FLAG   $TALGO"
-cmd="$cmd; ip xfrm state add   $ID_REV  $MODE  $REPLAY  $FLAG   $RALGO "
-cmd="$cmd; ip xfrm policy add   $SD_REV   dir out   tmpl $SDP_REV   $MODE"
-cmd="$cmd; ip xfrm policy add   $SD_FWD   dir in    tmpl $SDP_FWD   $MODE"
-run_telnet $SNABB_TELNET0 "$cmd &>/dev/console" >/dev/null
-#---------------------------------------------------------
-
-wait $snabb_pid
+echo "Probing a Linux guest through ESP in transport mode..."
+apps/ipsec/test-linux-compat.sh transport
+echo "Probing a Linux guest through ESP in tunnel mode..."
+apps/ipsec/test-linux-compat.sh tunnel

--- a/src/apps/ipsec/test-linux-compat.sh
+++ b/src/apps/ipsec/test-linux-compat.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+MODE=$1
+
+SPI=2953575118
+
+SRC=fc00:feed:face:dead::1
+DST=fc00:feed:face:dead::2
+
+TKEY=d4d61fec2861b3b806d0654eeea02ede
+TSALT=df3ddb99
+TKS=$TKEY$TSALT
+
+RKEY=c4d61fec2861b3b806d0654eeea02ede
+RSALT=cf3ddb99
+RKS=$RKEY$RSALT
+
+SPORT=60122
+DPORT=60123
+
+if ! source program/snabbnfv/test_env/test_env.sh; then
+    echo "Could not load test_env."; exit 1
+fi
+
+qemu soft esp.sock $SNABB_TELNET0
+
+apps/ipsec/test-linux-compat.snabb \
+   $MODE ${MAC}01 $SRC $DST $SPORT $DPORT $SPI $TKEY $TSALT $RKEY $RSALT ping &
+snabb_pid=$!
+
+wait_vm_up $SNABB_TELNET0
+run_telnet $SNABB_TELNET0 "systemctl stop dhcpcd.service &>/dev/console" >/dev/null
+run_telnet $SNABB_TELNET0 "ifconfig eth0 down &>/dev/console" >/dev/null
+run_telnet $SNABB_TELNET0 "ip -6 addr add $DST/7 dev eth0 &>/dev/console" >/dev/null
+run_telnet $SNABB_TELNET0 "ifconfig eth0 up &>/dev/console" >/dev/null
+run_telnet $SNABB_TELNET0 "ncat -vvvlkuc cat $DPORT &>/dev/console &" >/dev/null
+
+SPI_ID=0xb00bface
+
+SPISTR="spi $SPI_ID"
+PROTO="proto esp"
+
+SD_FWD="src $SRC dst $DST"
+SD_REV="src $DST dst $SRC"
+
+SDP_FWD="$SD_FWD $PROTO"
+SDP_REV="$SD_REV $PROTO"
+
+ID_FWD="$SDP_FWD $SPISTR"
+ID_REV="$SDP_REV $SPISTR"
+
+REPLAY="replay-window 128"
+FLAG="flag esn"
+RALGO="aead rfc4106\(gcm\(aes\)\) 0x$RKS 96"
+TALGO="aead rfc4106\(gcm\(aes\)\) 0x$TKS 96"
+
+cmd="echo 'spdflush; flush;' | setkey -c"
+cmd="$cmd; ip xfrm state add   $ID_FWD  mode $MODE  $REPLAY  $FLAG   $TALGO"
+cmd="$cmd; ip xfrm state add   $ID_REV  mode $MODE  $REPLAY  $FLAG   $RALGO "
+cmd="$cmd; ip xfrm policy add   $SD_REV   dir out   tmpl $SDP_REV   mode $MODE"
+cmd="$cmd; ip xfrm policy add   $SD_FWD   dir in    tmpl $SDP_FWD   mode $MODE"
+run_telnet $SNABB_TELNET0 "$cmd &>/dev/console" >/dev/null
+
+wait $snabb_pid

--- a/src/apps/ipsec/test-linux-compat.snabb
+++ b/src/apps/ipsec/test-linux-compat.snabb
@@ -1,3 +1,5 @@
+#!snabb snsh
+
 -- Use of this source code is governed by the Apache 2.0 license; see COPYING.
 
 io.stdout:setvbuf('no')
@@ -10,20 +12,19 @@ local eth = require("lib.protocol.ethernet")
 local dg = require("lib.protocol.datagram")
 local vhost = require("apps.vhost.vhost_user")
 local esp = require("apps.ipsec.esp")
-local filter = require("apps.packet_filter.pcap_filter")
+local nd_light = require("apps.ipv6.nd_light").nd_light
 local ffi = require("ffi")
-local C = require("ffi").C
 
 -- this is supposed to be run from a selftest shell script
 -- which hopefully can figure out most arguments on its own.
-if not (#main.parameters == 13 ) then
-   print("need 13 arguments: srcmac dstmac srcip dstip srcport dstport spi txkey txsalt rxkey rxsalt seqno payload") -- XXX usage
+if not (#main.parameters == 12 ) then
+   print("need 12 arguments: mode srcmac srcip dstip srcport dstport spi txkey txsalt rxkey rxsalt payload") -- XXX usage
    main.exit(1)
 end
 
 local args = {
-   srcmac = main.parameters[1],
-   dstmac = main.parameters[2],
+   mode = main.parameters[1],
+   srcmac = main.parameters[2],
    srcip = main.parameters[3],
    dstip = main.parameters[4],
    srcport = main.parameters[5],
@@ -33,8 +34,7 @@ local args = {
    txsalt = main.parameters[9],
    rxkey = main.parameters[10],
    rxsalt = main.parameters[11],
-   seqno = main.parameters[12],
-   payload = main.parameters[13],
+   payload = main.parameters[12],
 }
 
 local UDPing = {
@@ -44,17 +44,17 @@ local UDPing = {
       dstport = {default=args.dstport},
       srcaddr = {default=args.srcip},
       dstaddr = {default=args.dstip},
-      srclladdr = {default=args.srcmac},
-      dstlladdr = {default=args.dstmac},
-      payload = {default=args.payload}
+      payload = {default=args.payload},
+      throttle = {default=1},
+      timeout = {default=60}
    }
 }
 
 function UDPing:new (conf)
    local o = {
       conf = conf,
-      ping = lib.throttle(1),
-      timeout = lib.timeout(120)
+      ping = lib.throttle(conf.throttle),
+      timeout = lib.timeout(conf.timeout)
    }
    return setmetatable(o, {__index = UDPing})
 end
@@ -82,11 +82,7 @@ function UDPing:udpify (p)
    }
    local ipish = ipv6:new(ipcfg)
 
-   local ethcfg = {
-      src = eth:pton(self.conf.srclladdr),
-      dst = eth:pton(self.conf.dstlladdr),
-      type = 0x86dd -- IPv6
-   }
+   local ethcfg = { type = 0x86dd } -- IPv6
    local ethish = eth:new(ethcfg)
 
    local payload, length = dgram:payload()
@@ -109,7 +105,9 @@ function UDPing:pull ()
 end
 
 function UDPing:push ()
-   if self.timeout() then error("No reply.") end
+   if self.timeout() then
+      error("No reply.")
+   end
 
    while not link.empty(self.input.input) do
       local dgram = self:deudpify(link.receive(self.input.input))
@@ -127,6 +125,8 @@ local c = config.new()
 config.app(c, "udping", UDPing)
 
 local espconf = {
+   self_ip = (args.mode == "tunnel" and args.srcip) or nil,
+   nexthop_ip = (args.mode == "tunnel" and args.dstip) or nil,
    spi = args.spi,
    transmit_key = args.txkey,
    transmit_salt =  args.txsalt,
@@ -135,9 +135,11 @@ local espconf = {
    receive_window = 32,
    resync_threshold = 8192,
    resync_attempts = 8,
-   auditing = 1
+   auditing = true
 }
-config.app(c, "esp", esp.AES128gcm, espconf)
+config.app(c, "esp",
+           assert(({transport=esp.Transport6, tunnel=esp.Tunnel6})[args.mode]),
+           espconf)
 
 local vhostconf = {
    socket_path = 'esp.sock',
@@ -145,20 +147,19 @@ local vhostconf = {
 }
 config.app(c, "vhost", vhost.VhostUser, vhostconf)
 
-local pcapconf = {
-   filter = "ip6 and ip6 proto 50 " ..
-      "and ether src "..args.dstmac.." " ..
-      "and ether dst "..args.srcmac.." " ..
-      "and ip6 src host "..args.dstip.." " ..
-      "and ip6 dst host "..args.srcip
+local ndconf = {
+   local_mac = args.srcmac,
+   local_ip = args.srcip,
+   next_hop = args.dstip
 }
-config.app(c, "filter", filter.PcapFilter, pcapconf)
+config.app(c, "nd", nd_light, ndconf)
 
 config.link(c, "udping.output -> esp.decapsulated")
-config.link(c, "esp.encapsulated -> vhost.rx")
+config.link(c, "esp.encapsulated -> nd.north")
+config.link(c, "nd.south -> vhost.rx")
 
-config.link(c, "vhost.tx -> filter.input")
-config.link(c, "filter.output -> esp.encapsulated")
+config.link(c, "vhost.tx -> nd.south")
+config.link(c, "nd.north -> esp.encapsulated")
 config.link(c, "esp.decapsulated -> udping.input")
 
 engine.configure(c)
@@ -167,5 +168,3 @@ local function received_pong ()
    return link.stats(engine.app_table.udping.input.input).rxpackets > 0
 end
 engine.main({done=received_pong})
-
-

--- a/src/program/snabbnfv/README.md
+++ b/src/program/snabbnfv/README.md
@@ -73,7 +73,7 @@ The `crypto` section allows configuration of traffic encryption based on
 
 ```
 crypto := { type          = "esp-aes-128-gcm", -- The only type (for now)
-            spi           = <spi>,             -- As for AES128gcm
+            spi           = <spi>,             -- As for apps.ipsec.esp
             transmit_key  = <key>,
             transmit_salt = <salt>,
             receive_key   = <key>,

--- a/src/program/snabbnfv/nfvconfig.lua
+++ b/src/program/snabbnfv/nfvconfig.lua
@@ -7,7 +7,7 @@ local PcapFilter = require("apps.packet_filter.pcap_filter").PcapFilter
 local RateLimiter = require("apps.rate_limiter.rate_limiter").RateLimiter
 local nd_light = require("apps.ipv6.nd_light").nd_light
 local L2TPv3 = require("apps.keyed_ipv6_tunnel.tunnel").SimpleKeyedTunnel
-local AES128gcm = require("apps.ipsec.esp").AES128gcm
+local esp = require("apps.ipsec.esp")
 local virtual_ether_mux = require("lib.io.virtual_ether_mux")
 local pci = require("lib.hardware.pci")
 local ffi = require("ffi")
@@ -96,7 +96,7 @@ function load (file, pciaddr, sockpath, soft_bench)
       end
       if t.crypto and t.crypto.type == "esp-aes-128-gcm" then
          local Crypto = name.."_Crypto"
-         config.app(c, Crypto, AES128gcm,
+         config.app(c, Crypto, esp.Transport6,
                     {spi = t.crypto.spi,
                      transmit_key = t.crypto.transmit_key,
                      transmit_salt = t.crypto.transmit_salt,

--- a/src/program/snabbnfv/traffic/README
+++ b/src/program/snabbnfv/traffic/README
@@ -61,7 +61,7 @@ CONFIG FILE FORMAT:
   apps.ipsec.esp:
 
       crypto := { type          = "esp-aes-128-gcm", -- The only type (for now)
-                  spi           = <spi>,             -- As for AES128gcm
+                  spi           = <spi>,             -- As for apps.ipsec.esp
                   transmit_key  = <key>,
                   transmit_salt = <salt>,
                   receive_key   = <key>,


### PR DESCRIPTION
> This adds a simple ESP 6in6 tunnel app (Tunnel6) to apps.ipsec.esp, and also renames the transport mode app (AES18GCM -> Transport6) to match the naming.
> 
> The apps.ipsec Linux interoperability test is extended to exercise tunnel mode as well.

Why? This is not actually the app used by i.e. Vita. I had originally intended to consolidate the ESP apps in mainline snabb with the ESP apps in Vita, but noticed that this is really not straightforward. It boils down to “how much do you want your ESP app to do?” In the context of Vita the answer is currently “as little as possible”, in other contexts it might be different. I decided to add an ESP tunnel app that is mostly self-contained (you will probably want an `nd_light` in front of it), and serves as a show- and testcase that is compatible with e.g. the Linux IPsec stack.

Unless anyone objects, I will be my own upstream for this and merge it onto `ipsec`.