### PR TITLE
RaptorJIT: Pull more VM debug logging for Studio

### DIFF
--- a/lib/luajit/src/Makefile
+++ b/lib/luajit/src/Makefile
@@ -237,6 +237,7 @@ LJCORE_O= lj_gc.o lj_err.o lj_char.o lj_bc.o lj_obj.o lj_buf.o \
 	  lj_ctype.o lj_cdata.o lj_cconv.o lj_ccall.o lj_ccallback.o \
 	  lj_carith.o lj_clib.o lj_cparse.o \
 	  lj_lib.o lj_alloc.o lib_aux.o \
+	  lj_dwarf_dwo.o \
 	  $(LJLIB_O) lib_init.o
 
 DWARF_DWO= lj_dwarf.dwo
@@ -382,6 +383,12 @@ $(HOST_O): %.o: %.c
 $(DWARF_DWO): %.dwo: %.c
 	$(E) "CC(debug) $@"
 	$(Q)$(TARGET_CC) -g3 -fno-eliminate-unused-debug-types -gsplit-dwarf -c $<
+
+# Embed DWARF debug information as binary data available to raptorjit.
+lj_dwarf_dwo.o lj_dwarf_dwo_dyn.o: $(DWARF_DWO)
+	$(E) "EMBED     $@"
+	$(Q)$(LD) -r -b binary -o $@ $<
+	$(Q)$(LD) -shared -b binary -o $(@:.o=_dyn.o) $<
 
 include Makefile.dep
 

--- a/lib/luajit/src/lj_auditlog.c
+++ b/lib/luajit/src/lj_auditlog.c
@@ -10,6 +10,7 @@
 #include "lj_trace.h"
 #include "lj_ctype.h"
 #include "lj_auditlog.h"
+#include "lj_debuginfo.h"
 
 /* Maximum data to buffer in memory before file is opened. */
 #define MAX_MEM_BUFFER 10*1024*1024
@@ -61,7 +62,7 @@ static void uint_64(uint64_t n) {
   cfwrite(&big, sizeof(big), 1, fp); /* value */
 }
 
-static void bin_32(void *ptr, int n) {
+static void bin_32(const void *ptr, int n) {
   uint32_t biglen = __builtin_bswap32(n);
   cfputc(0xc6, fp);                        /* array 32 header */
   cfwrite(&biglen, sizeof(biglen), 1, fp); /* length */
@@ -90,10 +91,18 @@ static void log_event(const char *type, int nattributes) {
   /* Caller fills in the further nattributes... */
 }
 
+static void log_blob(const char *name, const char *ptr, int size) {
+  fixmap(3);
+  str_16("type"); /* = */ str_16("blob");
+  str_16("name"); /* = */ str_16(name);
+  str_16("data"); /* = */ bin_32(ptr, size);
+}
+
 /* Log objects that define the virtual machine. */
 static void lj_auditlog_vm_definitions()
 {
   log_mem("lj_ir_mode", (void*)&lj_ir_mode, sizeof(lj_ir_mode));
+  log_blob("lj_dwarf.dwo", &_binary_lj_dwarf_dwo_start, &_binary_lj_dwarf_dwo_end - &_binary_lj_dwarf_dwo_start);
 }
 
 /* Check that the log is open before logging a message. */
@@ -164,6 +173,7 @@ static void log_GCtrace(GCtrace *T)
   log_mem("SnapShot[]", T->snap, T->nsnap * sizeof(*T->snap));
   log_mem("SnapEntry[]", T->snapmap, T->nsnapmap * sizeof(*T->snapmap));
   log_mem("IRIns[]", &T->ir[T->nk], (T->nins - T->nk + 1) * sizeof(IRIns));
+  log_mem("uint16_t[]", T->szirmcode, (T->nins - REF_BIAS - 1) * sizeof(uint16_t));
   for (ref = T->nk; ref < REF_TRUE; ref++) {
     IRIns *ir = &T->ir[ref];
     if (ir->o == IR_KGC) {
@@ -220,8 +230,8 @@ static void log_GCobj(GCobj *o)
 void lj_auditlog_trace_stop(jit_State *J, GCtrace *T)
 {
   if (ensure_log_started()) {
-    log_jit_State(J);
     log_GCtrace(T);
+    log_jit_State(J);
     log_event("trace_stop", 2);
     str_16("GCtrace");   /* = */ uint_64((uint64_t)T);
     str_16("jit_State"); /* = */ uint_64((uint64_t)J);

--- a/lib/luajit/src/lj_debuginfo.h
+++ b/lib/luajit/src/lj_debuginfo.h
@@ -1,0 +1,6 @@
+/*
+** RaptorJIT access to embedded debug information objects.
+**/
+
+extern const char _binary_lj_dwarf_dwo_start, _binary_lj_dwarf_dwo_end;
+

--- a/lib/luajit/src/lj_dwarf.c
+++ b/lib/luajit/src/lj_dwarf.c
@@ -11,6 +11,7 @@
 #include "lj_state.h"
 #include "lj_bc.h"
 #include "lj_ir.h"
+#include "lj_ircall.h"
 #include "lj_jit.h"
 #include "lj_iropt.h"
 #include "lj_mcode.h"
@@ -22,3 +23,5 @@
 #include "lj_dispatch.h"
 #include "lj_vm.h"
 #include "lj_target.h"
+#include "lj_ff.h"
+


### PR DESCRIPTION
This updates the RaptorJIT VM to log more useful debug information for Studio:

- Full DWARF debug information is stored inside the audit.log.
- Fixed machine code to IR code map logging.
- Add names of internal VM functions.

The IR visualization looks like this nowadays (with disassembly on mouseover tooltip :-))

![screen shot 2018-04-26 at 13 32 02](https://user-images.githubusercontent.com/13791/39303456-6f5b0fb0-4956-11e8-8527-35ed7bf46847.png)

