### PR TITLE
Add engine.stop() to stop all apps

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -258,6 +258,10 @@ following keys are recognized:
    printed.
 
 
+— Function **engine.stop**
+
+Stop all apps in the engine by loading an empty configuration.
+
 — Function **engine.now**
 
 Returns monotonic time in seconds as a floating point number. Suitable

--- a/src/core/app.lua
+++ b/src/core/app.lua
@@ -137,6 +137,12 @@ function configure (new_config)
    counter.add(configs)
 end
 
+
+-- Stop all apps by loading an empty configuration.
+function stop ()
+   configure(config.new())
+end
+
 -- Removes the claim on a name, freeing it for other programs.
 --
 -- This relinquish a claim on a name if one exists. if the name does not
@@ -720,6 +726,11 @@ function selftest ()
    assert(app_table.app3 == orig_app3) -- should be the same
    main({duration = 4, report = {showapps = true}})
    assert(app_table.app3 ~= orig_app3) -- should be restarted
+
+   -- Check engine stop
+   assert(not lib.equal(app_table, {}))
+   engine.stop()
+   assert(lib.equal(app_table, {}))
 
    -- Check one can't unclaim a name if no name is claimed.
    assert(not pcall(unclaim_name))


### PR DESCRIPTION
Add `engine.stop()` as a way to trigger the orderly shutdown of apps via `:stop()` callback. This is a compromise solution to #1276.

If you want your apps to all shutdown in an orderly way with their `stop()` methods called then you can achieve this by calling `engine.stop()`. If your Snabb process terminates abruptly (`kill -9`, segfault, etc) then naturally this call will not be made and the stop methods will not run. (If you *really* need the shutdown actions to run then you can arrange for our separate supervisor process to do that, see #1276.)

Resolves #1276.