### PR TITLE
Ensure vhost-user socket paths are NUL-terminated

### DIFF
--- a/src/apps/vhost/vhost_user.c
+++ b/src/apps/vhost/vhost_user.c
@@ -33,7 +33,7 @@ int vhost_user_connect(const char *path)
     }
 
     un.sun_family = AF_UNIX;
-    strncpy(un.sun_path, path, sizeof(un.sun_path));
+    strncpy(un.sun_path, path, sizeof(un.sun_path)-1);
 
     if (connect(sock, (struct sockaddr *) &un, sizeof(un)) == -1) {
         close(sock);
@@ -54,7 +54,7 @@ int vhost_user_listen(const char *path)
     }
 
     un.sun_family = AF_UNIX;
-    strncpy(un.sun_path, path, sizeof(un.sun_path));
+    strncpy(un.sun_path, path, sizeof(un.sun_path)-1);
     unlink(un.sun_path);
     if (bind(sock, (struct sockaddr *) &un, sizeof(un)) == -1) {
         close(sock);


### PR DESCRIPTION
Found via GCC 8.2's -Werror=stringop-truncation.  NUL termination is required by the AF_UNIX socket API.