### PR TITLE
RaptorJIT: Enhance debug information in auditlog

### DIFF
--- a/lib/luajit/src/lj_auditlog.c
+++ b/lib/luajit/src/lj_auditlog.c
@@ -169,8 +169,11 @@ static void log_GCtrace(GCtrace *T)
     if (ir->o == IR_KGC) {
       GCobj *o = ir_kgc(ir);
       /* Log referenced string constants. For e.g. HREFK table keys. */
-      if (o->gch.gct == ~LJ_TSTR) {
+      switch (o->gch.gct) {
+      case ~LJ_TSTR:
+      case ~LJ_TFUNC:
         log_GCobj(o);
+        break;
       }
     }
   }
@@ -188,6 +191,11 @@ static void log_GCstr(GCstr *s)
   log_mem("GCstr", s, sizeof(*s) + s->len);
 }
 
+static void log_GCfunc(GCfunc *f)
+{
+  log_mem("GCfunc", f, sizeof(*f));
+}
+
 static void log_GCobj(GCobj *o)
 {
   /* Log some kinds of objects (could be fancier...) */
@@ -201,6 +209,8 @@ static void log_GCobj(GCobj *o)
   case ~LJ_TSTR:
     log_GCstr((GCstr *)o);
     break;
+  case ~LJ_TFUNC:
+    log_GCfunc((GCfunc *)o);
   }
 }
 

--- a/lib/luajit/src/lj_auditlog.c
+++ b/lib/luajit/src/lj_auditlog.c
@@ -8,6 +8,7 @@
 #include <time.h>
 
 #include "lj_trace.h"
+#include "lj_ctype.h"
 #include "lj_auditlog.h"
 
 /* Maximum data to buffer in memory before file is opened. */

--- a/lib/luajit/src/lj_auditlog.c
+++ b/lib/luajit/src/lj_auditlog.c
@@ -158,10 +158,21 @@ static void log_jit_State(jit_State *J)
 
 static void log_GCtrace(GCtrace *T)
 {
+  IRRef ref;
   log_mem("MCode[]", T->mcode, T->szmcode);
   log_mem("SnapShot[]", T->snap, T->nsnap * sizeof(*T->snap));
   log_mem("SnapEntry[]", T->snapmap, T->nsnapmap * sizeof(*T->snapmap));
   log_mem("IRIns[]", &T->ir[T->nk], (T->nins - T->nk + 1) * sizeof(IRIns));
+  for (ref = T->nk; ref < REF_TRUE; ref++) {
+    IRIns *ir = &T->ir[ref];
+    if (ir->o == IR_KGC) {
+      GCobj *o = ir_kgc(ir);
+      /* Log referenced string constants. For e.g. HREFK table keys. */
+      if (o->gch.gct == ~LJ_TSTR) {
+        log_GCobj(o);
+      }
+    }
+  }
   log_mem("GCtrace", T, sizeof(*T));
 }
 
@@ -241,6 +252,15 @@ void lj_auditlog_trace_flushall(jit_State *J)
     log_jit_State(J);
     log_event("trace_flushall", 1);
     str_16("jit_State");  /* = */ uint_64((uint64_t)J);
+  }
+}
+
+void lj_auditlog_new_ctypeid(CTypeID id, const char *desc)
+{
+  if (ensure_log_started()) {
+    log_event("new_ctypeid", 2);
+    str_16("id");   /* = */ uint_64(id);
+    str_16("desc"); /* = */ str_16(desc);
   }
 }
 

--- a/lib/luajit/src/lj_auditlog.h
+++ b/lib/luajit/src/lj_auditlog.h
@@ -7,6 +7,7 @@
 
 #include "lj_jit.h"
 #include "lj_trace.h"
+#include "lj_ctype.h"
 
 int lj_auditlog_open(const char *path, size_t maxsize);
 

--- a/lib/luajit/src/lj_auditlog.h
+++ b/lib/luajit/src/lj_auditlog.h
@@ -15,5 +15,6 @@ void lj_auditlog_lex(const char *chunkname, const char *s, int sz);
 void lj_auditlog_trace_flushall(jit_State *J);
 void lj_auditlog_trace_stop(jit_State *J, GCtrace *T);
 void lj_auditlog_trace_abort(jit_State *J, TraceError e);
+void lj_auditlog_new_ctypeid(CTypeID id, const char *desc);
 
 #endif

--- a/lib/luajit/src/lj_ctype.c
+++ b/lib/luajit/src/lj_ctype.c
@@ -14,6 +14,7 @@
 #include "lj_ctype.h"
 #include "lj_ccallback.h"
 #include "lj_buf.h"
+#include "lj_auditlog.h"
 
 /* -- C type definitions -------------------------------------------------- */
 
@@ -217,6 +218,7 @@ void lj_ctype_addname(CTState *cts, CType *ct, CTypeID id)
   uint32_t h = ct_hashname(gcref(ct->name));
   ct->next = cts->hash[h];
   cts->hash[h] = (CTypeID1)id;
+  lj_auditlog_new_ctypeid(id, strdata(gco2str(gcref(ct->name))));
 }
 
 /* Get a C type by name, matching the type mask. */


### PR DESCRIPTION
Add more debug information to the auditlog to support more detailed decoding in Studio (studio/studio#99).

Logging of CTypeID definitions is preliminary and does not cover all interesting types yet.