### PR TITLE
Add luajit CFLAGS back into Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ LUAJIT_CFLAGS := -include $(CURDIR)/gcc-preinclude.h
 
 all: $(LUAJIT) $(SYSCALL) $(PFLUA)
 #       LuaJIT
-	@(cd lib/luajit && (cd src && $(MAKE) reusevm) && $(MAKE))
+	@(cd lib/luajit && (cd src && $(MAKE) reusevm) && $(MAKE) CFLAGS="$(LUAJIT_CFLAGS)")
 #       ljsyscall
 	@mkdir -p src/syscall/linux
 	@cp -p lib/ljsyscall/syscall.lua   src/


### PR DESCRIPTION
On PR #1340 the CI makes much more progress on the raptorjit branch, but there's still a failure due to breaking a selftest for glibc <2.7 compatibility (https://gist.github.com/SnabbBot/494e9caf010b44602e2b4124b381441d). This PR fixes that.