### PR TITLE
AF_XDP app 

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -13,7 +13,11 @@ OBJDIR = $(patsubst %,obj/%,$(SRCDIR))
 LUASRC = $(shell find . -regex '[^\#]*\.lua' -printf '%P ')
 PFLUASRC = $(shell cd ../lib/pflua/src && \
 	         find . -regex '[^\#]*\.lua' -printf '%P ')
-CSRC   = $(shell find . -regex '[^\#]*\.c' -printf '%P ')
+ifdef LINUX_SOURCE_DIR
+	CSRC   = $(shell find . -regex '[^\#]*\.c' -printf '%P ')
+else
+	CSRC   = $(shell find . -regex '[^\#]*\.c' | egrep -v 'xdpsock' | tr '\n' ' ')
+endif
 CHDR   = $(shell find . -regex '[^\#]*\.h' -printf '%P ')
 ASM    = $(shell find . -regex '[^\#]*\.dasl' -printf '%P ')
 PFLUAASM = $(shell cd ../lib/pflua/src && \
@@ -40,6 +44,11 @@ EXE    := bin/snabb $(patsubst %,bin/%,$(PROGRAM))
 
 LUAJIT_A := ../lib/luajit/src/raptorjit.a
 
+XDPSRCDIR = apps/socket/xdp
+XDPOBJDIR = obj/apps/socket/xdp
+CLANG = clang
+LLC = llc
+
 # TESTMODS expands to:
 #   core.memory core.lib ...
 # for each module that has a top-level selftest () function.
@@ -59,10 +68,28 @@ snabb: $(LUAOBJ) $(PFLUAOBJ) $(HOBJ) $(COBJ) $(ASMOBJ) $(PFLUAASMOBJ) $(INCOBJ) 
 	$(Q) ../generate-version-lua.sh > obj/version.lua.gen
 	$(E) "LUA       obj/version.lua"
 	$(Q) raptorjit -bg -n core.version obj/version.lua.gen obj/version_lua.o
+ifdef LINUX_SOURCE_DIR
+	$(E) "GEN       obj/apps/socket/xdp/xdpsock_kern.o"
+	$(Q) $(CLANG) -c $(XDPSRCDIR)/xdpsock_kern.c \
+		-D__KERNEL__ -D__BPF_TRACING__ \
+		-I ${LINUX_SOURCE_DIR}/tools/include \
+		-I ${LINUX_SOURCE_DIR}/tools/testing/selftests/bpf \
+		-Wno-unused-value -Wno-pointer-sign -Wno-compare-distinct-pointer-types \
+		-Wno-gnu-variable-sized-type-not-at-end -Wno-address-of-packed-member \
+		-Wno-tautological-compare -Wno-unknown-warning-option \
+		-O2 -emit-llvm -c -o - | $(LLC) -march=bpf -filetype=obj -o $(XDPOBJDIR)/xdpsock_kern.o
+endif
 	$(E) "LINK      $@"
+ifdef LINUX_SOURCE_DIR
+	$(Q) $(CC) $(DEBUG) -Wl,--no-as-needed -Wl,-E -Werror -Wall -o $@ $^ \
+	    obj/version_lua.o \
+	    -lrt -lc -ldl -lm -lpthread -lelf \
+	    ${LINUX_SOURCE_DIR}/tools/lib/bpf/libbpf.a
+else
 	$(Q) $(CC) $(DEBUG) -Wl,--no-as-needed -Wl,-E -Werror -Wall -o $@ $^ \
 	    obj/version_lua.o \
 	    -lrt -lc -ldl -lm -lpthread
+endif
 	@echo -n "BINARY    "
 	@ls -sh snabb
 
@@ -133,7 +160,20 @@ $(PFLUAOBJ): obj/%_lua.o: ../lib/pflua/src/%.lua Makefile
 
 $(COBJ): obj/%_c.o: %.c $(CHDR) Makefile | $(OBJDIR)
 	$(E) "C         $@"
+ifndef LINUX_SOURCE_DIR
 	$(Q) $(CC) $(DEBUG) -O3 -Wl,-E -I ../lib/luajit/src -I . -include $(CURDIR)/../gcc-preinclude.h -c -Wall -Werror -o $@ $<
+else
+	$(Q) $(CC) $(DEBUG) -O3 -Wl,-E \
+		-I ../lib/luajit/src \
+		-I . \
+		-I ${LINUX_SOURCE_DIR}/tools/lib \
+		-I ${LINUX_SOURCE_DIR}/tools/include \
+		-I ${LINUX_SOURCE_DIR}/tools/testing/selftests/bpf \
+		-I ${LINUX_SOURCE_DIR}/usr/include \
+		-include $(CURDIR)/../gcc-preinclude.h \
+		-c -Wall -Wno-unused-variable -Werror \
+		-o $@ $<
+endif
 
 $(HOBJ): obj/%_h.o: %.h Makefile | $(OBJDIR)
 	$(E) "H         $@"

--- a/src/apps/basic/basic_apps.lua
+++ b/src/apps/basic/basic_apps.lua
@@ -27,6 +27,11 @@ function Source:pull ()
    end
 end
 
+function Source:set_packet (p)
+   self.size = p.length
+   self.packet = p
+end
+
 function Source:stop ()
    packet.free(self.packet)
 end

--- a/src/apps/socket/xdp/README.md
+++ b/src/apps/socket/xdp/README.md
@@ -1,0 +1,19 @@
+# XDPSocket App (apps.socket.xdp.socket)
+
+The `XDPSocket` app is a bridge between Linux network interfaces (`eth0`,
+`lo`, etc.) and a Snabb app network. Packets taken from the `rx` port are
+transmitted over the selected interface. Packets received on the
+interface are put on the `tx` port.
+
+    DIAGRAM: XDPSocket
+
+              +-----------+
+              |           |
+      rx ---->* XDPSocket *----> tx
+              |           |
+              +-----------+
+
+## Configuration
+
+The `XDPSocket` app accepts a string as its configuration argument. The
+string denotes the interface to bridge to.

--- a/src/apps/socket/xdp/xdp.lua
+++ b/src/apps/socket/xdp/xdp.lua
@@ -65,18 +65,15 @@ function XDPSocket:can_transmit()
 end
 
 function XDPSocket:transmit (p)
-   return self.dev.transmit(self.dev.context, p.data, p.length + 1)
+   self.dev.transmit(self.dev.context, p.data, p.length + 1)
 end
 
 function XDPSocket:push ()
    local rx = self.input and self.input.rx
    if not rx then return end
-   while not link.empty(rx) do
-		if not self:can_transmit() then break end
+   while not link.empty(rx) and self:can_transmit() do
       local p = link.receive(rx)
-		if p.length > 0 then
-			self:transmit(p)
-		end
+		self:transmit(p)
 		packet.free(p)
    end
 end

--- a/src/apps/socket/xdp/xdp.lua
+++ b/src/apps/socket/xdp/xdp.lua
@@ -1,0 +1,183 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
+module(...,package.seeall)
+
+local S = require("syscall")
+local lib = require("core.lib")
+local lwdebug = require("apps.lwaftr.lwdebug")
+
+local ffi = require("ffi")
+local C = ffi.C
+
+require("apps.socket.xdp.xdpsock_app_h")
+
+XDPSocket = {}
+XDPSocket.__index = XDPSocket
+
+function XDPSocket:new (ifname)
+   assert(ifname)
+
+   local ret = C.init_xdp(ifname) 
+   if not ret then
+      print("Error initializing XDP Socket in "..ifname)
+      os.exit(1)
+   end
+
+   local o = {
+      dev = {
+         context = ret,
+         can_receive = C.can_receive,
+         can_transmit = C.can_transmit,
+         receive = C.receive_packet,
+         transmit = C.transmit_packet,
+      }
+   }
+   return setmetatable(o, {__index = XDPSocket})
+end
+
+function XDPSocket:can_receive ()
+   return self.dev.can_receive(self.dev.context)
+end
+
+function XDPSocket:receive ()
+	local p = packet.allocate()
+   local sz = self.dev.receive(self.dev.context, p.data)
+   if sz == 0 then return end
+   p.length = sz
+	return p
+end
+
+function XDPSocket:pull ()
+   local tx = self.output and self.output.tx
+   if not tx then return end
+   local limit = engine.pull_npackets
+	while limit > 0 do
+      local pkt = self:receive()
+      if not pkt then break end
+      -- lwdebug.print_pkt(pkt)
+      link.transmit(tx, pkt)
+      limit = limit - 1
+	end
+end
+
+function XDPSocket:can_transmit()
+   return self.dev.can_transmit(self.dev.context)
+end
+
+function XDPSocket:transmit (p)
+   return self.dev.transmit(self.dev.context, p.data, p.length + 1)
+end
+
+function XDPSocket:push ()
+   local rx = self.input and self.input.rx
+   if not rx then return end
+   while not link.empty(rx) do
+		if not self:can_transmit() then break end
+      local p = link.receive(rx)
+		if p.length > 0 then
+			self:transmit(p)
+		end
+		packet.free(p)
+   end
+end
+
+function selftest ()
+   print("selftest:")
+   local lib = require("core.lib")
+   local basic_apps = require("apps.basic.basic_apps")
+
+   local function stats (l)
+      local w = function (arg1, arg2)
+         io.stdout:write(arg1) print(arg2)
+      end
+      w("dtime: ", l.stats.dtime)
+      w("txbytes: ", l.stats.txbytes)
+      w("rxbytes: ", l.stats.rxbytes)
+      w("txpackets: ", l.stats.txpackets)
+      w("rxpackets: ", l.stats.rxpackets)
+      w("txdrop: ", l.stats.txdrop)
+   end
+   local function test_app_and_links (pkt, if_name)
+      local counter = require("core.counter")
+      local xdp = XDPSocket:new(if_name)
+      xdp.input = {
+         rx = link.new("l_input")
+      }
+      link.transmit(xdp.input.rx, pkt)
+      assert(counter.read(xdp.input.rx.stats.txpackets) == 1)
+      xdp:push()
+      assert(counter.read(xdp.input.rx.stats.rxpackets) == 1)
+   end
+   local function test_send (pkt, if_name)
+      engine.configure(config.new())
+
+      local c = config.new()
+      config.app(c, "source", basic_apps.Source)
+      config.app(c, "tee", basic_apps.Tee)
+      config.app(c, "nic0", XDPSocket, if_name)
+      config.app(c, "sink", basic_apps.Sink)
+   
+      config.link(c, "source.tx -> tee.rx")
+      config.link(c, "tee.tx -> nic0.rx")
+   
+      engine.configure(c)
+      engine.app_table.source:set_packet(pkt)
+   
+      engine.main({duration=0.1, report={showlinks=true}})
+   end
+   local function test_send_and_receive (pkt, if_name0, if_name1)
+      engine.configure(config.new())
+
+      local c = config.new()
+      config.app(c, "source", basic_apps.Source)
+      config.app(c, "tee", basic_apps.Tee)
+      config.app(c, "nic0", XDPSocket, if_name0)
+      config.app(c, "nic1", XDPSocket, if_name1)
+      config.app(c, "sink", basic_apps.Sink)
+   
+      config.link(c, "source.tx -> tee.rx")
+      config.link(c, "tee.tx -> nic0.rx")
+      config.link(c, "nic1.tx -> sink.rx")
+   
+      engine.configure(c)
+      engine.app_table.source:set_packet(pkt)
+   
+      engine.main({duration=0.1, report={showlinks=true}})
+   end
+   local function test_receive (pkt, if_name)
+      engine.configure(config.new())
+
+      local c = config.new()
+      config.app(c, "nic0", XDPSocket, if_name)
+      config.app(c, "sink", basic_apps.Sink)
+   
+      config.link(c, "nic0.tx -> sink.rx")
+   
+      engine.configure(c)
+   
+      engine.main({duration=0.1, report={showlinks=true}})
+   end
+
+   local if_name0 = lib.getenv("SNABB_PCI0") or lib.getenv("SNABB_IFNAME0")
+   if not if_name0 then
+      print("skipped")
+      return main.exit(engine.test_skipped_code)
+   end
+
+   local pkt = packet.from_string(lib.hexundump([=[
+      90 e3 ba ac b9 b4 90 e2 ba ac b9 48 08 00 45 00
+      00 34 00 00 00 00 0f 11 d9 40 08 08 08 08 c1 05
+      01 64 30 39 04 00 00 20 00 00 00 00 00 00 00 00
+      00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+      00 00
+	]=], 66))
+
+   test_app_and_links(pkt, if_name0)
+   test_send(pkt, if_name0)
+   local if_name1 = lib.getenv("SNABB_PCI1") or lib.getenv("SNABB_IFNAME1")
+   if if_name1 then
+      test_send_and_receive(pkt, if_name0, if_name1)
+   end
+
+   print("ok")
+end

--- a/src/apps/socket/xdp/xdp.lua
+++ b/src/apps/socket/xdp/xdp.lua
@@ -59,10 +59,10 @@ function XDPSocket:can_receive ()
 end
 
 function XDPSocket:receive ()
-	local p = self.tx_packets[0]
+   local p = self.tx_packets[0]
    local rcvd = self.dev.receive(self.dev.context, cast("void*", p))
    if rcvd == 0 then return end
-	return rcvd
+   return rcvd
 end
 
 function XDPSocket:receive_packets ()
@@ -75,7 +75,7 @@ function XDPSocket:pull ()
    local tx = self.output and self.output.tx
    if not tx then return end
    local limit = engine.pull_npackets
-	while limit > 0 do
+   while limit > 0 do
       local rcvd = self:receive_packets()
       if not rcvd then break end
       for i=0,rcvd-1 do
@@ -83,7 +83,7 @@ function XDPSocket:pull ()
          link.transmit(tx, packet.clone(self.tx_packets[i]))
       end
       limit = limit - rcvd
-	end
+   end
 end
 
 function XDPSocket:can_transmit()
@@ -216,7 +216,7 @@ function selftest ()
       01 64 30 39 04 00 00 20 00 00 00 00 00 00 00 00
       00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
       00 00
-	]=], 66))
+   ]=], 66))
 
    test_app_and_links(pkt, if_name0)
    test_send(pkt, if_name0)

