### PR TITLE
Fix mmap usage in SIGSEGV handler (see issue #1429)

### DIFF
--- a/src/core/memory.c
+++ b/src/core/memory.c
@@ -73,7 +73,7 @@ static void memory_sigsegv_handler(int sig, siginfo_t *si, void *uc)
   }
   // Map the memory at the expected address
   if (mmap((void *)(page | TAG), st.st_size, PROT_READ|PROT_WRITE,
-           MAP_SHARED|MAP_FIXED|MAP_HUGETLB, fd, 0) == MAP_FAILED) {
+           MAP_SHARED|MAP_FIXED, fd, 0) == MAP_FAILED) {
     goto punt;
   }
   close(fd);


### PR DESCRIPTION
This addresses a bug reported in issue #1429. Long story short: RHEL does not like the redundant mmap flags we were passing.

See also: https://github.com/snabbco/snabb/pull/1373 (73de63b)

Fixes: #1429