### PR TITLE
RaptorJIT: Fix bug in auditlog constant logging (can crash)

### DIFF
--- a/lib/luajit/src/lj_auditlog.c
+++ b/lib/luajit/src/lj_auditlog.c
@@ -11,7 +11,7 @@
 #include "lj_auditlog.h"
 
 /* Maximum data to buffer in memory before file is opened. */
-#define MAX_MEM_BUFFER 1024*1024
+#define MAX_MEM_BUFFER 10*1024*1024
 /* State for initial in-memory stream. */
 static char *membuffer;
 static size_t membuffersize;


### PR DESCRIPTION
Quickly pulling this fix to RaptorJIT `audit.log` logging of IR constants. There was a bug where 64-bit values could be mistaken for points to Lua objects and dereferenced, which could cause a segfault or bus error. This is fixed now.