--- a/src/apps/socket/xdp/xdpsock_app.c
+++ b/src/apps/socket/xdp/xdpsock_app.c
@@ -592,7 +592,7 @@ static xdpsock_context_t* init_xdpsock_context(const xdpsock_options_t *opts, in
 
 bool can_receive(const xdpsock_context_t *ctx)
 {
-	const unsigned int timeout = 1000;
+    const unsigned int timeout = 1000;
 
     return poll(ctx->fds_in, ctx->nfds_in, timeout) > 0;
 }
@@ -607,17 +607,17 @@ size_t receive_packet(const xdpsock_context_t *ctx, char *data)
     rcvd = xq_deq(&xsk->rx, descs, BATCH_SIZE);
     if (!rcvd) {
         return 0;
-	}
+    }
 
-	char *buffer = xq_get_data(xsk, descs[0].addr);
-	size_t len = descs[0].len;
-	memcpy(data, buffer, len);
+    char *buffer = xq_get_data(xsk, descs[0].addr);
+    size_t len = descs[0].len;
+    memcpy(data, buffer, len);
 
     xsk->rx_npkts += rcvd;
 
     umem_fill_to_kernel_ex(&xsk->umem->fq, descs, rcvd);
 
-	return len;
+    return len;
 }
 
 void transmit_packets(const xdpsock_context_t *ctx, const char *pkt_data, size_t len, size_t batch_size)

