### PR TITLE
jit/bcsave: increment expected jit.version_num to match RaptorJIT

### DIFF
--- a/lib/luajit/src/jit/bc.lua
+++ b/lib/luajit/src/jit/bc.lua
@@ -41,7 +41,7 @@
 
 -- Cache some library functions and objects.
 local jit = require("jit")
-assert(jit.version_num == 10000, "LuaJIT core/library version mismatch")
+assert(jit.version_num == 100000, "LuaJIT core/library version mismatch")
 local jutil = require("jit.util")
 local vmdef = require("jit.vmdef")
 local bit = require("bit")

--- a/lib/luajit/src/jit/bcsave.lua
+++ b/lib/luajit/src/jit/bcsave.lua
@@ -11,7 +11,7 @@
 ------------------------------------------------------------------------------
 
 local jit = require("jit")
-assert(jit.version_num == 10000, "LuaJIT core/library version mismatch")
+assert(jit.version_num == 100000, "LuaJIT core/library version mismatch")
 local bit = require("bit")
 
 -- Symbol name prefix for LuaJIT bytecode.


### PR DESCRIPTION
I had to increment these to make the build work. Not sure if this is the right strategy or if this should be a `>=` instead. I guess it depends on whether that version number changes frequently or not?

Cc @lukego 