### PR TITLE
core.app: use implict pull/push loops in breathe()

### DIFF
--- a/src/core/app.lua
+++ b/src/core/app.lua
@@ -523,23 +523,35 @@ function breathe ()
    -- Restart: restart dead apps
    restart_dead_apps()
    -- Inhale: pull work into the app network
-   for i = 1, #breathe_pull_order do
+   local i = 1
+   ::PULL_LOOP::
+   do
+      if i > #breathe_pull_order then goto PULL_EXIT end
       local app = breathe_pull_order[i]
       if app.pull and not app.dead then
          zone(app.zone)
          with_restart(app, app.pull)
          zone()
       end
+      i = i+1
+      goto PULL_LOOP
    end
+   ::PULL_EXIT::
    -- Exhale: push work out through the app network
-   for i = 1, #breathe_push_order do
+   i = 1
+   ::PUSH_LOOP::
+   do
+      if i > #breathe_push_order then goto PUSH_EXIT end
       local app = breathe_push_order[i]
       if app.push and not app.dead then
          zone(app.zone)
          with_restart(app, app.push)
          zone()
       end
+      i = i+1
+      goto PUSH_LOOP
    end
+   ::PUSH_EXIT::
    counter.add(breaths)
    -- Commit counters and rebalance freelists at a reasonable frequency
    if counter.read(breaths) % 100 == 0 then


### PR DESCRIPTION
The goal of this change is to simplify the loop structure of the Snabb engine to make it more likely that the compiler can find and optimize the packet-processing loops. In particular, it can help in the situation when the program starts in an idle state with no packets to process. In that case, we want to avoid that traces compiled for this initial workload have a negative impact on the creation of traces for the actual (non-idle) workload.

See https://github.com/snabbco/snabb/issues/1414 for an analysis with a simplified engine.

I would like to encourage people to try this out with their own Snabb programs and provide feedback.