--- a/src/apps/socket/xdp/xdpsock_app.c
+++ b/src/apps/socket/xdp/xdpsock_app.c
@@ -1,0 +1,690 @@
+// Use of this source code is governed by the Apache 2.0 license; see COPYING.
+//
+// Heavily based on: https://github.com/torvalds/linux/blob/master/samples/bpf/xdpsock_user.c
+
+/* Power-of-2 number of sockets */
+#define MAX_SOCKS 1
+
+/* Round-robin receive */
+#define RR_LB 0
+
+#ifndef SOL_XDP
+#define SOL_XDP 283
+#endif
+
+#ifndef AF_XDP
+#define AF_XDP 44
+#endif
+
+#ifndef PF_XDP
+#define PF_XDP AF_XDP
+#endif
+
+#define NUM_FRAMES 131072
+#define FRAME_HEADROOM 0
+#define FRAME_SHIFT 11
+#define FRAME_SIZE 2048
+#define NUM_DESCS 1024
+#define BATCH_SIZE 1
+
+#define FQ_NUM_DESCS 1024
+#define CQ_NUM_DESCS 1024
+
+#define DEBUG_HEXDUMP 0
+
+#define lassert(expr)                                      \
+    do {                                                   \
+        if (!(expr)) {                                     \
+            fprintf(stderr, "%s:%s:%i: Assertion failed: " \
+                #expr ": errno: %d/\"%s\"\n",              \
+                __FILE__, __func__, __LINE__,              \
+                errno, strerror(errno));                   \
+            exit(EXIT_FAILURE);                            \
+        }                                                  \
+    } while (0)
+
+
+#include <assert.h>
+#include <errno.h>
+#include <libgen.h>
+#include <linux/bpf.h>
+#include <linux/if_link.h>
+#include <linux/if_xdp.h>
+#include <linux/if_ether.h>
+#include <net/if.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <net/ethernet.h>
+#include <sys/resource.h>
+#include <sys/socket.h>
+#include <sys/mman.h>
+#include <unistd.h>
+#include <pthread.h>
+#include <locale.h>
+#include <sys/types.h>
+#include <poll.h>
+
+#include "bpf/libbpf.h"
+#include "bpf_util.h"
+#include <bpf/bpf.h>
+
+#include "xdpsock_app.h"
+
+#define barrier() __asm__ __volatile__("": : :"memory")
+#ifdef __aarch64__
+#define u_smp_rmb() __asm__ __volatile__("dmb ishld": : :"memory")
+#define u_smp_wmb() __asm__ __volatile__("dmb ishst": : :"memory")
+#else
+#define u_smp_rmb() barrier()
+#define u_smp_wmb() barrier()
+#endif
+#define likely(x) __builtin_expect(!!(x), 1)
+#define unlikely(x) __builtin_expect(!!(x), 0)
+
+/* Private. */
+static inline u32 umem_nb_free(struct xdp_umem_uqueue *q, u32 nb);
+static inline u32 xq_nb_free(struct xdp_uqueue *q, u32 ndescs);
+static inline u32 umem_nb_avail(struct xdp_umem_uqueue *q, u32 nb);
+static inline u32 xq_nb_avail(struct xdp_uqueue *q, u32 ndescs);
+static inline int umem_fill_to_kernel_ex(struct xdp_umem_uqueue *fq, struct xdp_desc *d, size_t nb);
+static inline int umem_fill_to_kernel(struct xdp_umem_uqueue *fq, u64 *d, size_t nb);
+static inline size_t umem_complete_from_kernel(struct xdp_umem_uqueue *cq, u64 *d, size_t nb);
+static inline void *xq_get_data(struct xdpsock *xsk, u64 addr);
+static inline int xq_enq(struct xdp_uqueue *uq, const struct xdp_desc *descs, unsigned int ndescs);
+static inline int xq_enq_transmit(struct xdp_uqueue *uq, unsigned int id, unsigned int ndescs, size_t len);
+static inline int xq_deq(struct xdp_uqueue *uq, struct xdp_desc *descs, int ndescs);
+static struct xdp_umem *xdp_umem_configure(int sfd);
+static struct xdpsock *xsk_configure(const xdpsock_options_t *opts, struct xdp_umem *umem);
+static void kick_tx(int fd);
+static inline void complete_transmit(struct xdpsock *xsk);
+static xdpsock_context_t* init_xdpsock_context(const xdpsock_options_t *opts, int xsks_map);
+
+static inline u32 umem_nb_free(struct xdp_umem_uqueue *q, u32 nb)
+{
+    u32 free_entries = q->cached_cons - q->cached_prod;
+
+    if (free_entries >= nb)
+        return free_entries;
+
+    /* Refresh the local tail pointer */
+    q->cached_cons = *q->consumer + q->size;
+
+    return q->cached_cons - q->cached_prod;
+}
+
+static inline u32 xq_nb_free(struct xdp_uqueue *q, u32 ndescs)
+{
+    u32 free_entries = q->cached_cons - q->cached_prod;
+
+    if (free_entries >= ndescs)
+        return free_entries;
+
+    /* Refresh the local tail pointer */
+    q->cached_cons = *q->consumer + q->size;
+    return q->cached_cons - q->cached_prod;
+}
+
+static inline u32 umem_nb_avail(struct xdp_umem_uqueue *q, u32 nb)
+{
+    u32 entries = q->cached_prod - q->cached_cons;
+
+    if (entries == 0) {
+        q->cached_prod = *q->producer;
+        entries = q->cached_prod - q->cached_cons;
+    }
+
+    return (entries > nb) ? nb : entries;
+}
+
+static inline u32 xq_nb_avail(struct xdp_uqueue *q, u32 ndescs)
+{
+    u32 entries = q->cached_prod - q->cached_cons;
+
+    if (entries == 0) {
+        q->cached_prod = *q->producer;
+        entries = q->cached_prod - q->cached_cons;
+    }
+
+    return (entries > ndescs) ? ndescs : entries;
+}
+
+static inline int umem_fill_to_kernel_ex(struct xdp_umem_uqueue *fq,
+                     struct xdp_desc *d,
+                     size_t nb)
+{
+    u32 i;
+
+    if (umem_nb_free(fq, nb) < nb)
+        return -ENOSPC;
+
+    for (i = 0; i < nb; i++) {
+        u32 idx = fq->cached_prod++ & fq->mask;
+
+        fq->ring[idx] = d[i].addr;
+    }
+
+    u_smp_wmb();
+
+    *fq->producer = fq->cached_prod;
+
+    return 0;
+}
+
+static inline int umem_fill_to_kernel(struct xdp_umem_uqueue *fq, u64 *d, size_t nb)
+{
+    u32 i;
+
+    if (umem_nb_free(fq, nb) < nb)
+        return -ENOSPC;
+
+    for (i = 0; i < nb; i++) {
+        u32 idx = fq->cached_prod++ & fq->mask;
+
+        fq->ring[idx] = d[i];
+    }
+
+    u_smp_wmb();
+
+    *fq->producer = fq->cached_prod;
+
+    return 0;
+}
+
+static inline size_t umem_complete_from_kernel(struct xdp_umem_uqueue *cq, u64 *d, size_t nb)
+{
+    u32 idx, i, entries = umem_nb_avail(cq, nb);
+
+    u_smp_rmb();
+
+    for (i = 0; i < entries; i++) {
+        idx = cq->cached_cons++ & cq->mask;
+        d[i] = cq->ring[idx];
+    }
+
+    if (entries > 0) {
+        u_smp_wmb();
+
+        *cq->consumer = cq->cached_cons;
+    }
+
+    return entries;
+}
+
+static inline void *xq_get_data(struct xdpsock *xsk, u64 addr)
+{
+    return &xsk->umem->frames[addr];
+}
+
+static inline int xq_enq(struct xdp_uqueue *uq, const struct xdp_desc *descs, unsigned int ndescs)
+{
+    struct xdp_desc *r = uq->ring;
+    unsigned int i;
+
+    if (xq_nb_free(uq, ndescs) < ndescs)
+        return -ENOSPC;
+
+    for (i = 0; i < ndescs; i++) {
+        u32 idx = uq->cached_prod++ & uq->mask;
+
+        r[idx].addr = descs[i].addr;
+        r[idx].len = descs[i].len;
+    }
+
+    u_smp_wmb();
+
+    *uq->producer = uq->cached_prod;
+    return 0;
+}
+
+static inline int xq_enq_transmit(struct xdp_uqueue *uq,
+                 unsigned int id, unsigned int ndescs, size_t len)
+{
+    struct xdp_desc *r = uq->ring;
+    unsigned int i;
+
+    if (xq_nb_free(uq, ndescs) < ndescs)
+        return -ENOSPC;
+
+    for (i = 0; i < ndescs; i++) {
+        u32 idx = uq->cached_prod++ & uq->mask;
+
+        r[idx].addr = (id + i) << FRAME_SHIFT;
+        r[idx].len = len - 1;
+    }
+
+    u_smp_wmb();
+
+    *uq->producer = uq->cached_prod;
+    return 0;
+}
+
+static inline int xq_deq(struct xdp_uqueue *uq,
+             struct xdp_desc *descs,
+             int ndescs)
+{
+    struct xdp_desc *r = uq->ring;
+    unsigned int idx;
+    int i, entries;
+
+    entries = xq_nb_avail(uq, ndescs);
+
+    u_smp_rmb();
+
+    for (i = 0; i < entries; i++) {
+        idx = uq->cached_cons++ & uq->mask;
+        descs[i] = r[idx];
+    }
+
+    if (entries > 0) {
+        u_smp_wmb();
+
+        *uq->consumer = uq->cached_cons;
+    }
+
+    return entries;
+}
+
+static struct xdp_umem *xdp_umem_configure(int sfd)
+{
+    int fq_size = FQ_NUM_DESCS, cq_size = CQ_NUM_DESCS;
+    struct xdp_mmap_offsets off;
+    struct xdp_umem_reg mr;
+    struct xdp_umem *umem;
+    socklen_t optlen;
+    void *bufs;
+
+    umem = calloc(1, sizeof(*umem));
+    lassert(umem);
+
+    lassert(posix_memalign(&bufs, getpagesize(), /* PAGE_SIZE aligned */
+                   NUM_FRAMES * FRAME_SIZE) == 0);
+
+    mr.addr = (__u64)bufs;
+    mr.len = NUM_FRAMES * FRAME_SIZE;
+    mr.chunk_size = FRAME_SIZE;
+    mr.headroom = FRAME_HEADROOM;
+
+    lassert(setsockopt(sfd, SOL_XDP, XDP_UMEM_REG, &mr, sizeof(mr)) == 0);
+    lassert(setsockopt(sfd, SOL_XDP, XDP_UMEM_FILL_RING, &fq_size,
+               sizeof(int)) == 0);
+    lassert(setsockopt(sfd, SOL_XDP, XDP_UMEM_COMPLETION_RING, &cq_size,
+               sizeof(int)) == 0);
+
+    optlen = sizeof(off);
+    lassert(getsockopt(sfd, SOL_XDP, XDP_MMAP_OFFSETS, &off,
+               &optlen) == 0);
+
+    umem->fq.map = mmap(0, off.fr.desc +
+                FQ_NUM_DESCS * sizeof(u64),
+                PROT_READ | PROT_WRITE,
+                MAP_SHARED | MAP_POPULATE, sfd,
+                XDP_UMEM_PGOFF_FILL_RING);
+    lassert(umem->fq.map != MAP_FAILED);
+
+    umem->fq.mask = FQ_NUM_DESCS - 1;
+    umem->fq.size = FQ_NUM_DESCS;
+    umem->fq.producer = umem->fq.map + off.fr.producer;
+    umem->fq.consumer = umem->fq.map + off.fr.consumer;
+    umem->fq.ring = umem->fq.map + off.fr.desc;
+    umem->fq.cached_cons = FQ_NUM_DESCS;
+
+    umem->cq.map = mmap(0, off.cr.desc +
+                 CQ_NUM_DESCS * sizeof(u64),
+                 PROT_READ | PROT_WRITE,
+                 MAP_SHARED | MAP_POPULATE, sfd,
+                 XDP_UMEM_PGOFF_COMPLETION_RING);
+    lassert(umem->cq.map != MAP_FAILED);
+
+    umem->cq.mask = CQ_NUM_DESCS - 1;
+    umem->cq.size = CQ_NUM_DESCS;
+    umem->cq.producer = umem->cq.map + off.cr.producer;
+    umem->cq.consumer = umem->cq.map + off.cr.consumer;
+    umem->cq.ring = umem->cq.map + off.cr.desc;
+
+    umem->frames = bufs;
+    umem->fd = sfd;
+
+    return umem;
+}
+
+static struct xdpsock *xsk_configure(const xdpsock_options_t *opts, struct xdp_umem *umem)
+{
+    struct sockaddr_xdp sxdp = {};
+    struct xdp_mmap_offsets off;
+    int sfd, ndescs = NUM_DESCS;
+    struct xdpsock *xsk;
+    bool shared = true;
+    socklen_t optlen;
+    u64 i;
+
+    sfd = socket(PF_XDP, SOCK_RAW, 0);
+    lassert(sfd >= 0);
+
+    xsk = calloc(1, sizeof(*xsk));
+    lassert(xsk);
+
+    xsk->sfd = sfd;
+    xsk->outstanding_tx = 0;
+
+    if (!umem) {
+        shared = false;
+        xsk->umem = xdp_umem_configure(sfd);
+    } else {
+        xsk->umem = umem;
+    }
+
+    lassert(setsockopt(sfd, SOL_XDP, XDP_RX_RING,
+               &ndescs, sizeof(int)) == 0);
+    lassert(setsockopt(sfd, SOL_XDP, XDP_TX_RING,
+               &ndescs, sizeof(int)) == 0);
+    optlen = sizeof(off);
+    lassert(getsockopt(sfd, SOL_XDP, XDP_MMAP_OFFSETS, &off,
+               &optlen) == 0);
+
+    /* Rx */
+    xsk->rx.map = mmap(NULL,
+               off.rx.desc +
+               NUM_DESCS * sizeof(struct xdp_desc),
+               PROT_READ | PROT_WRITE,
+               MAP_SHARED | MAP_POPULATE, sfd,
+               XDP_PGOFF_RX_RING);
+    lassert(xsk->rx.map != MAP_FAILED);
+
+    if (!shared) {
+        for (i = 0; i < NUM_DESCS * FRAME_SIZE; i += FRAME_SIZE)
+            lassert(umem_fill_to_kernel(&xsk->umem->fq, &i, 1)
+                == 0);
+    }
+
+    /* Tx */
+    xsk->tx.map = mmap(NULL,
+               off.tx.desc +
+               NUM_DESCS * sizeof(struct xdp_desc),
+               PROT_READ | PROT_WRITE,
+               MAP_SHARED | MAP_POPULATE, sfd,
+               XDP_PGOFF_TX_RING);
+    lassert(xsk->tx.map != MAP_FAILED);
+
+    xsk->rx.mask = NUM_DESCS - 1;
+    xsk->rx.size = NUM_DESCS;
+    xsk->rx.producer = xsk->rx.map + off.rx.producer;
+    xsk->rx.consumer = xsk->rx.map + off.rx.consumer;
+    xsk->rx.ring = xsk->rx.map + off.rx.desc;
+
+    xsk->tx.mask = NUM_DESCS - 1;
+    xsk->tx.size = NUM_DESCS;
+    xsk->tx.producer = xsk->tx.map + off.tx.producer;
+    xsk->tx.consumer = xsk->tx.map + off.tx.consumer;
+    xsk->tx.ring = xsk->tx.map + off.tx.desc;
+    xsk->tx.cached_cons = NUM_DESCS;
+
+    sxdp.sxdp_family = PF_XDP;
+    sxdp.sxdp_ifindex = opts->opt_ifindex;
+    sxdp.sxdp_queue_id = opts->opt_queue;
+
+    if (shared) {
+        sxdp.sxdp_flags = XDP_SHARED_UMEM;
+        sxdp.sxdp_shared_umem_fd = umem->fd;
+    } else {
+        sxdp.sxdp_flags = opts->opt_xdp_bind_flags;
+    }
+
+    lassert(bind(sfd, (struct sockaddr *)&sxdp, sizeof(sxdp)) == 0);
+
+    return xsk;
+}
+
+static void kick_tx(int fd)
+{
+    int ret;
+
+    ret = sendto(fd, NULL, 0, MSG_DONTWAIT, NULL, 0);
+    if (ret >= 0 || errno == ENOBUFS || errno == EAGAIN || errno == EBUSY)
+        return;
+    lassert(0);
+}
+
+static inline void complete_transmit(struct xdpsock *xsk)
+{
+    u64 descs[BATCH_SIZE];
+    unsigned int rcvd;
+
+    if (!xsk->outstanding_tx)
+        return;
+
+    kick_tx(xsk->sfd);
+
+    rcvd = umem_complete_from_kernel(&xsk->umem->cq, descs, BATCH_SIZE);
+    if (rcvd > 0) {
+        xsk->outstanding_tx -= rcvd;
+        xsk->tx_npkts += rcvd;
+    }
+}
+
+static unsigned int if_index_by_name(const char *if_name)
+{
+    unsigned int ret = if_nametoindex(if_name);
+    if (!ret) {
+        fprintf(stderr, "ERROR: interface \"%s\" does not exist\n", if_name);
+        exit(EXIT_FAILURE);
+    }
+    return ret;
+}
+
+static int init_bpf(xdpsock_options_t *opts, const char *filename)
+{
+    char xdp_filename[256];
+    struct rlimit r = {RLIM_INFINITY, RLIM_INFINITY};
+    struct bpf_prog_load_attr prog_load_attr = {
+        .prog_type    = BPF_PROG_TYPE_XDP,
+    };
+    int prog_fd, qidconf_map, xsks_map;
+    struct bpf_object *obj;
+    struct bpf_map *map;
+    int ret, key = 0;
+
+    if (setrlimit(RLIMIT_MEMLOCK, &r)) {
+        fprintf(stderr, "ERROR: setrlimit(RLIMIT_MEMLOCK) \"%s\"\n",
+            strerror(errno));
+        exit(EXIT_FAILURE);
+    }
+
+    snprintf(xdp_filename, sizeof(xdp_filename), "obj/apps/socket/xdp/%s_kern.o", filename);
+    prog_load_attr.file = xdp_filename;
+
+    if (bpf_prog_load_xattr(&prog_load_attr, &obj, &prog_fd))
+        exit(EXIT_FAILURE);
+    if (prog_fd < 0) {
+        fprintf(stderr, "ERROR: no program found: %s\n",
+            strerror(prog_fd));
+        exit(EXIT_FAILURE);
+    }
+
+    map = bpf_object__find_map_by_name(obj, "qidconf_map");
+    qidconf_map = bpf_map__fd(map);
+    if (qidconf_map < 0) {
+        fprintf(stderr, "ERROR: no qidconf map found: %s\n",
+            strerror(qidconf_map));
+        exit(EXIT_FAILURE);
+    }
+
+    map = bpf_object__find_map_by_name(obj, "xsks_map");
+    xsks_map = bpf_map__fd(map);
+    if (xsks_map < 0) {
+        fprintf(stderr, "ERROR: no xsks map found: %s\n",
+            strerror(xsks_map));
+        exit(EXIT_FAILURE);
+    }
+
+    opts->opt_ifindex = if_index_by_name(opts->opt_if);
+    if (bpf_set_link_xdp_fd(opts->opt_ifindex, prog_fd, opts->opt_xdp_flags) < 0) {
+        fprintf(stderr, "ERROR: link set xdp fd failed\n");
+        exit(EXIT_FAILURE);
+    }
+
+    ret = bpf_map_update_elem(qidconf_map, &key, &opts->opt_queue, 0);
+    if (ret) {
+        fprintf(stderr, "ERROR: bpf_map_update_elem qidconf\n");
+        exit(EXIT_FAILURE);
+    }
+
+    return xsks_map;
+}
+
+xdpsock_context_t* init_xdp(const char *if_name)
+{
+    xdpsock_options_t opts = {
+        .opt_bench = 0,
+        .opt_poll = 1,
+        .opt_queue = 0,
+        .opt_xdp_flags = 0,
+    };
+    opts.opt_if = if_name;
+
+    int xsks_map = init_bpf(&opts, "xdpsock");
+    return init_xdpsock_context(&opts, xsks_map);
+}
+
+static xdpsock_context_t* init_xdpsock_context(const xdpsock_options_t *opts, int xsks_map)
+{
+    int i, key, ret;
+    struct xdpsock *xsks[MAX_SOCKS];
+    int num_socks = 0;
+
+    xdpsock_context_t *ctx = (xdpsock_context_t*) malloc(sizeof(xdpsock_context_t)); 
+
+    /* Create sockets... */
+    xsks[num_socks++] = xsk_configure(opts, NULL);
+
+#if RR_LB
+    for (i = 0; i < MAX_SOCKS - 1; i++)
+        xsks[num_socks++] = xsk_configure(opts, xsks[0]->umem);
+#endif
+
+    /* ...and insert them into the map. */
+    for (i = 0; i < num_socks; i++) {
+        key = i;
+        ret = bpf_map_update_elem(xsks_map, &key, &xsks[i]->sfd, 0);
+        if (ret) {
+            fprintf(stderr, "ERROR: bpf_map_update_elem %d\n", i);
+            exit(EXIT_FAILURE);
+        }
+    }
+
+    for (int i = 0; i < num_socks; i++) {
+        ctx->xsks[i] = xsks[i];
+    }
+    ctx->num_socks = num_socks;
+    ctx->opts = opts;
+    ctx->nfds_out = 1;
+    ctx->fds_out = (struct pollfd*) calloc(sizeof(struct pollfd), ctx->nfds_out + 1);
+    ctx->fds_out[0].fd = ctx->xsks[0]->sfd;
+    ctx->fds_out[0].events = POLLOUT;
+    ctx->nfds_in = 1;
+    ctx->fds_in = (struct pollfd*) calloc(sizeof(struct pollfd), ctx->nfds_in + 1);
+    ctx->fds_in[0].fd = ctx->xsks[0]->sfd;
+    ctx->fds_in[0].events = POLLIN;
+
+    return ctx;
+}
+
+bool can_receive(const xdpsock_context_t *ctx)
+{
+	const unsigned int timeout = 1000;
+
+    return poll(ctx->fds_in, ctx->nfds_in, timeout) > 0;
+}
+
+size_t receive_packet(const xdpsock_context_t *ctx, char *data)
+{
+    struct xdp_desc descs[BATCH_SIZE];
+    unsigned int rcvd, i;
+
+    struct xdpsock *xsk = ctx->xsks[0];
+
+    rcvd = xq_deq(&xsk->rx, descs, BATCH_SIZE);
+    if (!rcvd) {
+        return 0;
+	}
+
+	char *buffer = xq_get_data(xsk, descs[0].addr);
+	size_t len = descs[0].len;
+	memcpy(data, buffer, len);
+
+    xsk->rx_npkts += rcvd;
+
+    umem_fill_to_kernel_ex(&xsk->umem->fq, descs, rcvd);
+
+	return len;
+}
+
+void transmit_packets(const xdpsock_context_t *ctx, const char *pkt_data, size_t len, size_t batch_size)
+{
+    unsigned int idx = 0;
+
+    struct xdpsock *xsk = ctx->xsks[0];
+
+    if (xq_nb_free(&xsk->tx, batch_size) >= batch_size) {
+        for (int i = idx*FRAME_SIZE; i < (idx + batch_size)*FRAME_SIZE; i += FRAME_SIZE) {
+            memcpy(&xsk->umem->frames[i], pkt_data, len);
+        }
+        lassert(xq_enq_transmit(&xsk->tx, idx, batch_size, len) == 0);
+
+        xsk->outstanding_tx += batch_size;
+        idx += batch_size;
+        idx %= NUM_FRAMES;
+    }
+
+    complete_transmit(xsk);
+}
+
+void transmit_packet(const xdpsock_context_t *ctx, const char *pkt_data, size_t len)
+{   
+    transmit_packets(ctx, pkt_data, len, 1);
+}
+
+void transmit(const xdpsock_context_t *ctx, const char *pkt_data, size_t len)
+{
+    int timeout, nfds = 1;
+    struct pollfd fds[nfds + 1];
+    unsigned int idx = 0;
+
+    struct xdpsock *xsk = ctx->xsks[0];
+
+    for (int i = 0; i < NUM_FRAMES * FRAME_SIZE; i += FRAME_SIZE)
+        memcpy(&xsk->umem->frames[i], pkt_data, len);
+
+    if (ctx->opts->opt_poll) {
+        if (!can_transmit(ctx)) {
+            return;
+        }
+    }
+
+    if (xq_nb_free(&xsk->tx, BATCH_SIZE) >= BATCH_SIZE) {
+        lassert(xq_enq_transmit(&xsk->tx, idx, BATCH_SIZE, len) == 0);
+
+        xsk->outstanding_tx += BATCH_SIZE;
+        idx += BATCH_SIZE;
+        idx %= NUM_FRAMES;
+    }
+
+    complete_transmit(xsk);
+}
+
+bool can_transmit(const xdpsock_context_t *ctx)
+{
+    const struct xdpsock *xsk = ctx->xsks[0];
+    const int timeout = 1000;
+
+    int ret = poll(ctx->fds_out, ctx->nfds_out, timeout);
+    if (ret <= 0) {
+        return false;
+    }
+    if (ctx->fds_out[0].fd != xsk->sfd ||
+            !(ctx->fds_out[0].revents & POLLOUT)) {
+        return false;
+    }
+    return true;
+}

