### PR TITLE
packet: cast pointer arg in from_pointer()

### DIFF
--- a/src/core/packet.lua
+++ b/src/core/packet.lua
@@ -209,7 +209,9 @@ function shiftright (p, bytes)
 end
 
 -- Conveniently create a packet by copying some existing data.
-function from_pointer (ptr, len) return append(allocate(), ptr, len) end
+function from_pointer (ptr, len)
+   return append(allocate(), ffi.cast("uint8_t *", ptr), len)
+end
 function from_string (d)         return from_pointer(d, #d) end
 
 -- Free a packet that is no longer in use.


### PR DESCRIPTION
The pointer type passed to append() and prepend() should always be
canonicalized to "uint8_t *" to avoid side traces in code that uses
these functions.