### PR TITLE
Fix ljsyscall to more promptly close file descriptors when enumerating directories

### DIFF
--- a/lib/ljsyscall/syscall/bsd/syscalls.lua
+++ b/lib/ljsyscall/syscall/bsd/syscalls.lua
@@ -31,6 +31,7 @@ if C.getdirentries then
     basep = basep or t.long1()
     local ret, err = C.getdirentries(getfd(fd), buf, size, basep)
     if ret == -1 then return nil, t.error(err or errno()) end
+    if ret == 0 then return nil, nil end
     return t.dirents(buf, ret)
   end
 end

--- a/lib/ljsyscall/syscall/syscalls.lua
+++ b/lib/ljsyscall/syscall/syscalls.lua
@@ -740,6 +740,7 @@ if C.getdents then
     buf = buf or t.buffer(size)
     local ret, err = C.getdents(getfd(fd), buf, size)
     if ret == -1 then return nil, t.error(err or errno()) end
+    if ret == 0 then return nil, nil end
     return t.dirents(buf, ret)
   end
 end

--- a/lib/ljsyscall/syscall/types.lua
+++ b/lib/ljsyscall/syscall/types.lua
@@ -601,15 +601,10 @@ if bsdtypes then types = bsdtypes.init(c, types) end
 -- define dents type if dirent is defined
 if t.dirent then
   t.dirents = function(buf, size) -- buf should be char*
-    local d, i = nil, 0
+    local i = 0
     return function() -- TODO work out if possible to make stateless
-      if size > 0 and not d then
-        d = pt.dirent(buf)
-        i = i + d.d_reclen
-        return d
-      end
       while i < size do
-        d = pt.dirent(pt.char(d) + d.d_reclen)
+        local d = pt.dirent(buf + i)
         i = i + d.d_reclen
         if d.ino ~= 0 then return d end -- some systems use ino = 0 for deleted files before removed eg OSX; it is never valid
       end

--- a/lib/ljsyscall/syscall/util.lua
+++ b/lib/ljsyscall/syscall/util.lua
@@ -56,22 +56,19 @@ function util.ls(name, buf, size)
   if err then return nil, err end
   local di
   return function()
-    local d, first
-    repeat
-      if not di then
-        local err
-        di, err = fd:getdents(buf, size)
-        if not di then
-          fd:close()
-          error(err)
-        end
-        first = true
+    while true do
+      if di then
+        local d = di()
+        if d then return d.name, d end
       end
-      d = di()
-      if not d then di = nil end
-      if not d and first then return nil end
-    until d
-    return d.name, d
+      -- Fetch more entries.
+      local err
+      di, err = fd:getdents(buf, size)
+      if not di then
+        fd:close()
+        if err then error(err) else return nil end
+      end
+    end
   end
 end
 


### PR DESCRIPTION
A user was running into a bug whereby running `snabb config get-state` repeatedly on a Snabb network function was causing "too many open fds" errors.  When I asked them to do an `ls -l /proc/PID/fd`, they came back with something that looks like this:

```
lr-x------ 1 root root 64 Apr 18 08:46 126 -> /dev/urandom
lr-x------ 1 root root 64 Apr 18 08:46 127 -> /run/snabb/43754/apps
lr-x------ 1 root root 64 Apr 18 08:46 128 -> /run/snabb/43754/apps/inetNic
lr-x------ 1 root root 64 Apr 18 08:46 129 -> /run/snabb/43754/apps/lwaftr
lr-x------ 1 root root 64 Apr 18 08:45 13 -> /run/snabb/43754/apps/fragmenterv4
lr-x------ 1 root root 64 Apr 18 08:46 130 -> /run/snabb/43754/apps/b4sideNic
lr-x------ 1 root root 64 Apr 18 08:46 131 -> /run/snabb/43754/apps/reassemblerv6
lr-x------ 1 root root 64 Apr 18 08:46 132 -> /run/snabb/43754/apps/fragmenterv4
lr-x------ 1 root root 64 Apr 18 08:46 133 -> /run/snabb/43754/apps/reassemblerv4
lr-x------ 1 root root 64 Apr 18 08:46 134 -> /run/snabb/43754/apps/fragmenterv6
lr-x------ 1 root root 64 Apr 18 08:46 135 -> /dev/urandom
lr-x------ 1 root root 64 Apr 18 08:46 136 -> /run/snabb/43754/apps
lr-x------ 1 root root 64 Apr 18 08:46 137 -> /run/snabb/43754/apps/inetNic
lr-x------ 1 root root 64 Apr 18 08:46 138 -> /run/snabb/43754/apps/lwaftr
lr-x------ 1 root root 64 Apr 18 08:46 139 -> /run/snabb/43754/apps/b4sideNic
lr-x------ 1 root root 64 Apr 18 08:45 14 -> /run/snabb/43754/apps/reassemblerv4
lr-x------ 1 root root 64 Apr 18 08:46 140 -> /run/snabb/43754/apps/reassemblerv6
lr-x------ 1 root root 64 Apr 18 08:46 141 -> /run/snabb/43754/apps/fragmenterv4
lr-x------ 1 root root 64 Apr 18 08:46 142 -> /run/snabb/43754/apps/reassemblerv4
lr-x------ 1 root root 64 Apr 18 08:46 143 -> /run/snabb/43754/apps/fragmenterv6
lr-x------ 1 root root 64 Apr 18 08:46 144 -> /dev/urandom
lr-x------ 1 root root 64 Apr 18 08:46 145 -> /run/snabb/43754/apps
lr-x------ 1 root root 64 Apr 18 08:46 146 -> /run/snabb/43754/apps/inetNic
...
```

And so on.  I don't know what's going on with the `urandom` entries though I will track that down.  The other files are the SHM directories of the worker processes managed by the ptree manager process.  Tracking that down further, these are opened by `shm.children()`, which uses ljsyscall's `util.dirtable` to enumerate files in those directories.  Normally these files will become collectible and will be closed by GC, but in this case it seems that GC didn't happen.

Anyway the right thing is for ljsyscall to be more prompt at closing transient file descriptors, at least in normal use when iterators are run to completion.  I made a patch and submitted it upstream at https://github.com/justincormack/ljsyscall/pull/221; this PR is just that patch, applied to Snabb.