--- a/src/apps/socket/xdp/xdpsock_app.h
+++ b/src/apps/socket/xdp/xdpsock_app.h
@@ -76,9 +76,10 @@ typedef struct xdpsock_context_t {
 } __attribute__((packed)) xdpsock_context_t;
 
 /* Public. */
-
 xdpsock_context_t* init_xdp(const char *if_name);
-size_t receive_packet(const xdpsock_context_t *ctx, char *data);
-void transmit_packet(const xdpsock_context_t *ctx, const char *pkt_data, size_t len);
-bool can_transmit(const xdpsock_context_t *ctx);
 bool can_receive(const xdpsock_context_t *ctx);
+bool can_transmit(const xdpsock_context_t *ctx);
+size_t receive_packet(const xdpsock_context_t *ctx, void* packet);
+size_t receive_packets(const xdpsock_context_t *ctx, void** packets, size_t batch_size);
+void transmit_packet(const xdpsock_context_t *ctx, void* packet);
+void transmit_packets(const xdpsock_context_t *ctx, void** packets, size_t batch_size);

--- a/src/apps/socket/xdp/xdpsock_app.h
+++ b/src/apps/socket/xdp/xdpsock_app.h
@@ -1,0 +1,84 @@
+// Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
+typedef uint64_t u64;
+typedef uint32_t u32;
+
+enum benchmark_type {
+    BENCH_RXDROP = 0,
+    BENCH_TXONLY = 1,
+};
+
+struct xdp_umem_uqueue {
+    u32 cached_prod;
+    u32 cached_cons;
+    u32 mask;
+    u32 size;
+    u32 *producer;
+    u32 *consumer;
+    u64 *ring;
+    void *map;
+};
+
+struct xdp_umem {
+    char *frames;
+    struct xdp_umem_uqueue fq;
+    struct xdp_umem_uqueue cq;
+    int fd;
+};
+
+struct xdp_uqueue {
+    u32 cached_prod;
+    u32 cached_cons;
+    u32 mask;
+    u32 size;
+    u32 *producer;
+    u32 *consumer;
+    struct xdp_desc *ring;
+    void *map;
+};
+
+struct xdpsock {
+    struct xdp_uqueue rx;
+    struct xdp_uqueue tx;
+    int sfd;
+    struct xdp_umem *umem;
+    u32 outstanding_tx;
+    unsigned long rx_npkts;
+    unsigned long tx_npkts;
+    unsigned long prev_rx_npkts;
+    unsigned long prev_tx_npkts;
+};
+
+typedef struct packet_t {
+    char* data;
+    size_t len;
+} __attribute__((packed)) packet_t;
+
+typedef struct xdpsock_options_t {
+    enum benchmark_type opt_bench;
+    u32 opt_xdp_flags;
+    const char *opt_if;
+    int opt_ifindex;
+    int opt_queue;
+    int opt_poll;
+    int opt_shared_packet_buffer;
+    int opt_interval;
+    u32 opt_xdp_bind_flags;
+} xdpsock_options_t;
+
+typedef struct xdpsock_context_t {
+	struct xdpsock *xsks[4];  // MAX_SOCKS.
+	int num_socks;
+	int nfds_in, nfds_out;
+	struct pollfd *fds_in;
+	struct pollfd *fds_out;
+	const xdpsock_options_t *opts;
+} __attribute__((packed)) xdpsock_context_t;
+
+/* Public. */
+
+xdpsock_context_t* init_xdp(const char *if_name);
+size_t receive_packet(const xdpsock_context_t *ctx, char *data);
+void transmit_packet(const xdpsock_context_t *ctx, const char *pkt_data, size_t len);
+bool can_transmit(const xdpsock_context_t *ctx);
+bool can_receive(const xdpsock_context_t *ctx);

