### PR TITLE
ctable: fix power-of-2 issue

### DIFF
--- a/src/lib/README.ctable.md
+++ b/src/lib/README.ctable.md
@@ -52,6 +52,11 @@ Optional entries that may be present in the *parameters* table include:
    2.  Defaults to 0.9, for a 90% maximum occupancy ratio.
  * `min_occupancy_rate`: Minimum ratio of `occupancy/size`.  Removing an
    entry from an "empty" table will shrink the table.
+ * `pad_entry`: If `true`, the data structure stored in the table is
+   padded with bytes of zero to make its size to be equal to a power
+   of two.  This can be used to work around a limitation of LuaJIT
+   which causes traces to abort when calculating differences of
+   pointers which are not a power of two.  The default is `false`.
 
 — Function **ctable.load** *stream* *parameters*
 

--- a/src/lib/ctable.lua
+++ b/src/lib/ctable.lua
@@ -38,7 +38,7 @@ local function compute_multi_hash_fn(key_ctype, width, stride, seed)
 end
 
 local entry_types = {}
-local function make_entry_type(key_type, value_type)
+local function make_entry_type(key_type, value_type, pad)
    local cache = entry_types[key_type]
    if cache then
       cache = cache[value_type]
@@ -47,7 +47,8 @@ local function make_entry_type(key_type, value_type)
       entry_types[key_type] = {}
    end
    local raw_size = ffi.sizeof(key_type) + ffi.sizeof(value_type) + 4
-   local padding = 2^ceil(math.log(raw_size)/math.log(2)) - raw_size
+   local padding = (pad and 2^ceil(math.log(raw_size)/math.log(2)) - raw_size)
+      or raw_size
    local ret = ffi.typeof([[struct {
          uint32_t hash;
          $ key;
@@ -126,13 +127,15 @@ local optional_params = {
    hash_seed = false,
    initial_size = 8,
    max_occupancy_rate = 0.9,
-   min_occupancy_rate = 0.0
+   min_occupancy_rate = 0.0,
+   pad_entry = false,
 }
 
 function new(params)
    local ctab = {}   
    local params = parse_params(params, required_params, optional_params)
-   ctab.entry_type = make_entry_type(params.key_type, params.value_type)
+   ctab.entry_type = make_entry_type(params.key_type, params.value_type,
+                                     params.pad_entry)
    ctab.type = make_entries_type(ctab.entry_type)
    function ctab.make_hash_fn()
       return compute_hash_fn(params.key_type, ctab.hash_seed)

--- a/src/lib/ctable.lua
+++ b/src/lib/ctable.lua
@@ -48,7 +48,7 @@ local function make_entry_type(key_type, value_type, pad)
    end
    local raw_size = ffi.sizeof(key_type) + ffi.sizeof(value_type) + 4
    local padding = (pad and 2^ceil(math.log(raw_size)/math.log(2)) - raw_size)
-      or raw_size
+      or 0
    local ret = ffi.typeof([[struct {
          uint32_t hash;
          $ key;

--- a/src/lib/ctable.lua
+++ b/src/lib/ctable.lua
@@ -46,24 +46,28 @@ local function make_entry_type(key_type, value_type)
    else
       entry_types[key_type] = {}
    end
+   local raw_size = ffi.sizeof(key_type) + ffi.sizeof(value_type) + 4
+   local padding = 2^ceil(math.log(raw_size)/math.log(2)) - raw_size
    local ret = ffi.typeof([[struct {
          uint32_t hash;
          $ key;
          $ value;
+         uint8_t padding[$];
       } __attribute__((packed))]],
       key_type,
-      value_type)
+      value_type,
+      padding)
    entry_types[key_type][value_type] = ret
    return ret
 end
 
 local function make_entries_type(entry_type)
-   return ffi.typeof('$[?]', entry_type)
+   return (ffi.typeof('$[?]', entry_type))
 end
 
 -- hash := [0,HASH_MAX); scale := size/HASH_MAX
 local function hash_to_index(hash, scale)
-   return floor(hash*scale)
+   return (floor(hash*scale))
 end
 
 local function make_equal_fn(key_type)


### PR DESCRIPTION
I have brought this up in issue https://github.com/snabbco/snabb/issues/1207, which is still open. I propose this fix at least as an interim solution until RaptorJIT lands (provided it will contain the fix proposed by @lukego).

Removal of two tail-call optimizations is also part of this PR. I found that this reduces trace aborts in my ipfix app some time ago. I'm not sure if we have converged on a common strategy to deal with this sort of problem, so this could be debatable.