### PR TITLE
Set SNABB_RANDOM_SEED for intel_mp tests

### DIFF
--- a/src/apps/intel_mp/selftest.sh
+++ b/src/apps/intel_mp/selftest.sh
@@ -14,6 +14,7 @@ TESTS=$(echo "$TESTS1G" "$TESTS10G" | grep -e "$FILTER" | sort)
 ESTATUS=0
 export SNABB_RECV_DEBUG=true
 export SNABB_RECV_MASTER_STATS=true
+export SNABB_RANDOM_SEED=0xacabba9e
 for i in $TESTS; do
    pkill -P $$ -f snabb
    sleep 1


### PR DESCRIPTION
This should fix some flakiness in these tests, as they use a
random number as the RSS key.

See also https://github.com/snabbco/snabb/pull/1323 for an alternate take on the same problem.