### PR TITLE
intel_mp: fix ctype diversity for txdesc_t

### DIFF
--- a/src/apps/intel_mp/intel_mp.lua
+++ b/src/apps/intel_mp/intel_mp.lua
@@ -545,6 +545,8 @@ function Intel:init_rx_q ()
    end
    self:unlock_sw_sem()
 end
+
+txdesc_t = ffi.typeof("struct { uint64_t address, flags; }")
 function Intel:init_tx_q ()                               -- 4.5.10
    if not self.txq then return end
    assert((self.txq >=0) and (self.txq < self.max_q),
@@ -554,7 +556,6 @@ function Intel:init_tx_q ()                               -- 4.5.10
    self.txqueue = ffi.new("struct packet *[?]", self.ndesc)
 
    -- 7.2.2.3
-   local txdesc_t = ffi.typeof("struct { uint64_t address, flags; }")
    local txdesc_ring_t = ffi.typeof("$[$]", txdesc_t, self.ndesc)
    self.txdesc = ffi.cast(ffi.typeof("$&", txdesc_ring_t),
    memory.dma_alloc(ffi.sizeof(txdesc_ring_t)))


### PR DESCRIPTION
Move the ctype declaration of txdesc_t out of the init_tx_q() method
to make its ctype identical in all instances of the driver.  This
eliminates certain side traces in the transmit code path.