### PR TITLE
Enable vmprofiling in workers

### DIFF
--- a/src/core/app.lua
+++ b/src/core/app.lua
@@ -33,7 +33,11 @@ local named_program_root = shm.root .. "/" .. "by-name"
 program_name = false
 
 -- Auditlog state
-local auditlog_enabled = false
+auditlog_enabled = false
+function enable_auditlog ()
+   jit.auditlog(shm.path("audit.log"))
+   auditlog_enabled = true
+end
 
 -- The set of all active apps and links in the system, indexed by name.
 app_table, link_table = {}, {}
@@ -89,7 +93,7 @@ local function getvmprofile (name)
    return vmprofiles[name]
 end
 
-local function setvmprofile (name)
+function setvmprofile (name)
    C.vmprofile_set_profile(getvmprofile(name))
 end
 
@@ -497,8 +501,7 @@ function main (options)
 
    -- Enable auditlog
    if not auditlog_enabled then
-      jit.auditlog(shm.path("audit.log"))
-      auditlog_enabled = true
+      enable_auditlog()
    end
 
    -- Setup vmprofile

--- a/src/lib/ptree/worker.lua
+++ b/src/lib/ptree/worker.lua
@@ -92,8 +92,14 @@ function Worker:handle_actions_from_manager()
 end
 
 function Worker:main ()
+   local vmprofile = require("jit.vmprofile")
    local stop = engine.now() + self.duration
    local next_time = engine.now()
+
+   -- Setup vmprofile.
+   engine.setvmprofile("engine")
+   vmprofile.start()
+
    repeat
       self.breathe()
       if next_time < engine.now() then
@@ -102,6 +108,7 @@ function Worker:main ()
          timer.run()
       end
       if not engine.busywait then engine.pace_breathing() end
+      if not engine.auditlog_enabled then engine.enable_auditlog() end
    until stop < engine.now()
    counter.commit()
    if not self.no_report then engine.report(self.report) end

--- a/src/lib/ptree/worker.lua
+++ b/src/lib/ptree/worker.lua
@@ -100,6 +100,8 @@ function Worker:main ()
    engine.setvmprofile("engine")
    vmprofile.start()
 
+   if not engine.auditlog_enabled then engine.enable_auditlog() end
+
    repeat
       self.breathe()
       if next_time < engine.now() then
@@ -108,7 +110,6 @@ function Worker:main ()
          timer.run()
       end
       if not engine.busywait then engine.pace_breathing() end
-      if not engine.auditlog_enabled then engine.enable_auditlog() end
    until stop < engine.now()
    counter.commit()
    if not self.no_report then engine.report(self.report) end


### PR DESCRIPTION
This PR enables vmprofiling in workers. It fixes the issue of inspecting a worker process with Studio (which didn't work since `audit.log` could not be found).

Performance doesn't suffer with vmprofiling enabled.

```bash
$ SNABB_SHM_ROOT=/tmp/shm SNABB_SHM_KEEP=1 \
   ./snabb lwaftr run --cpu 11 --name lwaftr --conf lwaftr.conf --v4 82:00.0 --v6 82:00.1
```

```bash
$ sudo ./snabb loadtest find-limit from-inet-0550.pcap "NIC 0" "NIC 1" \
   02:00.0 from-b4-0550.pcap "NIC 1" "NIC 0" 02:00.1
Success.
9.999
```

When opening the process with Studio it shows profiling data for every worker app.

![worker-studio](https://user-images.githubusercontent.com/11567/39193737-84893220-47dc-11e8-8eb9-df86d303a6e8.png)
