### PR TITLE
core.main: call vmprofile.start() before running program...

### DIFF
--- a/src/core/app.lua
+++ b/src/core/app.lua
@@ -12,7 +12,6 @@ local histogram = require('core.histogram')
 local counter   = require("core.counter")
 local jit       = require("jit")
 local S         = require("syscall")
-local vmprofile = require("jit.vmprofile")
 local ffi       = require("ffi")
 local C         = ffi.C
 require("core.packet_h")
@@ -89,7 +88,7 @@ local function getvmprofile (name)
    return vmprofiles[name]
 end
 
-local function setvmprofile (name)
+function setvmprofile (name)
    C.vmprofile_set_profile(getvmprofile(name))
 end
 
@@ -503,7 +502,6 @@ function main (options)
 
    -- Setup vmprofile
    setvmprofile("engine")
-   vmprofile.start()
 
    local breathe = breathe
    if options.measure_latency or options.measure_latency == nil then
@@ -519,6 +517,9 @@ function main (options)
    until done and done()
    counter.commit()
    if not options.no_report then report(options.report) end
+
+   -- Switch to catch-all profile
+   setvmprofile("program")
 end
 
 local nextbreath

--- a/src/core/main.lua
+++ b/src/core/main.lua
@@ -8,6 +8,7 @@ package.path = ''
 
 local STP = require("lib.lua.StackTracePlus")
 local ffi = require("ffi")
+local vmprofile = require("jit.vmprofile")
 local lib = require("core.lib")
 local shm = require("core.shm")
 local C   = ffi.C
@@ -53,6 +54,8 @@ function main ()
       if f == nil then
          error(("Failed to load $SNABB_PROGRAM_LUACODE: %q"):format(expr))
       else
+         engine.setvmprofile("program")
+         vmprofile.start()
          f()
       end
    else
@@ -62,9 +65,12 @@ function main ()
          print("unsupported program: "..program:gsub("_", "-"))
          usage(1)
       else
+         engine.setvmprofile("program")
+         vmprofile.start()
          require(modulename(program)).run(args)
       end
    end
+   vmprofile.stop()
 end
 
 -- Take the program name from the first argument, unless the first


### PR DESCRIPTION
...so that profiling code outside the engine works. Adds a "program" profile
for everything that happens outside of the engine and apps.

Cc @lukego 