### PR TITLE
Add optional callback to the CTable:resize() method

### DIFF
--- a/src/lib/README.ctable.md
+++ b/src/lib/README.ctable.md
@@ -52,6 +52,9 @@ Optional entries that may be present in the *parameters* table include:
    2.  Defaults to 0.9, for a 90% maximum occupancy ratio.
  * `min_occupancy_rate`: Minimum ratio of `occupancy/size`.  Removing an
    entry from an "empty" table will shrink the table.
+ * `resize_callback`: An optional function that is called after the
+   table has been resized.  The function is called with two arguments:
+   the ctable object and the old size. By default, no callback is used.
 
 — Function **ctable.load** *stream* *parameters*
 

--- a/src/lib/ctable.lua
+++ b/src/lib/ctable.lua
@@ -122,7 +122,8 @@ local optional_params = {
    hash_seed = false,
    initial_size = 8,
    max_occupancy_rate = 0.9,
-   min_occupancy_rate = 0.0
+   min_occupancy_rate = 0.0,
+   resize_callback = false
 }
 
 function new(params)
@@ -143,6 +144,7 @@ function new(params)
    ctab.occupancy = 0
    ctab.max_occupancy_rate = params.max_occupancy_rate
    ctab.min_occupancy_rate = params.min_occupancy_rate
+   ctab.resize_callback = params.resize_callback
    ctab = setmetatable(ctab, { __index = CTable })
    ctab:reseed_hash_function(params.hash_seed)
    ctab:resize(params.initial_size)
@@ -227,6 +229,9 @@ function CTable:resize(size)
       if old_entries[i].hash ~= HASH_MAX then
          self:add(old_entries[i].key, old_entries[i].value)
       end
+   end
+   if self.resize_callback then
+      self.resize_callback(self, old_size)
    end
 end
 


### PR DESCRIPTION
My motivation for this change is to be able to perform a JIT flush after a table has been resized, which turned out to be crucial for performance in the case of the ipfix app. I also use it to emit an informational message about the growth of the table.