### PR TITLE
core.packet: release packets to group freelist on shutdown

### DIFF
--- a/src/core/main.lua
+++ b/src/core/main.lua
@@ -178,6 +178,7 @@ function shutdown (pid)
       if not ok then print(err) end
    end
    -- Run cleanup hooks
+   safely(function () require("core.packet").shutdown(pid) end)
    safely(function () require("apps.interlink.receiver").shutdown(pid) end)
    safely(function () require("apps.interlink.transmitter").shutdown(pid) end)
    -- Parent process performs additional cleanup steps.

--- a/src/core/main.lua
+++ b/src/core/main.lua
@@ -198,7 +198,6 @@ function shutdown (pid)
       S.unlink(backlink)
 
       shm.unlink("/"..pid)
-      shm.unlink("/"..S.getpid())
    end
 end
 

--- a/src/core/main.lua
+++ b/src/core/main.lua
@@ -198,6 +198,7 @@ function shutdown (pid)
       S.unlink(backlink)
 
       shm.unlink("/"..pid)
+      shm.unlink("/"..S.getpid())
    end
 end
 

--- a/src/core/main.lua
+++ b/src/core/main.lua
@@ -158,7 +158,7 @@ function initialize ()
    _G.engine = require("core.app")
    _G.memory = require("core.memory")
    _G.link   = require("core.link")
-   _G.packet = require("core.packet")
+   _G.packet = require("core.packet"); _G.packet.initialize()
    _G.timer  = require("core.timer")
    _G.main   = getfenv()
 end

--- a/src/core/packet.lua
+++ b/src/core/packet.lua
@@ -104,8 +104,13 @@ end
 
 local packet_allocation_step = 1000
 local packets_allocated = 0
-local packets_fl = freelist_create("engine/packets.freelist")
-local group_fl -- Initialized on demand.
+ -- Initialized on demand.
+local packets_fl, group_fl
+
+-- Call to ensure packet freelist is enabled.
+function initialize ()
+   packets_fl = freelist_create("engine/packets.freelist")
+end
 
 -- Call to ensure group freelist is enabled.
 function enable_group_freelist ()

--- a/src/core/packet.lua
+++ b/src/core/packet.lua
@@ -58,6 +58,16 @@ struct freelist {
 };
 ]])
 
+local function freelist_create(name)
+   local fl = shm.create(name..".freelist", "struct freelist")
+   fl.max = max_packets
+   return fl
+end
+
+local function freelist_open(name, readonly)
+   return shm.open(name..".freelist", "struct freelist", readonly)
+end
+
 local function freelist_full(freelist)
    return freelist.nfree == freelist.max
 end
@@ -94,14 +104,13 @@ end
 
 local packet_allocation_step = 1000
 local packets_allocated = 0
-local packets_fl = ffi.new("struct freelist", {max=max_packets})
+local packets_fl = freelist_create("engine/packets")
 local group_fl -- Initialized on demand.
 
 -- Call to ensure group freelist is enabled.
 function enable_group_freelist ()
    if not group_fl then
-      group_fl = shm.create("group/packets.freelist", "struct freelist")
-      group_fl.max = max_packets
+      group_fl = freelist_create("group/packets")
    end
 end
 
@@ -133,6 +142,22 @@ function allocate ()
       end
    end
    return freelist_remove(packets_fl)
+end
+
+-- Release all packets allocated by pid to its group freelist (if one exists.)
+--
+-- This is an internal API function provided for cleanup during
+-- process termination.
+function shutdown (pid)
+   local in_group, group_fl = pcall(freelist_open, "/"..pid.."/group/packets")
+   if in_group then
+      local packets_fl = freelist_open("/"..pid.."/engine/packets")
+      freelist_lock(group_fl)
+      while freelist_nfree(packets_fl) > 0 do
+         freelist_add(group_fl, freelist_remove(packets_fl))
+      end
+      freelist_unlock(group_fl)
+   end
 end
 
 -- Create a new empty packet.

--- a/src/lib/interlink.lua
+++ b/src/lib/interlink.lua
@@ -275,7 +275,7 @@ local function describe (r)
          [DOWN] = "deallocating"
       })[r.state[0]]
    end
-   return ("%d/%d (%s)"):format(queue_fill(r), SIZE, status(r))
+   return ("%d/%d (%s)"):format(queue_fill(r), SIZE - 1, status(r))
 end
 
 ffi.metatype(ffi.typeof("struct interlink"), {__tostring=describe})


### PR DESCRIPTION
In multi-process Snabb DMA huge pages are only released to the operating system
once the group’s parent shuts down. This commit makes it so that packets
allocated by workers are released into the group freelist when a worker shuts
down. This addresses two issues:

 - workers can have packets allocated by other workers on their freelist at the
   time of their shut down
 - DMA huge pages used for packets owned by workers that have shut down would
   otherwise leak (i.e. not be available to the OS and other processes until
   the group parent shuts down)

4da22e6  intends to handle both issues by recycling all allocated packets
within the process group (to match the DMA huge page management model.)

58fa77f is a minor, barely related fix.

Cc @lukego 