### PR TITLE
A little generic poptrie implementation

### DIFF
--- a/src/dasm_x86.lua
+++ b/src/dasm_x86.lua
@@ -1023,6 +1023,7 @@ end
 --   "u"       Use VEX encoding, vvvv unused.
 --   "v"/"V"   Use VEX encoding, vvvv from 1st/2nd operand (the operand is
 --             removed from the list used by future characters).
+--   "w"       Use VEX encoding, vvvv from 3rd operand.
 --   "L"       Force VEX.L
 --
 -- All of the following characters force a flush of the opcode:
@@ -1608,8 +1609,8 @@ local map_op = {
   vrcpss_3 =	"rrro:F30FV53rM|rrx/ood:",
   vrsqrtps_2 =	"rmoy:0Fu52rM",
   vrsqrtss_3 =	"rrro:F30FV52rM|rrx/ood:",
-  vroundpd_3 =	"rmioy:660F3AV09rMU",
-  vroundps_3 =	"rmioy:660F3AV08rMU",
+  vroundpd_3 =	"rmioy:660F3Au09rMU",
+  vroundps_3 =	"rmioy:660F3Au08rMU",
   vroundsd_4 =	"rrrio:660F3AV0BrMU|rrxi/ooq:",
   vroundss_4 =	"rrrio:660F3AV0ArMU|rrxi/ood:",
   vshufpd_4 =	"rrmioy:660FVC6rMU",
@@ -1745,6 +1746,95 @@ local map_op = {
   vpsravd_3 =	"rrmoy:660F38V46rM",
   vpsrlvd_3 =	"rrmoy:660F38V45rM",
   vpsrlvq_3 =	"rrmoy:660F38VX45rM",
+
+  -- Intel ADX
+  adcx_2 =	"rmqd:660F38F6rM",
+  adox_2 =	"rmqd:F30F38F6rM",
+
+  -- BMI1
+  andn_3 =	"rrmqd:0F38VF2rM",
+  bextr_3 =	"rmrqd:0F38wF7rM",
+  blsi_2 =	"rmqd:0F38vF33m",
+  blsmsk_2 =	"rmqd:0F38vF32m",
+  blsr_2 =	"rmqd:0F38vF31m",
+  tzcnt_2 =	"rmqdw:F30FBCrM",
+
+  -- BMI2
+  bzhi_3 =	"rmrqd:0F38wF5rM",
+  mulx_3 =	"rrmqd:F20F38VF6rM",
+  pdep_3 =	"rrmqd:F20F38VF5rM",
+  pext_3 =	"rrmqd:F30F38VF5rM",
+  rorx_3 =	"rmSqd:F20F3AuF0rMS",
+  sarx_3 =	"rmrqd:F30F38wF7rM",
+  shrx_3 =	"rmrqd:F20F38wF7rM",
+  shlx_3 =	"rmrqd:660F38wF7rM",
+
+  -- FMA3
+  vfmaddsub132pd_3 = "rrmoy:660F38VX96rM",
+  vfmaddsub132ps_3 = "rrmoy:660F38V96rM",
+  vfmaddsub213pd_3 = "rrmoy:660F38VXA6rM",
+  vfmaddsub213ps_3 = "rrmoy:660F38VA6rM",
+  vfmaddsub231pd_3 = "rrmoy:660F38VXB6rM",
+  vfmaddsub231ps_3 = "rrmoy:660F38VB6rM",
+
+  vfmsubadd132pd_3 = "rrmoy:660F38VX97rM",
+  vfmsubadd132ps_3 = "rrmoy:660F38V97rM",
+  vfmsubadd213pd_3 = "rrmoy:660F38VXA7rM",
+  vfmsubadd213ps_3 = "rrmoy:660F38VA7rM",
+  vfmsubadd231pd_3 = "rrmoy:660F38VXB7rM",
+  vfmsubadd231ps_3 = "rrmoy:660F38VB7rM",
+
+  vfmadd132pd_3 = "rrmoy:660F38VX98rM",
+  vfmadd132ps_3 = "rrmoy:660F38V98rM",
+  vfmadd132sd_3 = "rrro:660F38VX99rM|rrx/ooq:",
+  vfmadd132ss_3 = "rrro:660F38V99rM|rrx/ood:",
+  vfmadd213pd_3 = "rrmoy:660F38VXA8rM",
+  vfmadd213ps_3 = "rrmoy:660F38VA8rM",
+  vfmadd213sd_3 = "rrro:660F38VXA9rM|rrx/ooq:",
+  vfmadd213ss_3 = "rrro:660F38VA9rM|rrx/ood:",
+  vfmadd231pd_3 = "rrmoy:660F38VXB8rM",
+  vfmadd231ps_3 = "rrmoy:660F38VB8rM",
+  vfmadd231sd_3 = "rrro:660F38VXB9rM|rrx/ooq:",
+  vfmadd231ss_3 = "rrro:660F38VB9rM|rrx/ood:",
+
+  vfmsub132pd_3 = "rrmoy:660F38VX9ArM",
+  vfmsub132ps_3 = "rrmoy:660F38V9ArM",
+  vfmsub132sd_3 = "rrro:660F38VX9BrM|rrx/ooq:",
+  vfmsub132ss_3 = "rrro:660F38V9BrM|rrx/ood:",
+  vfmsub213pd_3 = "rrmoy:660F38VXAArM",
+  vfmsub213ps_3 = "rrmoy:660F38VAArM",
+  vfmsub213sd_3 = "rrro:660F38VXABrM|rrx/ooq:",
+  vfmsub213ss_3 = "rrro:660F38VABrM|rrx/ood:",
+  vfmsub231pd_3 = "rrmoy:660F38VXBArM",
+  vfmsub231ps_3 = "rrmoy:660F38VBArM",
+  vfmsub231sd_3 = "rrro:660F38VXBBrM|rrx/ooq:",
+  vfmsub231ss_3 = "rrro:660F38VBBrM|rrx/ood:",
+
+  vfnmadd132pd_3 = "rrmoy:660F38VX9CrM",
+  vfnmadd132ps_3 = "rrmoy:660F38V9CrM",
+  vfnmadd132sd_3 = "rrro:660F38VX9DrM|rrx/ooq:",
+  vfnmadd132ss_3 = "rrro:660F38V9DrM|rrx/ood:",
+  vfnmadd213pd_3 = "rrmoy:660F38VXACrM",
+  vfnmadd213ps_3 = "rrmoy:660F38VACrM",
+  vfnmadd213sd_3 = "rrro:660F38VXADrM|rrx/ooq:",
+  vfnmadd213ss_3 = "rrro:660F38VADrM|rrx/ood:",
+  vfnmadd231pd_3 = "rrmoy:660F38VXBCrM",
+  vfnmadd231ps_3 = "rrmoy:660F38VBCrM",
+  vfnmadd231sd_3 = "rrro:660F38VXBDrM|rrx/ooq:",
+  vfnmadd231ss_3 = "rrro:660F38VBDrM|rrx/ood:",
+
+  vfnmsub132pd_3 = "rrmoy:660F38VX9ErM",
+  vfnmsub132ps_3 = "rrmoy:660F38V9ErM",
+  vfnmsub132sd_3 = "rrro:660F38VX9FrM|rrx/ooq:",
+  vfnmsub132ss_3 = "rrro:660F38V9FrM|rrx/ood:",
+  vfnmsub213pd_3 = "rrmoy:660F38VXAErM",
+  vfnmsub213ps_3 = "rrmoy:660F38VAErM",
+  vfnmsub213sd_3 = "rrro:660F38VXAFrM|rrx/ooq:",
+  vfnmsub213ss_3 = "rrro:660F38VAFrM|rrx/ood:",
+  vfnmsub231pd_3 = "rrmoy:660F38VXBErM",
+  vfnmsub231ps_3 = "rrmoy:660F38VBErM",
+  vfnmsub231sd_3 = "rrro:660F38VXBFrM|rrx/ooq:",
+  vfnmsub231ss_3 = "rrro:660F38VBFrM|rrx/ood:",
 }
 
 ------------------------------------------------------------------------------
@@ -1834,7 +1924,7 @@ end
 
 ------------------------------------------------------------------------------
 
-local map_vexarg = { u = false, v = 1, V = 2 }
+local map_vexarg = { u = false, v = 1, V = 2, w = 3 }
 
 -- Process pattern string.
 local function dopattern(pat, args, sz, op, needrex)

--- a/src/doc/genbook.sh
+++ b/src/doc/genbook.sh
@@ -84,6 +84,8 @@ $(cat $mdroot/lib/README.checksum.md)
 
 $(cat $mdroot/lib/README.ctable.md)
 
+$(cat $mdroot/lib/README.poptrie.md)
+
 $(cat $mdroot/lib/README.pmu.md)
 
 $(cat $mdroot/lib/yang/README.md)

--- a/src/lib/README.poptrie.md
+++ b/src/lib/README.poptrie.md
@@ -53,6 +53,8 @@ Creates and returns a new `Poptrie` object.
 
 * `direct_pointing` - *Optional*. Boolean that governs whether to use the
   *direct pointing* optimization. Default is `false`.
+* `s` - *Optional*. Bits to use for the *direct pointing* optimization.
+  Default is 18. Note that the direct map array will be 2×2ˢ bytes in size.
 * `leaves` - *Optional*. An array of leaves. When *leaves* is supplied *nodes*
    must be supplied as well.
 * `nodes` - *Optional*. An array of nodes. When *nodes* is supplied *leaves*

--- a/src/lib/README.poptrie.md
+++ b/src/lib/README.poptrie.md
@@ -1,0 +1,70 @@
+### Poptrie (lib.poptrie)
+
+An implementation of
+[Poptrie](http://conferences.sigcomm.org/sigcomm/2015/pdf/papers/p57.pdf).
+Includes high-level functions for building the Poptrie data structure, as well
+as a hand-written, optimized assembler lookup routine.
+
+#### Example usage
+
+```lua
+local pt = poptrie.new{}
+-- Associate prefixes of length to values (uint16_t)
+pt:add(0x00FF, 8, 1)
+pt:add(0x000F, 4, 2)
+pt:build()
+pt:lookup64(0x001F) ⇒ 2
+pt:lookup64(0x10FF) ⇒ 1
+-- The value zero denotes "no match"
+pt:lookup64(0x0000) ⇒ 0
+-- You can create a pre-built poptrie from nodes and leaves arrays.
+local pt2 = poptrie.new{nodes=pt.nodes, leaves=pt.leaves}
+```
+
+#### Known bugs and limitations
+
+ - Only supports keys up to 64 bits wide
+ - *Direct pointing* is not yet implemented
+
+#### Performance
+
+```
+PMU analysis (numentries=10000, keysize=64)
+lookup: 30001.41 cycles/lookup 59357.23 instructions/lookup
+lookup64: 179.39 cycles/lookup 205.72 instructions/lookup
+```
+
+#### Interface
+
+— Function **new** *init*
+
+Creates and returns a new `Poptrie` object.
+
+*Init* is a table with the following keys:
+
+* `leaves` - *Optional*. An array of leaves. When *leaves* is supplied *nodes*
+   must be supplied as well.
+* `nodes` - *Optional*. An array of nodes. When *nodes* is supplied *leaves*
+   must be supplied as well.
+
+— Method **Poptrie:add** *prefix* *length* *value*
+
+Associates *value* to *prefix* of *length*. *Prefix* must be an unsigned
+integer (little-endian) of up to 64 bits. *Length* must be an an unsigned
+integer between 1 and 64. *Value* must be a 16‑bit unsigned integer, and should
+be greater than zero (see `lookup64` as to why.)
+
+— Method **Poptrie:build**
+
+Compiles the optimized poptrie data structure used by `lookup64`. After calling
+this method, the *leaves* and *nodes* fields of the `Poptrie` object will
+contain the leaves and nodes arrays respectively. These arrays can be used to
+construct a `Poptrie` object.
+
+— Method **Poptrie:lookup64** *key*
+
+Looks up *key* in the `Poptrie` object and returns the associated value or
+zero. *Key* must be an unsigned, little-endian integer of up to 64 bits.
+
+Unless the `Poptrie` object was initialized with leaves and nodes arrays, the
+user must call `Poptrie:build` before calling `Poptrie:lookup64`.

--- a/src/lib/README.poptrie.md
+++ b/src/lib/README.poptrie.md
@@ -8,7 +8,7 @@ as a hand-written, optimized assembler lookup routine.
 #### Example usage
 
 ```lua
-local pt = poptrie.new{}
+local pt = poptrie.new{direct_pointing=true}
 -- Associate prefixes of length to values (uint16_t)
 pt:add(0x00FF, 8, 1)
 pt:add(0x000F, 4, 2)
@@ -17,21 +17,30 @@ pt:lookup64(0x001F) ⇒ 2
 pt:lookup64(0x10FF) ⇒ 1
 -- The value zero denotes "no match"
 pt:lookup64(0x0000) ⇒ 0
--- You can create a pre-built poptrie from nodes and leaves arrays.
-local pt2 = poptrie.new{nodes=pt.nodes, leaves=pt.leaves}
+-- You can create a pre-built poptrie from its backing memory.
+local pt2 = poptrie.new{
+   nodes = pt.nodes,
+   leaves = pt.leaves,
+   directmap = pt.directmap
+}
 ```
 
 #### Known bugs and limitations
 
  - Only supports keys up to 64 bits wide
- - *Direct pointing* is not yet implemented
 
 #### Performance
 
+- Intel(R) Xeon(R) CPU E3-1246 v3 @ 3.50GHz (Haswell, Turbo off)
+
 ```
-PMU analysis (numentries=10000, keysize=64)
-lookup: 30001.41 cycles/lookup 59357.23 instructions/lookup
-lookup64: 179.39 cycles/lookup 205.72 instructions/lookup
+PMU analysis (numentries=10000, keysize=32)
+build: 0.1290 seconds
+lookup: 13217.09 cycles/lookup 28014.35 instructions/lookup
+lookup64: 122.94 cycles/lookup 133.22 instructions/lookup
+build(direct_pointing): 0.1056 seconds
+lookup(direct_pointing): 5519.01 cycles/lookup 11412.01 instructions/lookup
+lookup64(direct_pointing): 89.82 cycles/lookup 70.72 instructions/lookup
 ```
 
 #### Interface
@@ -42,10 +51,15 @@ Creates and returns a new `Poptrie` object.
 
 *Init* is a table with the following keys:
 
+* `direct_pointing` - *Optional*. Boolean that governs whether to use the
+  *direct pointing* optimization. Default is `false`.
 * `leaves` - *Optional*. An array of leaves. When *leaves* is supplied *nodes*
    must be supplied as well.
 * `nodes` - *Optional*. An array of nodes. When *nodes* is supplied *leaves*
    must be supplied as well.
+* `directmap` - *Optional*. A direct map array. When *directmap* is supplied,
+   *nodes* and *leaves* must be supplied as well and *direct_pointing* is
+   implicit.
 
 — Method **Poptrie:add** *prefix* *length* *value*
 

--- a/src/lib/poptrie.lua
+++ b/src/lib/poptrie.lua
@@ -92,7 +92,7 @@ function Poptrie:rib_lookup (key, length, root)
          return {value=value}
       end
    end
-   return lookup(root or self.rib, 0)
+   return lookup(root or self.rib or {}, 0)
 end
 
 -- Compress RIB into Poptrie
@@ -115,6 +115,11 @@ function Poptrie:build (rib, node_index, leaf_base, node_base)
       return self.nodes[node_index]
    end
    -- When called without arguments, create the root node.
+   if not rib then
+      -- Clear previous FIB
+      ffi.fill(self.leaves, ffi.sizeof(self.leaves))
+      ffi.fill(self.nodes, ffi.sizeof(self.nodes))
+   end
    rib = rib or self.rib
    leaf_base = leaf_base or 0
    node_base = node_base or 0
@@ -249,6 +254,8 @@ end
 
 function selftest ()
    local t = new{}
+   -- Tets building empty RIB
+   t:build()
    -- Test RIB
    t:add(0x00, 8, 1) -- 00000000
    t:add(0x0F, 8, 2) -- 00001111

--- a/src/lib/poptrie.lua
+++ b/src/lib/poptrie.lua
@@ -53,8 +53,11 @@ function new (init)
       if init.direct_pointing ~= nil then
          self.direct_pointing = init.direct_pointing
       end
+      if init.s ~= nil then
+         self.s = init.s
+      end
       if self.direct_pointing then
-         self.directmap = array(Poptrie.base_t, 2^Poptrie.s)
+         self.directmap = array(Poptrie.base_t, 2^self.s)
       end
    end
    self.asm_lookup64 = poptrie_lookup.generate(self, 64)
@@ -218,7 +221,7 @@ function Poptrie:build_directmap (rib)
          self.directmap[index] = bor(value or 0, Poptrie.leaf_tag)
       end
    end
-   self:rib_map(build, Poptrie.s, rib)
+   self:rib_map(build, self.s, rib)
 end
 
 -- Compress RIB into Poptrie
@@ -283,7 +286,7 @@ function Poptrie:lookup (key)
    local N, L, D = self.nodes, self.leaves, self.directmap
    local index, offset = 0, 0
    if self.direct_pointing then
-      offset = Poptrie.s
+      offset = self.s
       index = D[extract(key, 0, offset)]
       if debug then print(bin(index), band(index, Poptrie.leaf_tag - 1)) end
       if band(index, Poptrie.leaf_tag) ~= 0 then

--- a/src/lib/poptrie.lua
+++ b/src/lib/poptrie.lua
@@ -1,0 +1,415 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
+module(...,package.seeall)
+
+local debug = false
+
+-- Poptrie, see
+--   http://conferences.sigcomm.org/sigcomm/2015/pdf/papers/p57.pdf
+
+local ffi = require("ffi")
+local bit = require("bit")
+local band, bor, lshift, rshift, bnot =
+   bit.band, bit.bor, bit.lshift, bit.rshift, bit.bnot
+
+local poptrie_lookup = require("lib.poptrie_lookup")
+
+local Poptrie = {
+   leaf_compression = true,
+   k = 6,
+   leaf_t = ffi.typeof("uint16_t"),
+   vector_t = ffi.typeof("uint64_t"),
+   base_t = ffi.typeof("uint32_t")
+}
+Poptrie.node_t = ffi.typeof([[struct {
+   $ leafvec, vector;
+   $ base0, base1;
+} __attribute__((packed))]], Poptrie.vector_t, Poptrie.base_t)
+
+local function array (t, n)
+   return ffi.new(ffi.typeof("$[?]", t), n)
+end
+
+function new (init)
+   local num_default = 4
+   local pt = {
+      nodes = init.nodes or array(Poptrie.node_t, num_default),
+      num_nodes = (init.nodes and assert(init.num_nodes)) or num_default,
+      leaves = init.leaves or array(Poptrie.leaf_t, num_default),
+      num_leaves = (init.leaves and assert(init.num_leaves)) or num_default
+   }
+   return setmetatable(pt, {__index=Poptrie})
+end
+
+function Poptrie:grow_nodes ()
+   self.num_nodes = self.num_nodes * 2
+   local new_nodes = array(Poptrie.node_t, self.num_nodes)
+   ffi.copy(new_nodes, self.nodes, ffi.sizeof(self.nodes))
+   self.nodes = new_nodes
+end
+
+function Poptrie:grow_leaves ()
+   self.num_leaves = self.num_leaves * 2
+   local new_leaves = array(Poptrie.leaf_t, self.num_leaves)
+   ffi.copy(new_leaves, self.leaves, ffi.sizeof(self.leaves))
+   self.leaves = new_leaves
+end
+
+-- XXX - Generalize for key=uint8_t[?]
+local function extract (key, offset, length)
+   return band(rshift(key+0ULL, offset), lshift(1ULL, length) - 1)
+end
+
+-- Add key/value pair to RIB (intermediary binary trie)
+-- key=uint64_t, length=uint16_t, value=uint16_t
+function Poptrie:add (key, length, value)
+   assert(value)
+   local function add (node, offset)
+      if offset == length then
+         node.value = value
+      elseif extract(key, offset, 1) == 0 then
+         node.left = add(node.left or {}, offset + 1)
+      elseif extract(key, offset, 1) == 1 then
+         node.right = add(node.right or {}, offset + 1)
+      else error("invalid state") end
+      return node
+   end
+   self.rib = add(self.rib or {}, 0)
+end
+
+-- Longest prefix match on RIB
+function Poptrie:rib_lookup (key, length, root)
+   local function lookup (node, offset, value)
+      value = node.value or value
+      if offset == length then
+         return {value=value, left=node.left, right=node.right}
+      elseif extract(key, offset, 1) == 0 and node.left then
+         return lookup(node.left, offset + 1, value)
+      elseif extract(key, offset, 1) == 1 and node.right then
+         return lookup(node.right, offset + 1, value)
+      else
+         -- No match: return longest prefix key value, but no child nodes.
+         return {value=value}
+      end
+   end
+   return lookup(root or self.rib, 0)
+end
+
+-- Compress RIB into Poptrie
+function Poptrie:build (rib, node_index, leaf_base, node_base)
+   local function allocate_leaf ()
+      while leaf_base >= self.num_leaves do
+         self:grow_leaves()
+      end
+      leaf_base = leaf_base + 1
+      return leaf_base - 1
+   end
+   local function allocate_node ()
+      while node_base >= self.num_nodes do
+         self:grow_nodes()
+      end
+      node_base = node_base + 1
+      return node_base - 1
+   end
+   local function node ()
+      return self.nodes[node_index]
+   end
+   -- When called without arguments, create the root node.
+   rib = rib or self.rib
+   leaf_base = leaf_base or 0
+   node_base = node_base or 0
+   node_index = node_index or allocate_node()
+   -- Initialize node base pointers.
+   node().base0 = leaf_base
+   node().base1 = node_base
+   -- Compute children
+   local children = {}
+   for index = 0, 2^Poptrie.k - 1 do
+      children[index] = self:rib_lookup(index, Poptrie.k, rib)
+   end
+   -- Allocate and initialize node.leafvec and leaves.
+   local last_leaf_value = nil
+   for index = 0, 2^Poptrie.k - 1 do
+      local child = children[index]
+      if not (child.left or child.right) then
+         local value = child.value or 0
+         if value ~= last_leaf_value then -- always true when leaf_compression=false
+            if Poptrie.leaf_compression then
+               node().leafvec = bor(node().leafvec, lshift(1ULL, index))
+               last_leaf_value = value
+            end
+            local leaf_index = allocate_leaf()
+            self.leaves[leaf_index] = value
+         end
+      end
+   end
+   -- Allocate child nodes (this has to be done before recursing into build()
+   -- because their indices into the nodes array need to be node.base1 + index,
+   -- and build() will advance the node_base.)
+   local child_nodes = {}
+   for index = 0, 2^Poptrie.k - 1 do
+      local child = children[index]
+      if child.left or child.right then
+         child_nodes[index] = allocate_node()
+      end
+   end
+   -- Initialize node.vector and child nodes.
+   for index = 0, 2^Poptrie.k - 1 do
+      local child = children[index]
+      if child.left or child.right then
+         node().vector = bor(node().vector, lshift(1ULL, index))
+         leaf_base, node_base =
+            self:build(child, child_nodes[index], leaf_base, node_base)
+      end
+   end
+   -- Return new leaf_base and node_base indices.
+   return leaf_base, node_base
+end
+
+-- http://graphics.stanford.edu/~seander/bithacks.html#CountBitsSetNaive
+local function popcnt (v) -- XXX - popcaan is 64-bit only
+   local c = 0
+   while v > 0 do
+      c = c + band(v, 1ULL)
+      v = rshift(v, 1ULL)
+   end
+   return c
+end
+
+-- [Algorithm 1] lookup(t = (N , L), key); the lookup procedure for the address
+-- key in the tree t (when k = 6). The function extract(key, off, len) extracts
+-- bits of length len, starting with the offset off, from the address key.
+-- N and L represent arrays of internal nodes and leaves, respectively.
+-- << denotes the shift instruction of bits. Numerical literals with the UL and
+-- ULL suffixes denote 32-bit and 64-bit unsigned integers, respectively.
+-- Vector and base are the variables to hold the contents of the node’s fields.
+--
+-- if [direct_pointing] then
+--    index = extract(key, 0, t.s);
+--    dindex = t.D[index].direct index;
+--    if (dindex & (1UL << 31)) then
+--       return dindex & ((1UL << 31) - 1);
+--    end if
+--    index = dindex;
+--    offset = t.s;
+-- else
+--    index = 0;
+--    offset = 0;
+-- end if
+-- vector = t.N [index].vector;
+-- v = extract(key, offset, 6);
+-- while (vector & (1ULL << v)) do
+--    base = t.N [index].base1;
+--    bc = popcnt(vector & ((2ULL << v) - 1));
+--    index = base + bc - 1;
+--    vector = t.N [index].vector;
+--    offset += 6;
+--    v = extract(key, offset, 6);
+-- end while
+-- base = t.N [index].base0;
+-- if [leaf_compression] then
+--    bc = popcnt(t.N [index].leafvec & ((2ULL << v) - 1));
+-- else
+--    bc = popcnt((∼t.N [index].vector) & ((2ULL << v) - 1));
+-- end if
+-- return t.L[base + bc - 1];
+--
+function Poptrie:lookup (key)
+   local N, L = self.nodes, self.leaves
+   local index = 0
+   local node = N[index]
+   local offset = 0
+   local v = extract(key, offset, Poptrie.k)
+   if debug then print(index, bin(node.vector), bin(v)) end
+   while band(node.vector, lshift(1ULL, v)) ~= 0 do
+      local base = N[index].base1
+      local bc = popcnt(band(node.vector, lshift(2ULL, v) - 1))
+      index = base + bc - 1
+      node = N[index]
+      offset = offset + Poptrie.k
+      v = extract(key, offset, Poptrie.k)
+      if debug then print(index, bin(node.vector), bin(v)) end
+   end
+   if debug then print(node.base0, bin(node.leafvec), bin(v)) end
+   local base = node.base0
+   local bc
+   if Poptrie.leaf_compression then
+      bc = popcnt(band(node.leafvec, lshift(2ULL, v) - 1))
+   else
+      bc = popcnt(band(bnot(node.vector), lshift(2ULL, v) - 1))
+   end
+   if debug then print(base + bc - 1) end
+   return L[base + bc - 1]
+end
+
+Poptrie.asm_lookup64 = poptrie_lookup.generate(Poptrie, 64)
+function Poptrie:lookup64 (key)
+   return Poptrie.asm_lookup64(self.leaves, self.nodes, key)
+end
+
+function selftest ()
+   local t = new{}
+   -- Test RIB
+   t:add(0x00, 8, 1) -- 00000000
+   t:add(0x0F, 8, 2) -- 00001111
+   t:add(0x07, 4, 3) --     0111
+   t:add(0xFF, 8, 4) -- 11111111
+   t:add(0xFF, 5, 5) --    11111
+   local n = t:rib_lookup(0x0, 1)
+   assert(not n.value and n.left and not n.right)
+   local n = t:rib_lookup(0x00, 8)
+   assert(n.value == 1 and not (n.left or n.right))
+   local n = t:rib_lookup(0x07, 3)
+   assert(not n.value and (n.left and n.right))
+   local n = t:rib_lookup(0x0, 1, n)
+   assert(n.value == 3 and not (n.left or n.right))
+   local n = t:rib_lookup(0xFF, 5)
+   assert(n.value == 5 and (not n.left) and n.right)
+   local n = t:rib_lookup(0x0F, 3, n)
+   assert(n.value == 4 and not (n.left or n.right))
+   local n = t:rib_lookup(0x3F, 8)
+   assert(n.value == 5 and not (n.left or n.right))
+   -- Test FIB
+   local leaf_base, node_base = t:build()
+   if debug then
+      for i=0, node_base-1 do
+         print("node:", i)
+         print(t.nodes[i].base0, bin(t.nodes[i].leafvec))
+         print(t.nodes[i].base1, bin(t.nodes[i].vector))
+      end
+      for i=0, leaf_base-1 do
+         print("leaf:", i, t.leaves[i])
+      end
+   end
+   assert(t:lookup(0x00) == 1) -- 00000000
+   assert(t:lookup(0x03) == 0) -- 00000011
+   assert(t:lookup(0x07) == 3) -- 00000111
+   assert(t:lookup(0x0F) == 2) -- 00001111
+   assert(t:lookup(0x1F) == 5) -- 00011111
+   assert(t:lookup(0x3F) == 5) -- 00111111
+   assert(t:lookup(0xFF) == 4) -- 11111111
+   assert(t:lookup64(0x00) == 1)
+   assert(t:lookup64(0x03) == 0)
+   assert(t:lookup64(0x07) == 3)
+   assert(t:lookup64(0x0F) == 2)
+   assert(t:lookup64(0x1F) == 5)
+   assert(t:lookup64(0x3F) == 5)
+   assert(t:lookup64(0xFF) == 4)
+
+   -- Random testing
+   local function reproduce (cases)
+      debug = true
+      print("repoducing...")
+      local t = new{}
+      for entry, case in ipairs(cases) do
+         print("key:", entry, bin(case[1]))
+         print("prefix:", entry, bin(case[1], case[2]))
+         t:add(case[1], case[2], entry)
+      end
+      local leaf_base, node_base = t:build()
+      for i=0, node_base-1 do
+         print("node:", i)
+         print(t.nodes[i].base0, bin(t.nodes[i].leafvec))
+         print(t.nodes[i].base1, bin(t.nodes[i].vector))
+      end
+      for i=0, leaf_base-1 do
+         if t.leaves[i] > 0 then print("leaf:", i, t.leaves[i]) end
+      end
+      for _, case in ipairs(cases) do
+         print("rib:", t:rib_lookup(case[1]).value)
+         print("fib:", t:lookup(case[1]))
+         print("64:",  t:lookup64(case[1]))
+      end
+   end
+   local function r_assert (condition, cases)
+      if condition then return end
+      reproduce(cases)
+      print("selftest failed")
+      main.exit(1)
+   end
+   local lib = require("core.lib")
+   local seed = lib.getenv("SNABB_RANDOM_SEED") or 0
+   for keysize = 1, 64 do
+      print("keysize:", keysize)
+      -- ramp up the geometry below to crank up test coverage
+      for entries = 1, 8 do
+         for i = 1, 4 do
+            math.randomseed(seed+i)
+            cases = {}
+            local t = new{}
+            local k = {}
+            for entry= 1, entries do
+               local a, l = math.random(2^keysize - 1), math.random(keysize)
+               cases[entry] = {a, l}
+               t:add(a, l, entry)
+               k[entry] = a
+            end
+            local v = {}
+            for entry, a in ipairs(k) do
+               v[entry] = t:rib_lookup(a, keysize).value
+               r_assert(v[entry] > 0, cases)
+            end
+            t:build()
+            for entry, a in ipairs(k) do
+               r_assert(t:lookup(a) == v[entry], cases)
+               r_assert(t:lookup64(a) == v[entry], cases)
+            end
+         end
+      end
+   end
+
+   -- PMU analysis
+   local pmu = require("lib.pmu")
+   local function measure (description, f, iterations)
+      local set = pmu.new_counter_set()
+      pmu.switch_to(set)
+      f(iterations)
+      pmu.switch_to(nil)
+      local tab = pmu.to_table(set)
+      print(("%s: %.2f cycles/lookup %.2f instructions/lookup")
+            :format(description,
+                    tab.cycles / iterations,
+                    tab.instructions / iterations))
+   end
+   if pmu.is_available() then
+      local t = new{}
+      local k = {}
+      local numentries = 10000
+      local keysize = 64
+      for entry = 1, numentries do
+         local a, l = math.random(2^keysize - 1), math.random(keysize)
+         t:add(a, l, entry)
+         k[entry] = a
+      end
+      t:build()
+      print("PMU analysis (numentries="..numentries..", keysize="..keysize..")")
+      pmu.setup()
+      measure("lookup",
+              function (iter)
+                 for i=1,iter do t:lookup(k[i%#k+1]) end
+              end,
+              1e5)
+      measure("lookup64",
+              function (iter)
+                 for i=1,iter do t:lookup64(k[i%#k+1]) end
+              end,
+              1e7)
+   else
+      print("No PMU available.")
+   end
+end
+
+-- debugging utils
+function bin (number, length)
+   local digits = {"0", "1"}
+   local s = ""
+   local i = 0
+   repeat
+      local remainder = number % 2
+      s = digits[tonumber(remainder+1)]..s
+      number = (number - remainder) / 2
+      i = i + 1
+      if i % Poptrie.k == 0 then s = " "..s end
+   until number == 0 or (i == length)
+   return s
+end

--- a/src/lib/poptrie.lua
+++ b/src/lib/poptrie.lua
@@ -331,8 +331,8 @@ end
 function Poptrie:lookup64 (key)
    return self.asm_lookup64(self.leaves, self.nodes, key, self.directmap)
 end
-function Poptrie:lookup64 (key)
-   return self.asm_lookup64(self.leaves, self.nodes, key, self.directmap)
+function Poptrie:lookup128 (key)
+   return self.asm_lookup128(self.leaves, self.nodes, key, self.directmap)
 end
 
 function Poptrie:fib_info ()

--- a/src/lib/poptrie.lua
+++ b/src/lib/poptrie.lua
@@ -534,12 +534,13 @@ function selftest ()
    if pmu.is_available() then
       local t = new{direct_pointing=false}
       local k = {}
-      local numentries = 10000
-      local keysize = 32
+      local numentries = lib.getenv("SNABB_POPTRIE_NUMENTRIES") or 10000
+      local numhit = lib.getenv("SNABB_POPTRIE_NUMHIT") or 100
+      local keysize = lib.getenv("SNABB_POPTRIE_KEYSIZE") or 32
       for entry = 0, numentries - 1 do
          local a, l = rs(), math.random(keysize)
          t:add(a, l, entry)
-         k[entry % 100 + 1] = a
+         k[entry % numhit + 1] = a
       end
       local function build ()
          t:build()
@@ -556,7 +557,8 @@ function selftest ()
       local function lookup128 (iter)
          for i=1,iter do t:lookup128(k[i%#k+1]) end
       end
-      print("PMU analysis (numentries="..numentries..", keysize="..keysize..")")
+      print(("PMU analysis (numentries=%d, numhit=%d, keysize=%d)")
+         :format(numentries, numhit, keysize))
       pmu.setup()
       time("build", build)
       measure("lookup", lookup, 1e5)

--- a/src/lib/poptrie.lua
+++ b/src/lib/poptrie.lua
@@ -60,13 +60,9 @@ function new (init)
          self.directmap = array(Poptrie.base_t, 2^self.s)
       end
    end
-   for _, keysize in ipairs{ 32, 64, 128 } do
-      self["asm_lookup"..keysize] = poptrie_lookup.generate(self, keysize)
-      self["lookup"..keysize] = function (self, key)
-         local lookup = self["asm_lookup"..keysize]
-         return lookup(self.leaves, self.nodes, key, self.directmap)
-      end
-   end
+   self.asm_lookup32 = poptrie_lookup.generate(self, 32)
+   self.asm_lookup64 = poptrie_lookup.generate(self, 64)
+   self.asm_lookup128 = poptrie_lookup.generate(self, 128)
    return self
 end
 
@@ -327,6 +323,16 @@ function Poptrie:lookup (key)
    end
    if debug then print(base + bc - 1) end
    return L[base + bc - 1]
+end
+
+function Poptrie:lookup32 (key)
+   return self.asm_lookup32(self.leaves, self.nodes, key, self.directmap)
+end
+function Poptrie:lookup64 (key)
+   return self.asm_lookup64(self.leaves, self.nodes, key, self.directmap)
+end
+function Poptrie:lookup64 (key)
+   return self.asm_lookup64(self.leaves, self.nodes, key, self.directmap)
 end
 
 function Poptrie:fib_info ()

--- a/src/lib/poptrie.lua
+++ b/src/lib/poptrie.lua
@@ -534,9 +534,15 @@ function selftest ()
    if pmu.is_available() then
       local t = new{direct_pointing=false}
       local k = {}
-      local numentries = lib.getenv("SNABB_POPTRIE_NUMENTRIES") or 10000
-      local numhit = lib.getenv("SNABB_POPTRIE_NUMHIT") or 100
-      local keysize = lib.getenv("SNABB_POPTRIE_KEYSIZE") or 32
+      local numentries = tonumber(
+         lib.getenv("SNABB_POPTRIE_NUMENTRIES") or 10000
+      )
+      local numhit = tonumber(
+         lib.getenv("SNABB_POPTRIE_NUMHIT") or 100
+      )
+      local keysize = tonumber(
+         lib.getenv("SNABB_POPTRIE_KEYSIZE") or 32
+      )
       for entry = 0, numentries - 1 do
          local a, l = rs(), math.random(keysize)
          t:add(a, l, entry)

--- a/src/lib/poptrie.lua
+++ b/src/lib/poptrie.lua
@@ -203,9 +203,9 @@ function Poptrie:build_node (rib, node_index, default)
          end
       end
    end
-   -- Allocate child nodes (this has to be done before recursing into build()
-   -- because their indices into the nodes array need to be node.base1 + index,
-   -- and build() will advance the node_base.)
+   -- Allocate child nodes (this has to be done before recursing into
+   -- build_node() because their indices into the nodes array need to be
+   -- node.base1 + index, and build() will advance the node_base.)
    local child_nodes = {}
    for index = 0, 2^Poptrie.k - 1 do
       if children[index] then

--- a/src/lib/poptrie.lua
+++ b/src/lib/poptrie.lua
@@ -294,7 +294,9 @@ function Poptrie:fib_info ()
       print(self.nodes[i].base1, bin(self.nodes[i].vector))
    end
    for i=0, self.leaf_base-1 do
-      print("leaf:", i, self.leaves[i])
+      if self.leaves[i] > 0 then
+         print("leaf:", i, self.leaves[i])
+      end
    end
 end
 

--- a/src/lib/poptrie.lua
+++ b/src/lib/poptrie.lua
@@ -87,8 +87,9 @@ end
 -- Extract bits at offset
 -- key=uint8_t[?]
 function extract (key, offset, length)
-   assert(length <= 32); assert(offset < 128)
-   local byte_offset = math.min(math.floor(offset/8), 12)
+   assert(offset >= 0 and length > 0 and length <= 32)
+   assert(offset <= ffi.sizeof(key) * 8)
+   local byte_offset = math.min(math.floor(offset / 8), ffi.sizeof(key) - 4)
    local bit_offset = offset - byte_offset*8
    local dword = ffi.cast("uint32_t*", key + byte_offset)[0]
    return band(rshift(dword, bit_offset), lshift(1, length) - 1)

--- a/src/lib/poptrie.lua
+++ b/src/lib/poptrie.lua
@@ -505,10 +505,10 @@ function selftest ()
       local k = {}
       local numentries = 10000
       local keysize = 32
-      for entry = 1, numentries do
+      for entry = 0, numentries - 1 do
          local a, l = rs(), math.random(keysize)
          t:add(a, l, entry)
-         k[entry] = a
+         k[entry % 100 + 1] = a
       end
       local function build ()
          t:build()

--- a/src/lib/poptrie.lua
+++ b/src/lib/poptrie.lua
@@ -60,10 +60,24 @@ function new (init)
          self.directmap = array(Poptrie.base_t, 2^self.s)
       end
    end
-   self.asm_lookup32 = poptrie_lookup.generate(self, 32)
-   self.asm_lookup64 = poptrie_lookup.generate(self, 64)
-   self.asm_lookup128 = poptrie_lookup.generate(self, 128)
+   self:configure_lookup()
    return self
+end
+
+local asm_cache = {}
+
+function Poptrie:configure_lookup ()
+   local config = ("leaf_compression=%s,direct_pointing=%s,s=%s")
+      :format(self.leaf_compression, self.direct_pointing, self.s)
+   if not asm_cache[config] then
+      asm_cache[config] = {
+         poptrie_lookup.generate(self, 32),
+         poptrie_lookup.generate(self, 64),
+         poptrie_lookup.generate(self, 128)
+      }
+   end
+   self.asm_lookup32, self.asm_lookup64, self.asm_lookup128 =
+      unpack(asm_cache[config])
 end
 
 function Poptrie:grow_nodes ()

--- a/src/lib/poptrie_lookup.dasl
+++ b/src/lib/poptrie_lookup.dasl
@@ -19,7 +19,6 @@ function generate (Poptrie, keysize)
    -- Assert assumptions about lib.poptrie
    assert(Poptrie.k == 6)
    if Poptrie.direct_pointing then
-      assert(Poptrie.s == 18)
       assert(Poptrie.leaf_tag == bit.lshift(1, 31))
    end
    assert(ffi.sizeof(Poptrie.leaf_t) == 2)
@@ -66,9 +65,10 @@ end
 -- lookup(leaf_t *leaves, node_t *nodes, key) -> leaf_t
 function lookup (Dst, Poptrie, keysize)
    if Poptrie.direct_pointing then
-      -- v = extract(key, 0, s=18)
-      -- v = band(key, lshift(1, s=18) - 1)
-      | mov v, 0x3FFFF
+      -- v = extract(key, 0, Poptrie.s)
+      local direct_mask = bit.lshift(1ULL, Poptrie.s) - 1
+      -- v = band(key, direct_mask)
+      | mov v, direct_mask
       | and v, key
       -- index = dmap[v]
       | mov index, dword [dmap+v*4]

--- a/src/lib/poptrie_lookup.dasl
+++ b/src/lib/poptrie_lookup.dasl
@@ -1,0 +1,127 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
+module(..., package.seeall)
+
+local debug = false
+
+local ffi = require("ffi")
+local dasm = require("dasm")
+
+|.arch x64
+|.actionlist actions
+|.globalnames globalnames
+
+-- Table keeping machine code alive to the GC.
+local anchor = {}
+
+-- Assemble a lookup routine
+function generate (Poptrie, keysize)
+   local offsets = 
+   -- Assert assumptions about lib.poptrie
+   assert(Poptrie.k == 6)
+   assert(ffi.sizeof(Poptrie.leaf_t) == 2)
+   assert(ffi.sizeof(Poptrie.vector_t) == 8)
+   assert(ffi.sizeof(Poptrie.base_t) == 4)
+   assert(ffi.offsetof(Poptrie.node_t, 'leafvec') == 0)
+   assert(ffi.offsetof(Poptrie.node_t, 'vector') == 8)
+   assert(ffi.offsetof(Poptrie.node_t, 'base0') == 16)
+   assert(ffi.offsetof(Poptrie.node_t, 'base1') == 20)
+
+   local name = "poptrie_lookup(k="..Poptrie.k..", keysize="..keysize..")"
+
+   local Dst = dasm.new(actions)
+   lookup(Dst, Poptrie, keysize)
+   local mcode, size = Dst:build()
+   table.insert(anchor, mcode)
+
+   if debug then
+      print("mcode dump: "..name)
+      dasm.dump(mcode, size)
+   end
+
+   local prototype
+   if keysize <= 64 then
+      prototype = ffi.typeof("$ (*) ($ *, $ *, uint64_t)",
+                             Poptrie.leaf_t, Poptrie.leaf_t, Poptrie.node_t)
+   else error("NYI") end
+
+   return ffi.cast(prototype, mcode)
+end
+
+|.define leaves,  rdi -- pointer to leaves array
+|.define nodes,   rsi -- pointer to nodes array
+|.define key,     rdx -- key to look up
+|.define index,   r8d -- index into node array
+|.define node,    r8  -- pointer into node array 
+|.define offset,  r9  -- offset into key
+|.define v,       r10 -- k bits extracted from key
+|.define vec,     r11 -- 64-bit vector or leafvec
+
+-- lookup(leaf_t *leaves, node_t *nodes, key) -> leaf_t
+function lookup (Dst, Poptrie, keysize)
+   -- index, node, offset = 0, nodes[index], 0
+   | mov index, 0
+   | lea node, [nodes+0] -- nodes[0]
+   | mov offset, 0
+   -- while band(vec, lshift(1ULL, v)) ~= 0
+   |1:
+   -- v = extract(key, offset, k=6)
+   if keysize <= 64 then
+      -- v = rshift(key, offset)
+      | mov v, key
+      | mov rcx, offset
+      | shr v, cl
+      -- v = band(v, lshift(1, k=6) - 1)
+      | and v, 63
+   else error("NYI") end
+   -- vec = nodes[index].vector
+   | mov vec, qword [node+8]
+   -- rax = lshift(1ULL, v)
+   | mov rax, 1
+   | mov rcx, v
+   | shl rax, cl
+   -- rax = band(vec, rax)
+   | and rax, vec
+   -- is bit v set in vec?
+   | cmp rax, 0
+   | je >2 -- reached leaf, exit loop
+   -- rax = lshift(2ULL, v) - 1
+   | mov rax, 2
+   | mov rcx, v
+   | shl rax, cl
+   | sub rax, 1
+   -- rax = popcnt(band(vec, rax))
+   | and rax, vec
+   | popcnt rax, rax
+   -- index = base + bc - 1
+   | mov index, dword [node+20] -- nodes[index].base1
+   | add index, eax
+   | sub index, 1
+   -- node = nodes[index]
+   | imul index, 24 -- multiply by node size
+   | lea node, [nodes+index]
+   -- offset = offset + k
+   | add offset, 6
+   | jmp <1 -- loop
+   -- end while
+   |2:
+   -- rax = lshift(2ULL, v) - 1
+   | mov rax, 2
+   | mov rcx, v
+   | shl rax, cl
+   | sub rax, 1
+   if Poptrie.leaf_compression then
+      -- vec = nodes[index].leafvec
+      | mov vec, qword [node+0]
+   else error("NYI") end
+   -- rax = popcnt(band(vec, rax)) - 1
+   | and rax, vec
+   | popcnt rax, rax
+   -- return leaves[base + bc - 1]
+   | mov index, dword [node+16] -- nodes[index].base0
+   | add index, eax
+   | sub index, 1
+   -- assumption: at most ax is set at this point because popcnt(qword) < byte
+   | mov ax, word [leaves+index*2] -- leaves[index]
+   | ret
+end

--- a/src/lib/poptrie_lookup.dasl
+++ b/src/lib/poptrie_lookup.dasl
@@ -74,7 +74,8 @@ function lookup (Dst, Poptrie, keysize)
       | mov index, dword [dmap+v*4]
       -- eax = band(index, leaf_tag - 1) (tag inverted)
       | mov eax, index
-      | btr eax, 31 -- is leaf_tag set?
+      -- is leaf_tag set? (unsets bit)
+      | btr eax, 31
       | jnc >1 -- leaf_tag not set, index is a node
       | ret
       -- node, offset = nodes[index], s
@@ -102,7 +103,8 @@ function lookup (Dst, Poptrie, keysize)
    else error("NYI") end
    -- vec = nodes[index].vector
    | mov vec, qword [node+8]
-   | bt vec, v -- is bit v set in vec?
+   -- is bit v set in vec?
+   | bt vec, v
    | jnc >3 -- reached leaf, exit loop
    -- rax = lshift(2ULL, v) - 1
    | mov rax, 2

--- a/src/lib/poptrie_lookup.dasl
+++ b/src/lib/poptrie_lookup.dasl
@@ -4,6 +4,7 @@ module(..., package.seeall)
 
 local debug = false
 
+local lib = require("core.lib")
 local ffi = require("ffi")
 local dasm = require("dasm")
 
@@ -52,6 +53,11 @@ function generate (Poptrie, keysize)
    return ffi.cast(prototype, mcode)
 end
 
+-- Do we have BMI2?
+local BMI2 = (assert(lib.readfile("/proc/cpuinfo", "*a"),
+                    "failed to read /proc/cpuinfo for hardware check")
+                 :match("bmi2"))
+
 |.define leaves,  rdi -- pointer to leaves array
 |.define nodes,   rsi -- pointer to nodes array
 |.define key,     rdx -- key to look up
@@ -59,6 +65,7 @@ end
 |.define index,   r8d -- index into node array
 |.define node,    r8  -- pointer into node array 
 |.define offset,  r9d -- offset into key
+|.define offsetx, r9  -- (offset as qword)
 |.define v,       r10 -- k or s bits extracted from key
 |.define v_dw,    r10d -- (v as dword)
 |.define vec,     r11 -- 64-bit vector or leafvec
@@ -94,15 +101,24 @@ function lookup (Dst, Poptrie, keysize)
    -- while band(vec, lshift(1ULL, v)) ~= 0
    |2:
    -- v = extract(key, offset, k=6)
-   | mov ecx, offset
-   -- v = rshift(key, offset)
    if keysize == 32 then
-      | mov v_dw, dword [key]
-      | shr v, cl
+      if BMI2 then
+         | shrx v_dw, dword [key], offset
+      else
+         | mov ecx, offset
+         | mov v_dw, dword [key]
+         | shr v, cl
+      end
    elseif keysize == 64 then
-      | mov v, [key]
-      | shr v, cl
+      if BMI2 then
+         | shrx v, [key], offsetx
+      else
+         | mov ecx, offset
+         | mov v, [key]
+         | shr v, cl
+      end
    elseif keysize == 128 then
+      | mov ecx, offset
       | mov v, [key]
       | mov vec, [key+8]
       | test cl, 64
@@ -116,13 +132,18 @@ function lookup (Dst, Poptrie, keysize)
    -- is bit v set in vec?
    | bt vec, v
    | jnc >4 -- reached leaf, exit loop
-   -- rax = lshift(2ULL, v) - 1
-   | mov eax, 2
-   | mov ecx, v_dw
-   | shl rax, cl
-   | sub rax, 1
-   -- rax = popcnt(band(vec, rax))
-   | and rax, vec
+   -- rax = band(vec, lshift(2ULL, v) - 1)
+   if BMI2 then
+      | lea rcx, [v+1]
+      | bzhi rax, vec, rcx
+   else
+      | mov eax, 2
+      | mov ecx, v_dw
+      | shl rax, cl
+      | sub rax, 1
+      | and rax, vec
+   end
+   -- rax = popcnt(rax)
    | popcnt rax, rax
    -- index = base + bc - 1
    | mov index, dword [node+20] -- nodes[index].base1
@@ -136,21 +157,26 @@ function lookup (Dst, Poptrie, keysize)
    | jmp <2 -- loop
    -- end while
    |4:
-   -- rax = lshift(2ULL, v) - 1
-   | mov eax, 2
-   | mov ecx, v_dw
-   | shl rax, cl
-   | sub rax, 1
    if Poptrie.leaf_compression then
       -- vec = nodes[index].leafvec
       | mov vec, qword [node+0]
    else error("NYI") end
-   -- rax = popcnt(band(vec, rax)) - 1
-   | and rax, vec
+   -- rax = band(vec, lshift(2ULL, v) - 1)
+   if BMI2 then
+      | lea rcx, [v+1]
+      | bzhi rax, vec, rcx
+   else
+      | mov eax, 2
+      | mov ecx, v_dw
+      | shl rax, cl
+      | sub rax, 1
+      | and rax, vec
+   end
+   -- rax = popcnt(rax)
    | popcnt rax, rax
    -- return leaves[base + bc - 1]
    | mov index, dword [node+16] -- nodes[index].base0
-   | add index, eax
-   | movzx eax, word [leaves+index*2-2] -- leaves[index]
+   | add index, eax -- index = base + bc
+   | movzx eax, word [leaves+index*2-2] -- leaves[index - 1]
    | ret
 end

--- a/src/lib/poptrie_lookup.dasl
+++ b/src/lib/poptrie_lookup.dasl
@@ -84,7 +84,7 @@ function lookup (Dst, Poptrie, keysize)
       | imul index, 24 -- multiply by node size
       | lea node, [nodes+index]
       -- offset = s
-      | mov offset, 18
+      | mov offset, Poptrie.s
    else
       -- index, node, offset = 0, nodes[index], 0
       | xor index, index

--- a/src/lib/poptrie_lookup.dasl
+++ b/src/lib/poptrie_lookup.dasl
@@ -68,19 +68,14 @@ function lookup (Dst, Poptrie, keysize)
       -- v = extract(key, 0, Poptrie.s)
       local direct_mask = bit.lshift(1ULL, Poptrie.s) - 1
       -- v = band(key, direct_mask)
-      | mov v, direct_mask
-      | and v, key
+      | mov v, key
+      | and v, direct_mask
       -- index = dmap[v]
       | mov index, dword [dmap+v*4]
-      -- eax = band(index, leaf_tag)
-      | mov eax, 0x80000000
-      | and eax, index
-      -- is leaf_tag set?
-      | cmp eax, 0
-      | je >1 -- leaf_tag not set, index is a node
-      -- eax = leaf_tag - 1 (tag inverted)
-      | mov eax, 0x7FFFFFFF
-      | and eax, index
+      -- eax = band(index, leaf_tag - 1) (tag inverted)
+      | mov eax, index
+      | btr eax, 31 -- is leaf_tag set?
+      | jnc >1 -- leaf_tag not set, index is a node
       | ret
       -- node, offset = nodes[index], s
       |1:
@@ -90,9 +85,9 @@ function lookup (Dst, Poptrie, keysize)
       | mov offset, 18
    else
       -- index, node, offset = 0, nodes[index], 0
-      | mov index, 0
+      | xor index, index
       | lea node, [nodes+0] -- nodes[0]
-      | mov offset, 0
+      | xor offset, offset
    end
    -- while band(vec, lshift(1ULL, v)) ~= 0
    |2:
@@ -107,15 +102,8 @@ function lookup (Dst, Poptrie, keysize)
    else error("NYI") end
    -- vec = nodes[index].vector
    | mov vec, qword [node+8]
-   -- rax = lshift(1ULL, v)
-   | mov rax, 1
-   | mov rcx, v
-   | shl rax, cl
-   -- rax = band(vec, rax)
-   | and rax, vec
-   -- is bit v set in vec?
-   | cmp rax, 0
-   | je >3 -- reached leaf, exit loop
+   | bt vec, v -- is bit v set in vec?
+   | jnc >3 -- reached leaf, exit loop
    -- rax = lshift(2ULL, v) - 1
    | mov rax, 2
    | mov rcx, v
@@ -126,8 +114,8 @@ function lookup (Dst, Poptrie, keysize)
    | popcnt rax, rax
    -- index = base + bc - 1
    | mov index, dword [node+20] -- nodes[index].base1
-   | add index, eax
    | sub index, 1
+   | add index, eax
    -- node = nodes[index]
    | imul index, 24 -- multiply by node size
    | lea node, [nodes+index]
@@ -151,8 +139,6 @@ function lookup (Dst, Poptrie, keysize)
    -- return leaves[base + bc - 1]
    | mov index, dword [node+16] -- nodes[index].base0
    | add index, eax
-   | sub index, 1
-   -- assumption: at most ax is set at this point because popcnt(qword) < byte
-   | mov ax, word [leaves+index*2] -- leaves[index]
+   | movzx eax, word [leaves+index*2-2] -- leaves[index]
    | ret
 end

--- a/src/lib/poptrie_lookup.dasl
+++ b/src/lib/poptrie_lookup.dasl
@@ -43,7 +43,7 @@ function generate (Poptrie, keysize)
    end
 
    local prototype
-   if keysize <= 64 and Poptrie.direct_pointing then
+   if keysize <= 64 then
       prototype = ffi.typeof(
          "$ (*) ($ *, $ *, uint64_t, $ *)",
          Poptrie.leaf_t, Poptrie.leaf_t, Poptrie.node_t, Poptrie.base_t

--- a/src/lib/poptrie_lookup.dasl
+++ b/src/lib/poptrie_lookup.dasl
@@ -58,7 +58,7 @@ end
 |.define dmap,    rcx -- pointer to directmap
 |.define index,   r8d -- index into node array
 |.define node,    r8  -- pointer into node array 
-|.define offset,  r9  -- offset into key
+|.define offset,  r9d -- offset into key
 |.define v,       r10 -- k or s bits extracted from key
 |.define v_dw,    r10d -- (v as dword)
 |.define vec,     r11 -- 64-bit vector or leafvec
@@ -94,7 +94,7 @@ function lookup (Dst, Poptrie, keysize)
    -- while band(vec, lshift(1ULL, v)) ~= 0
    |2:
    -- v = extract(key, offset, k=6)
-   | mov rcx, offset
+   | mov ecx, offset
    -- v = rshift(key, offset)
    if keysize == 32 then
       | mov v_dw, dword [key]
@@ -105,23 +105,20 @@ function lookup (Dst, Poptrie, keysize)
    elseif keysize == 128 then
       | mov v, [key]
       | mov vec, [key+8]
-      | cmp rcx, 63
-      | jng >3
-      | sub rcx, 64
-      | mov v, vec
-      | 3:
+      | test cl, 64
+      | cmovnz v, vec
       | shrd v, vec, cl
    else error("NYI") end
    -- v = band(v, lshift(1, k=6) - 1)
-   | and v, 0x3F
+   | and v_dw, 0x3F
    -- vec = nodes[index].vector
    | mov vec, qword [node+8]
    -- is bit v set in vec?
    | bt vec, v
    | jnc >4 -- reached leaf, exit loop
    -- rax = lshift(2ULL, v) - 1
-   | mov rax, 2
-   | mov rcx, v
+   | mov eax, 2
+   | mov ecx, v_dw
    | shl rax, cl
    | sub rax, 1
    -- rax = popcnt(band(vec, rax))
@@ -140,8 +137,8 @@ function lookup (Dst, Poptrie, keysize)
    -- end while
    |4:
    -- rax = lshift(2ULL, v) - 1
-   | mov rax, 2
-   | mov rcx, v
+   | mov eax, 2
+   | mov ecx, v_dw
    | shl rax, cl
    | sub rax, 1
    if Poptrie.leaf_compression then

--- a/src/lib/poptrie_lookup.dasl
+++ b/src/lib/poptrie_lookup.dasl
@@ -14,11 +14,19 @@ local dasm = require("dasm")
 -- Table keeping machine code alive to the GC.
 local anchor = {}
 
+-- leaf_t poptrie_lookup
+-- (leaf_t *leaves, node_t *nodes, uint8_t *key, base_t *directmap)
+-- NB: this type is hardcoded here to avoid filling up the ctype table
+local prototype = ffi.typeof(
+   "uint16_t (*) (void *, void *, uint8_t *, void *)"
+)
+
 -- Assemble a lookup routine
 function generate (Poptrie, keysize)
    -- Assert assumptions about lib.poptrie
    assert(Poptrie.k == 6)
    if Poptrie.direct_pointing then
+      assert(Poptrie.s <= 32)
       assert(Poptrie.leaf_tag == bit.lshift(1, 31))
    end
    assert(ffi.sizeof(Poptrie.leaf_t) == 2)
@@ -41,14 +49,6 @@ function generate (Poptrie, keysize)
       dasm.dump(mcode, size)
    end
 
-   local prototype
-   if keysize <= 64 then
-      prototype = ffi.typeof(
-         "$ (*) ($ *, $ *, uint64_t, $ *)",
-         Poptrie.leaf_t, Poptrie.leaf_t, Poptrie.node_t, Poptrie.base_t
-      )
-   else error("NYI") end
-
    return ffi.cast(prototype, mcode)
 end
 
@@ -60,6 +60,7 @@ end
 |.define node,    r8  -- pointer into node array 
 |.define offset,  r9  -- offset into key
 |.define v,       r10 -- k or s bits extracted from key
+|.define v_dw,    r10d -- (v as dword)
 |.define vec,     r11 -- 64-bit vector or leafvec
 
 -- lookup(leaf_t *leaves, node_t *nodes, key) -> leaf_t
@@ -68,7 +69,7 @@ function lookup (Dst, Poptrie, keysize)
       -- v = extract(key, 0, Poptrie.s)
       local direct_mask = bit.lshift(1ULL, Poptrie.s) - 1
       -- v = band(key, direct_mask)
-      | mov v, key
+      | mov v_dw, dword [key]
       | and v, direct_mask
       -- index = dmap[v]
       | mov index, dword [dmap+v*4]
@@ -93,19 +94,31 @@ function lookup (Dst, Poptrie, keysize)
    -- while band(vec, lshift(1ULL, v)) ~= 0
    |2:
    -- v = extract(key, offset, k=6)
-   if keysize <= 64 then
-      -- v = rshift(key, offset)
-      | mov v, key
-      | mov rcx, offset
+   | mov rcx, offset
+   -- v = rshift(key, offset)
+   if keysize == 32 then
+      | mov v_dw, dword [key]
       | shr v, cl
-      -- v = band(v, lshift(1, k=6) - 1)
-      | and v, 0x3F
+   elseif keysize == 64 then
+      | mov v, [key]
+      | shr v, cl
+   elseif keysize == 128 then
+      | mov v, [key]
+      | mov vec, [key+8]
+      | cmp rcx, 63
+      | jng >3
+      | sub rcx, 64
+      | mov v, vec
+      | 3:
+      | shrd v, vec, cl
    else error("NYI") end
+   -- v = band(v, lshift(1, k=6) - 1)
+   | and v, 0x3F
    -- vec = nodes[index].vector
    | mov vec, qword [node+8]
    -- is bit v set in vec?
    | bt vec, v
-   | jnc >3 -- reached leaf, exit loop
+   | jnc >4 -- reached leaf, exit loop
    -- rax = lshift(2ULL, v) - 1
    | mov rax, 2
    | mov rcx, v
@@ -125,7 +138,7 @@ function lookup (Dst, Poptrie, keysize)
    | add offset, 6
    | jmp <2 -- loop
    -- end while
-   |3:
+   |4:
    -- rax = lshift(2ULL, v) - 1
    | mov rax, 2
    | mov rcx, v

--- a/src/lib/poptrie_lookup.dasl
+++ b/src/lib/poptrie_lookup.dasl
@@ -16,9 +16,12 @@ local anchor = {}
 
 -- Assemble a lookup routine
 function generate (Poptrie, keysize)
-   local offsets = 
    -- Assert assumptions about lib.poptrie
    assert(Poptrie.k == 6)
+   if Poptrie.direct_pointing then
+      assert(Poptrie.s == 18)
+      assert(Poptrie.leaf_tag == bit.lshift(1, 31))
+   end
    assert(ffi.sizeof(Poptrie.leaf_t) == 2)
    assert(ffi.sizeof(Poptrie.vector_t) == 8)
    assert(ffi.sizeof(Poptrie.base_t) == 4)
@@ -40,9 +43,11 @@ function generate (Poptrie, keysize)
    end
 
    local prototype
-   if keysize <= 64 then
-      prototype = ffi.typeof("$ (*) ($ *, $ *, uint64_t)",
-                             Poptrie.leaf_t, Poptrie.leaf_t, Poptrie.node_t)
+   if keysize <= 64 and Poptrie.direct_pointing then
+      prototype = ffi.typeof(
+         "$ (*) ($ *, $ *, uint64_t, $ *)",
+         Poptrie.leaf_t, Poptrie.leaf_t, Poptrie.node_t, Poptrie.base_t
+      )
    else error("NYI") end
 
    return ffi.cast(prototype, mcode)
@@ -51,20 +56,46 @@ end
 |.define leaves,  rdi -- pointer to leaves array
 |.define nodes,   rsi -- pointer to nodes array
 |.define key,     rdx -- key to look up
+|.define dmap,    rcx -- pointer to directmap
 |.define index,   r8d -- index into node array
 |.define node,    r8  -- pointer into node array 
 |.define offset,  r9  -- offset into key
-|.define v,       r10 -- k bits extracted from key
+|.define v,       r10 -- k or s bits extracted from key
 |.define vec,     r11 -- 64-bit vector or leafvec
 
 -- lookup(leaf_t *leaves, node_t *nodes, key) -> leaf_t
 function lookup (Dst, Poptrie, keysize)
-   -- index, node, offset = 0, nodes[index], 0
-   | mov index, 0
-   | lea node, [nodes+0] -- nodes[0]
-   | mov offset, 0
+   if Poptrie.direct_pointing then
+      -- v = extract(key, 0, s=18)
+      -- v = band(key, lshift(1, s=18) - 1)
+      | mov v, 0x3FFFF
+      | and v, key
+      -- index = dmap[v]
+      | mov index, dword [dmap+v*4]
+      -- eax = band(index, leaf_tag)
+      | mov eax, 0x80000000
+      | and eax, index
+      -- is leaf_tag set?
+      | cmp eax, 0
+      | je >1 -- leaf_tag not set, index is a node
+      -- eax = leaf_tag - 1 (tag inverted)
+      | mov eax, 0x7FFFFFFF
+      | and eax, index
+      | ret
+      -- node, offset = nodes[index], s
+      |1:
+      | imul index, 24 -- multiply by node size
+      | lea node, [nodes+index]
+      -- offset = s
+      | mov offset, 18
+   else
+      -- index, node, offset = 0, nodes[index], 0
+      | mov index, 0
+      | lea node, [nodes+0] -- nodes[0]
+      | mov offset, 0
+   end
    -- while band(vec, lshift(1ULL, v)) ~= 0
-   |1:
+   |2:
    -- v = extract(key, offset, k=6)
    if keysize <= 64 then
       -- v = rshift(key, offset)
@@ -72,7 +103,7 @@ function lookup (Dst, Poptrie, keysize)
       | mov rcx, offset
       | shr v, cl
       -- v = band(v, lshift(1, k=6) - 1)
-      | and v, 63
+      | and v, 0x3F
    else error("NYI") end
    -- vec = nodes[index].vector
    | mov vec, qword [node+8]
@@ -84,7 +115,7 @@ function lookup (Dst, Poptrie, keysize)
    | and rax, vec
    -- is bit v set in vec?
    | cmp rax, 0
-   | je >2 -- reached leaf, exit loop
+   | je >3 -- reached leaf, exit loop
    -- rax = lshift(2ULL, v) - 1
    | mov rax, 2
    | mov rcx, v
@@ -102,9 +133,9 @@ function lookup (Dst, Poptrie, keysize)
    | lea node, [nodes+index]
    -- offset = offset + k
    | add offset, 6
-   | jmp <1 -- loop
+   | jmp <2 -- loop
    -- end while
-   |2:
+   |3:
    -- rax = lshift(2ULL, v) - 1
    | mov rax, 2
    | mov rcx, v


### PR DESCRIPTION
This branch contains the beginning of an implementation of [Poptrie](http://conferences.sigcomm.org/sigcomm/2015/pdf/papers/p57.pdf). So far it can...

 - build the poptrie lookup structure for prefixes of up to 64 bits
 - look up keys in the poptrie fairly quick using a DynASM based lookup routine
 - be instantiated using a pre-built poptrie structure

Performance on an Intel(R) Xeon(R) CPU E3-1246 v3 @ 3.50GHz (Haswell, Turbo off)

```
PMU analysis (numentries=10000, keysize=32)
build: 0.1290 seconds
lookup: 13217.09 cycles/lookup 28014.35 instructions/lookup
lookup64: 122.94 cycles/lookup 133.22 instructions/lookup
build(direct_pointing): 0.1056 seconds
lookup(direct_pointing): 5519.01 cycles/lookup 11412.01 instructions/lookup
lookup64(direct_pointing): 89.82 cycles/lookup 70.72 instructions/lookup
```

Not implemented yet:

- ~~prefixes/keys of up to 128 bits (i.e., supporting IPv6)~~

Cc @petebristow 