--- a/src/apps/socket/xdp/xdpsock_app.h
+++ b/src/apps/socket/xdp/xdpsock_app.h
@@ -67,12 +67,12 @@ typedef struct xdpsock_options_t {
 } xdpsock_options_t;
 
 typedef struct xdpsock_context_t {
-	struct xdpsock *xsks[4];  // MAX_SOCKS.
-	int num_socks;
-	int nfds_in, nfds_out;
-	struct pollfd *fds_in;
-	struct pollfd *fds_out;
-	const xdpsock_options_t *opts;
+    struct xdpsock *xsks[4];  // MAX_SOCKS.
+    int num_socks;
+    int nfds_in, nfds_out;
+    struct pollfd *fds_in;
+    struct pollfd *fds_out;
+    const xdpsock_options_t *opts;
 } __attribute__((packed)) xdpsock_context_t;
 
 /* Public. */

--- a/src/apps/socket/xdp/xdpsock_kern.c
+++ b/src/apps/socket/xdp/xdpsock_kern.c
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: GPL-2.0
+
+#define KBUILD_MODNAME "foo"
+#include <uapi/linux/bpf.h>
+#include "bpf_helpers.h"
+
+struct bpf_map_def SEC("maps") qidconf_map = {
+    .type        = BPF_MAP_TYPE_ARRAY,
+    .key_size    = sizeof(int),
+    .value_size  = sizeof(int),
+    .max_entries = 1,
+};
+
+struct bpf_map_def SEC("maps") xsks_map = {
+    .type = BPF_MAP_TYPE_XSKMAP,
+    .key_size = sizeof(int),
+    .value_size = sizeof(int),
+    .max_entries = 4,
+};
+
+struct bpf_map_def SEC("maps") rr_map = {
+    .type = BPF_MAP_TYPE_PERCPU_ARRAY,
+    .key_size = sizeof(int),
+    .value_size = sizeof(unsigned int),
+    .max_entries = 1,
+};
+
+SEC("xdp_sock")
+int xdp_sock_prog(struct xdp_md *ctx)
+{
+    int *qidconf, key = 0, idx;
+
+    qidconf = bpf_map_lookup_elem(&qidconf_map, &key);
+    if (!qidconf)
+        return XDP_ABORTED;
+
+    if (*qidconf != ctx->rx_queue_index)
+        return XDP_PASS;
+
+#if RR_LB /* NB! RR_LB is configured in xdpsock.h */
+    unsigned int *rr;
+    rr = bpf_map_lookup_elem(&rr_map, &key);
+    if (!rr)
+        return XDP_ABORTED;
+
+    *rr = (*rr + 1) & (MAX_SOCKS - 1);
+    idx = *rr;
+#else
+    idx = 0;
+#endif
+
+    return bpf_redirect_map(&xsks_map, idx, 0);
+}
+
+char _license[] SEC("license") = "GPL";

