### PR TITLE
core.engine: Add .vmprofile suffix to filenames to help Studio

### DIFF
--- a/src/core/app.lua
+++ b/src/core/app.lua
@@ -87,7 +87,7 @@ local vmprofile_t = ffi.new("uint8_t["..C.vmprofile_get_profile_size().."]")
 local vmprofiles = {}
 local function getvmprofile (name)
    if vmprofiles[name] == nil then
-      vmprofiles[name] = shm.create("vmprofile/"..name, vmprofile_t)
+      vmprofiles[name] = shm.create("vmprofile/"..name..".vmprofile", vmprofile_t)
    end
    return vmprofiles[name]
 end


### PR DESCRIPTION
Just a tiny change to make Studio automatically detect Snabb profiler data in more contexts: name the profiler datasets with the `.vmprofile` filename suffix.