### PR TITLE
doc/branches.md: Add snabbco/raptorjit integration branch

### DIFF
--- a/src/doc/branches.md
+++ b/src/doc/branches.md
@@ -175,3 +175,12 @@ The current state of each branch with respect to master is visible here:
 
     Maintainer: Jianbo Liu <jianbo.liu@linaro.org>
 
+#### raptorjit
+
+    BRANCH: raptorjit git://github.com/snabbco/raptorjit
+    RaptorJIT updates integration and testing branch.
+
+    - Contains new RaptorJIT changes targeted to Snabb.
+
+    Maintainers: Luke Gorrie (@lukego) and Andy Wingo (@wingo)
+


### PR DESCRIPTION
@wingo and I volunteered to maintain this branch. Initially it's for making Snabb-on-RaptorJIT work well enough for merge to mainline. In the future we can use it for pulling new RaptorJIT updates too.