### PR TITLE
`ipfix probe` fix

### DIFF
--- a/src/program/ipfix/probe/probe.lua
+++ b/src/program/ipfix/probe/probe.lua
@@ -176,7 +176,7 @@ function run (args)
    local done
    if not duration then
       done = function ()
-         return engine.app_table.source.done
+         return engine.app_table["in"].done
       end
    end
 


### PR DESCRIPTION
Fixes a bug in `snabb ipfix probe` that would crash it when the duration flag wasn't provided.