--- a/src/program/snabbmark/README
+++ b/src/program/snabbmark/README
@@ -37,6 +37,47 @@ Usage:
     Example usage with 10 million packets, packet size 128 bytes:
     sudo SNABB_PCI0="0000:02:00.0"  SNABB_PCI1="0000:03:00.0" ./snabb snabbmark intel1g 10e6 128
 
+  snabbmark intel10g <npackets> <packet-size> [<timeout>]
+    Send the given number of packets through a Intel 82599 NIC. The test
+    assumes that the two Intel NICs are connected back-to-back.
+
+    The optional <timeout> parameter can be used to specify a timeout in
+    seconds. If supplied the benchmark run for no longer than <timeout>
+    seconds.
+
+    Uses SNABB_PCI0 and SNABB_PCI1.
+
+    Example usage with 10 million packets, packet size 128 bytes:
+    sudo SNABB_PCI0="0000:02:00.0"  SNABB_PCI1="0000:03:00.0" ./snabb snabbmark intel10g 10e6 128
+
+  snabbmark rawsocket <npackets> <packet-size> [<timeout>]
+    Send the given number of packets through an OS managed network interface
+    using a raw socket. The test assumes that the two Intel NICs are connected
+    back-to-back.
+
+    The optional <timeout> parameter can be used to specify a timeout in
+    seconds. If supplied the benchmark run for no longer than <timeout>
+    seconds.
+
+    Uses SNABB_IFNAME0 and SNABB_IFNAME1.
+
+    Example usage with 10 million packets, packet size 128 bytes:
+    sudo SNABB_IFNAME0=ens2f0  SNABB_IFNAME1=ens3f0 ./snabb snabbmark rawsocket 10e6 128
+
+  snabbmark xdpsocket <npackets> <packet-size> [<timeout>]
+    Send the given number of packets through an OS managed network interface
+    using a XDP socket. The test assumes that the two Intel NICs are connected
+    back-to-back.
+
+    The optional <timeout> parameter can be used to specify a timeout in
+    seconds. If supplied the benchmark run for no longer than <timeout>
+    seconds.
+
+    Uses SNABB_IFNAME0 and SNABB_IFNAME1.
+
+    Example usage with 10 million packets, packet size 128 bytes:
+    sudo SNABB_IFNAME0=ens2f0  SNABB_IFNAME1=ens3f0 ./snabb snabbmark xdpsocket 10e6 128
+
   snabbmark esp <npackets> <packet-size> [<mode>] [<direction>] [<profile>]
     Benchmark ESP encapsulating or decapsulatiing <npackets> of
     <packet-size>. <mode> can be either "transport" (default) or "tunnel",

--- a/src/program/snabbmark/snabbmark.lua
+++ b/src/program/snabbmark/snabbmark.lua
@@ -507,12 +507,7 @@ function intel10g (npackets, packet_size, timeout)
    end
 end
 
-function rawsocket (npackets, packet_size, timeout)
-   local driver = require("apps.socket.raw").RawSocket
-   npackets = tonumber(npackets) or 10e3
-   packet_size = tonumber(packet_size) or 64
-   timeout = tonumber(timeout) or 1000
-
+local function socket (driver, npackets, packet_size, timeout)
    local ifname0 = lib.getenv("SNABB_IFNAME0") or lib.getenv("SNABB_PCI0")
    if not ifname0 then
       skip("SNABB_IFNAME0 not set.")
@@ -590,6 +585,13 @@ function rawsocket (npackets, packet_size, timeout)
    end
 end
 
+function rawsocket (npackets, packet_size, timeout)
+   local driver = require("apps.socket.raw").RawSocket
+   npackets = tonumber(npackets) or 10e3
+   packet_size = tonumber(packet_size) or 64
+   timeout = tonumber(timeout) or 1000
+   socket(driver, npackets, packet_size, timeout)
+end
 
 function esp (npackets, packet_size, mode, direction)
    local esp = require("lib.ipsec.esp")

