### PR TITLE
core.memory: unmap tmpptr in allocate_huge_page

### DIFF
--- a/src/core/memory.lua
+++ b/src/core/memory.lua
@@ -160,6 +160,7 @@ function allocate_huge_page (size,  persistent)
    else
       assert(syscall.unlink(tmpfile))
    end
+   syscall.munmap(tmpptr, size)
    syscall.close(fd)
    return ptr, filename
 end


### PR DESCRIPTION
Unmap temporary hugepage memory mapping that is used to determine the page’s
physical memory address before returning the tagged mapping. This way we avoid
a superflous mapping in the process’ virtual memory space.