--- a/src/program/snabbmark/snabbmark.lua
+++ b/src/program/snabbmark/snabbmark.lua
@@ -2,13 +2,16 @@
 
 module(..., package.seeall)
 
+local basic_apps = require("apps.basic.basic_apps")
+local datagram = require("lib.protocol.datagram")
+local ethernet = require("lib.protocol.ethernet")
+local ffi = require("ffi")
+local ipv4 = require("lib.protocol.ipv4")
+local lib = require("core.lib")
+local pci = require("lib.hardware.pci")
+local udp = require("lib.protocol.udp")
 local usage = require("program.snabbmark.README_inc")
 
-local basic_apps = require("apps.basic.basic_apps")
-local pci           = require("lib.hardware.pci")
-local ethernet      = require("lib.protocol.ethernet")
-local lib = require("core.lib")
-local ffi = require("ffi")
 local C = ffi.C
 
 function run (args)
@@ -21,6 +24,8 @@ function run (args)
       solarflare(unpack(args))
    elseif command == 'intel1g' and #args >= 2 and #args <= 3 then
       intel1g(unpack(args))
+   elseif command == 'rawsocket' and #args ~= 3 then
+      rawsocket(unpack(args))
    elseif command == 'esp' and #args >= 2 then
       esp(unpack(args))
    elseif command == 'hash' and #args <= 1 then
@@ -334,6 +339,161 @@ receive_device.interface= "rx1GE"
    end
 end
 
+local function get_macaddr (iface)
+   local fd = io.open("/sys/class/net/"..iface.."/address", "rt")
+   if not fd then return nil end
+   local ret = fd:read("*all")
+   ret = ret:match("[%x:]+")
+   fd:close()
+   return ret
+end
+
+local function w (...) io.stdout:write(...) end
+
+local function skip (...)
+   w(...) w("\n")
+   main.exit(engine.test_skipped_code)
+end
+
+local function stats (txpackets, rxpackets, runtime, packet_size)
+   local total = txpackets / 1e6
+   local mpps = txpackets / runtime / 1e6
+   local gbps = ((txpackets * packet_size * 8) / runtime) / (1024*1024*1024)
+   local loss = (txpackets - rxpackets) * 100 / txpackets
+   print()
+   print(("Processed %.1f million packets in %.2f seconds (rate: %.1f Mpps, "..
+          "%.2f Gbit/s, %.2f %% packet loss)."):format(total, runtime, mpps,
+                                                       gbps, loss))
+end
+
+local function build_packet (args)
+   local ETHER_PROTO_IPV4 = 0x0800
+   local PROTO_UDP = 0x11
+
+   local size = args.size or 64
+   local src_mac = args.src_mac or "00:00:5E:00:00:01"
+   local dst_mac = args.dst_mac or "00:00:5E:00:00:02"
+
+   local dgram = datagram:new()
+
+   local eth_h = ethernet:new({dst = ethernet:pton(dst_mac),
+                               src = ethernet:pton(src_mac),
+                               type = ETHER_PROTO_IPV4})
+   local ip_h = ipv4:new({dst = ipv4:pton("192.0.2.254"),
+                          src = ipv4:pton("192.0.2.1"),
+                          protocol = PROTO_UDP,
+                          ttl = 64})
+   local udp_h = udp:new({src_port = math.random(65535),
+                          dst_port = math.random(65535)})
+
+   local total_length = size - 14
+   local length = total_length - 20
+
+   ip_h:total_length(total_length)
+   udp_h:length(length)
+
+   ip_h:checksum()
+
+   local payload_length = length - 8
+   local payload = ffi.new("uint8_t[?]", payload_length)
+   local count = 0
+   for i=0,payload_length-1 do
+      payload[i] = count
+      count = count + 1
+   end
+
+   dgram:push_raw(payload, payload_length)
+   dgram:push(udp_h)
+   dgram:push(ip_h)
+   dgram:push(eth_h)
+
+   return dgram:packet()
+end
+
+function rawsocket (npackets, packet_size, timeout)
+   local driver = require("apps.socket.raw").RawSocket
+   npackets = tonumber(npackets) or 10e3
+   packet_size = tonumber(packet_size) or 64
+   timeout = tonumber(timeout) or 1000
+
+   local ifname0 = lib.getenv("SNABB_IFNAME0") or lib.getenv("SNABB_PCI0")
+   if not ifname0 then
+      skip("SNABB_IFNAME0 not set.")
+   end
+   local ifname1 = lib.getenv("SNABB_IFNAME1") or lib.getenv("SNABB_PCI1")
+   if not ifname1 then
+      skip("SNABB_IFNAME1 not set.")
+   end
+
+   -- Topology:
+   -- Source -> Socket NIC#1 => Socket NIC#2 -> Sink
+
+   -- Initialize apps.
+   local c = config.new()
+
+   config.app(c, "source", Source)
+   config.app(c, "tee", basic_apps.Tee)
+   config.app(c, ifname0, driver, ifname0)
+   config.app(c, ifname1, driver, ifname1)
+   config.app(c, "sink", basic_apps.Sink)
+
+   -- Set links.
+   config.link(c, "source.tx -> tee.rx")
+   config.link(c, "tee.tx -> "..ifname0..".rx")
+   config.link(c, ifname1..".tx -> sink.input")
+
+   -- Set engine.
+   engine.configure(c)
+   engine.Hz = false
+
+   -- Adjust packet.
+   local src_mac = get_macaddr(ifname0) or "00:00:5E:00:00:01"
+   local dst_mac = get_macaddr(ifname1) or "00:00:5E:00:00:02"
+   local pkt = build_packet({src_mac = src_mac,
+                             dst_mac = dst_mac,
+                             size = packet_size})
+   engine.app_table.source:set_packet(pkt)
+
+   -- Print info.
+   w(("Packets: %d; "):format(npackets))
+   w(("Packet Size: %d; "):format(packet_size))
+   w(("Timeout: %d"):format(timeout))
+   print("")
+
+   w(("Sending through %s (%s); "):format(ifname0, src_mac))
+   w(("Receiving through %s (%s)"):format(ifname1, dst_mac))
+   print("")
+
+   -- Run.
+   local start = C.get_monotonic_time()
+   timer.activate(timer.new("null", function () end, 1e6, 'repeating'))
+   local txpackets = 0
+   local n, n_max = 0, timeout and timeout * 100
+   while txpackets < npackets and n < n_max do
+      txpackets = link.stats(engine.app_table.source.output.tx).txpackets
+      engine.main({duration = 0.01, no_report = true})
+      n = n + 1
+   end
+   local finish = C.get_monotonic_time()
+   local runtime = finish - start
+   local rxpackets = link.stats(engine.app_table.sink.input.input).rxpackets
+   if rxpackets >= txpackets then
+      rxpackets = txpackets
+   end
+
+   -- Print report if any.
+   engine.report()
+
+   -- Print stats.
+   stats(txpackets, rxpackets, runtime, packet_size)
+
+   if txpackets < npackets then
+      print(("Packets lost. Rx: %d. Lost: %d"):format(txpackets, npackets - txpackets))
+      main.exit(1)
+   end
+end
+
+
 function esp (npackets, packet_size, mode, direction)
    local esp = require("lib.ipsec.esp")
    local ethernet = require("lib.protocol.ethernet")
@@ -618,18 +778,20 @@ end
 function selftest ()
    local function test_source ()
       local source = Source:new()
-      local src_mac = ethernet:pton("02:00:00:00:00:01")
-      local dst_mac = ethernet:pton("02:00:00:00:00:01")
+      local src_mac = ethernet:pton("00:00:5E:00:00:01")
+      local dst_mac = ethernet:pton("00:00:5E:00:00:02")
       source:set_packet_addresses(src_mac, dst_mac)
       source:set_packet_size(128)
-      local pkt = packet.from_string(lib.hexundump([[
-         02:00:00:00:00:01 02:00:00:00:00:02 08 00 45 00
-         3c fd fe 9e 7f 71 ec b1 d7 98 3a c0 08 00 45 00
-         00 2e 00 00 00 00 40 11 88 97 05 08 07 08 c8 14
-         1e 04 10 92 10 92 00 1a 6d a3 34 33 1f 69 40 6b
-         54 59 b6 14 2d 11 44 bf af d9 be aa
-      ]], 60))
+   end
+   local function test_set_packet ()
+      local source = Source:new()
+      local pkt = build_packet({size = 550,
+                                src_mac = "00:00:5E:00:00:01",
+                                dst_mac = "00:00:5E:00:00:02"})
       source:set_packet(pkt)
    end
+   print("selftest:")
    test_source()
+   test_set_packet()
+   print("ok")
 end

--- a/src/program/snabbmark/snabbmark.lua
+++ b/src/program/snabbmark/snabbmark.lua
@@ -28,6 +28,8 @@ function run (args)
       intel10g(unpack(args))
    elseif command == 'rawsocket' and #args ~= 3 then
       rawsocket(unpack(args))
+   elseif command == 'xdpsocket' and #args ~= 3 then
+      xdpsocket(unpack(args))
    elseif command == 'esp' and #args >= 2 then
       esp(unpack(args))
    elseif command == 'hash' and #args <= 1 then
@@ -587,6 +589,14 @@ end
 
 function rawsocket (npackets, packet_size, timeout)
    local driver = require("apps.socket.raw").RawSocket
+   npackets = tonumber(npackets) or 10e3
+   packet_size = tonumber(packet_size) or 64
+   timeout = tonumber(timeout) or 1000
+   socket(driver, npackets, packet_size, timeout)
+end
+
+function xdpsocket (npackets, packet_size, timeout)
+   local driver = require("apps.socket.xdp.xdp").XDPSocket
    npackets = tonumber(npackets) or 10e3
    packet_size = tonumber(packet_size) or 64
    timeout = tonumber(timeout) or 1000

--- a/src/program/snabbmark/snabbmark.lua
+++ b/src/program/snabbmark/snabbmark.lua
@@ -24,6 +24,8 @@ function run (args)
       solarflare(unpack(args))
    elseif command == 'intel1g' and #args >= 2 and #args <= 3 then
       intel1g(unpack(args))
+   elseif command == 'intel10g' and #args >= 2 and #args <= 3 then
+      intel10g(unpack(args))
    elseif command == 'rawsocket' and #args ~= 3 then
       rawsocket(unpack(args))
    elseif command == 'esp' and #args >= 2 then
@@ -408,6 +410,101 @@ local function build_packet (args)
    dgram:push(eth_h)
 
    return dgram:packet()
+end
+
+function intel10g (npackets, packet_size, timeout)
+   local function load_driver ()
+      return require("apps.intel_mp.intel_mp").Intel
+   end
+   local function device_info (pciaddr)
+      pciaddr = assert(tostring(pciaddr), "Invalid pciaddr: "..pciaddr)
+      local device = pciaddr and pci.device_info(pciaddr)
+      if not (device or device.driver == 'apps.intel_mp.intel_mp') then
+         skip("SNABB_PCI[0|1] not set, or not suitable Intel 10G.")
+      end
+      return device
+   end
+
+   local pciaddr0 = lib.getenv("SNABB_PCI0")
+   if not pciaddr0 then
+      skip("SNABB_PCI0 not set")
+   end
+   local pciaddr1 = lib.getenv("SNABB_PCI1")
+   if not pciaddr1 then
+      skip("SNABB_PCI1 not set")
+   end
+   local status, Intel10gNic = pcall(load_driver)
+   if not status then
+      skip("Could not find driver: "..Intel10gNic)
+   end
+
+   npackets = tonumber(npackets) or error("Invalid number of packets: " .. npackets)
+   packet_size = tonumber(packet_size) or error("Invalid packet size: " .. packet_size)
+   timeout = tonumber(timeout) or 1000
+
+   local nic0 = device_info(pciaddr0)
+   local nic1 = device_info(pciaddr1)
+
+   nic0.interface = "nic0"
+   nic1.interface = "nic1"
+
+   w(("Sending through %s (%s); "):format(nic0.interface, nic0.pciaddress))
+   w(("Receiving through %s (%s)"):format(nic1.interface, nic1.pciaddress))
+   print("")
+
+   -- Topology:
+   -- Source -> Intel10g NIC#1 => Intel10g NIC#2 -> Sink
+
+   -- Initialize apps.
+   local c = config.new()
+   config.app(c, "source", Source)
+   config.app(c, "tee", basic_apps.Tee)
+   config.app(c, "sink", basic_apps.Sink)
+   config.app(c, nic0.interface, Intel10gNic, {
+      pciaddr = pciaddr0,
+   })
+   config.app(c, nic1.interface, Intel10gNic, {
+      pciaddr = pciaddr1,
+   })
+   config.app(c, "sink", basic_apps.Sink)
+
+   -- Set links.
+   config.link(c, "source.tx -> tee.rx")
+   config.link(c, "tee.tx -> "..nic0.interface.."."..nic0.rx)
+   config.link(c, nic1.interface.."."..nic1.tx.." -> sink.rx")
+
+   -- Set engine.
+   engine.configure(c)
+   engine.Hz = false
+
+   -- Adjust packet.
+   local pkt = build_packet({size = packet_size})
+   engine.app_table.source:set_packet(pkt)
+
+   local start = C.get_monotonic_time()
+   local txpackets = 0
+   local n, n_max = 0, timeout and timeout * 100
+   while txpackets < npackets and n < n_max do
+      engine.main({duration = 0.01, no_report = true})
+      txpackets = link.stats(engine.app_table[nic0.interface].input[nic0.rx]).rxpackets
+      n = n + 1
+   end
+   local rxpackets = link.stats(engine.app_table.sink.input.rx).rxpackets
+   local finish = C.get_monotonic_time()
+   local runtime = finish - start
+   if rxpackets >= txpackets then
+      rxpackets = txpackets
+   end
+
+   engine.report()
+
+   -- Print stats.
+   stats(txpackets, rxpackets, runtime, packet_size)
+
+   if txpackets < npackets then
+      print("Packets lost. Test failed!")
+      main.exit(1)
+   end
 end
 
 function rawsocket (npackets, packet_size, timeout)


### PR DESCRIPTION
This has been taking longer than I expected, so I'd like to share the work done so far. At this point I have an AF_XDP app working. Here are some benchmarks (Load: 10M packets; packet size: 550 byte):

• Intel10G snabbmark:

```
$ sudo SNABB_PCI0=0000:82:00.0 SNABB_PCI1=0000:02:00.0 ./snabb snabbmark intel10g 10e6 550
No PMU available: single core cpu affinity required
Sending through nic0 (82:00.0); Receiving through nic1 (02:00.0)

Processed 10.0 million packets in 4.78 seconds (rate: 2.1 Mpps, 8.58 Gbit/s, 0.04 % packet loss).
```

• XDPSockApp (AF_XDP) snabbmark:

```
$ sudo SNABB_PCI0=ens6f0 SNABB_PCI1=ens2f0 ./snabb snabbmark xdpsocket 10e6 550
No PMU available: single core cpu affinity required
Packets: 10000000; Packet Size: 550; Timeout: 1000
Sending through ens6f0 (90:e2:ba:ac:b9:b4); Receiving through ens2f0 (90:e2:ba:ac:b9:48)

Processed 10.0 million packets in 14.87 seconds (rate: 0.7 Mpps, 2.76 Gbit/s, 0.00 % packet loss).
```

• RawSocketApp (AF_PACKET) snabbmark:

```
$ sudo SNABB_PCI0=ens6f0 SNABB_PCI1=ens2f0 ./snabb snabbmark rawsocket 10e6 550
No PMU available: single core cpu affinity required
Packets: 10000000; Packet Size: 550; Timeout: 1000
Sending through ens6f0 (90:e2:ba:ac:b9:b4); Receiving through ens2f0 (90:e2:ba:ac:b9:48)

Processed 10.0 million packets in 117.35 seconds (rate: 0.1 Mpps, 0.35 Gbit/s, 6.79 % packet loss).
```

The AF_XDP app is way much faster than the traditional RawSocket app (8 times faster), but it's still slower than the native Intel10G driver (4 times slower). I think there's room for improving the performance. The code of the app is based in the Linux kernel AF_XDP example (https://github.com/torvalds/linux/blob/master/samples/bpf/xdpsock_user.c). This example reads and writes packets in batches with a BATCH_SIZE of 16. However in the app, to simplify the code and make it work, I used a BATCH_SIZE of 1. Also, the Linux kernel example uses 4 sockets whereas the Snabb AF_XDP app only opens one socket.

Being able to send and receive packets in batches plus using several sockets underneath should definitely help to improve the performance. Once that is done, likely rewriting as much code of the app as possible in Lua may help to improve performance too (since more code could be trace jitted by RaptorJIT).

I'm currently working in increasing the BATCH_SIZE.

Note: To use the AF_XDP app is necessary to use a Linux kernel >=4.18 (built with AF_XDP support). At this moment the app also depends on the Linux kernel source code. So to build Snabb with AF_XDP enabled do: `LINUX_SOURCE_DIR=/path/to/linux/source make -j`.