### PR TITLE
Unbind PCI devices before mapping their memory (take two)

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -1016,6 +1016,7 @@ Groups of Snabb processes each have the following special properties:
   mastering (DMA) is disabled upon termination before any DMA memory
   is returned to the kernel. This prevents "dangling" DMA requests
   from corrupting memory that has been freed and reused.
+  See [lib.hardware.pci](#pci-lib.hardware.pci) for details.
 
 The `core.worker` API functions are available in the main process only:
 

--- a/src/apps/intel/intel10g.lua
+++ b/src/apps/intel/intel10g.lua
@@ -91,9 +91,10 @@ function new_sf (conf)
 end
 
 function M_sf:open ()
+   self.fd = pci.open_pci_resource_locked(self.pciaddress, 0)
    pci.unbind_device_from_linux(self.pciaddress)
    pci.set_bus_master(self.pciaddress, true)
-   self.base, self.fd = pci.map_pci_memory_locked(self.pciaddress, 0)
+   self.base = pci.map_pci_memory(self.fd)
    register.define(config_registers_desc, self.r, self.base)
    register.define(transmit_registers_desc, self.r, self.base)
    register.define(receive_registers_desc, self.r, self.base)
@@ -497,9 +498,10 @@ function new_pf (conf)
 end
 
 function M_pf:open ()
+   self.fd = pci.open_pci_resource_locked(self.pciaddress, 0)
    pci.unbind_device_from_linux(self.pciaddress)
    pci.set_bus_master(self.pciaddress, true)
-   self.base, self.fd = pci.map_pci_memory_locked(self.pciaddress, 0)
+   self.base = pci.map_pci_memory(self.fd)
    register.define(config_registers_desc, self.r, self.base)
    register.define_array(switch_config_registers_desc, self.r, self.base)
    register.define_array(packet_filter_desc, self.r, self.base)

--- a/src/apps/intel_mp/intel_mp.lua
+++ b/src/apps/intel_mp/intel_mp.lua
@@ -400,7 +400,6 @@ function Intel:new (conf)
       -- the device, loads registers, initializes it before sharing the lock.
       pci.unbind_device_from_linux(self.pciaddress)
       pci.set_bus_master(self.pciaddress, true)
-      pci.disable_bus_master_cleanup(self.pciaddress)
       self.base = pci.map_pci_memory(self.fd)
       self:load_registers(byid.registers)
       self:init()

--- a/src/lib/hardware/README.md
+++ b/src/lib/hardware/README.md
@@ -5,14 +5,16 @@ operations on PCI devices on Linux. In order to drive a PCI device using
 [Direct memory access (DMA)](https://en.wikipedia.org/wiki/Direct_memory_access)
 one must:
 
-1. Unbind the PCI device using `pci.unbind_device_from_linux`.
-2. Enable PCI bus mastering for device using `pci.set_bus_master` in
+1. Open the PCI device using `pci.open_pci_resource_locked` or
+   `pci.open_pci_resource_unlocked`.
+2. Unbind the PCI device using `pci.unbind_device_from_linux`.
+3. Enable PCI bus mastering for device using `pci.set_bus_master` in
    order to enable DMA.
-3. Memory map PCI device configuration space using `pci.map_pci_memory`.
-4. Control the PCI device by manipulating the memory referenced by the
+4. Memory map PCI device configuration space using `pci.map_pci_memory`.
+5. Control the PCI device by manipulating the memory referenced by the
    pointer returned by `pci.map_pci_memory`.
-5. Disable PCI bus master for device using `pci.set_bus_master`.
-6. Unmap PCI device configuration space using `pci.close_pci_resource`.
+6. Disable PCI bus master for device using `pci.set_bus_master`.
+7. Unmap PCI device configuration space using `pci.close_pci_resource`.
 
 The correct ordering of these steps is absolutely critical.
 
@@ -74,15 +76,20 @@ Enables or disables PCI bus mastering for device identified by
 value. PCI bus mastering must be enabled in order to perform DMA on the
 PCI device.
 
-— Function **pci.map_pci_memory_unlocked** *pciaddress*, *n*
-— Function **pci.map_pci_memory_locked** *pciaddress*, *n*
+— Function **pci.open_pci_resource_unlocked** *pciaddress*, *n*
+— Function **pci.open_pci_resource_locked** *pciaddress*, *n*
 
-Memory maps configuration space *n* of PCI device identified by
-*pciaddress*. Returns a pointer to the memory mapped region and a file
-descriptor of the opened sysfs resource file. PCI bus mastering must be
-enabled on the device identified by *pciaddress* before calling this function.
-The 2 variants indicate if the underlying memory mapped file should be
+Opens configuration space *n* of PCI device identified by *pciaddress*. Returns
+a file descriptor of the opened sysfs resource file.
+
+The two variants indicate if the underlying memory mapped file should be
 exclusively `flocked` or not.
+
+— Function **pci.map_pci_memory** *fd*
+
+Memory maps configuration space of PCI device identified by *fd*. Returns a
+pointer to the memory mapped region. The device must be unbound from linux and
+PCI bus mastering must be enabled on the device before calling this function.
 
 — Function **pci.close_pci_resource** *file_descriptor*, *pointer*
 

--- a/src/lib/hardware/README.md
+++ b/src/lib/hardware/README.md
@@ -18,6 +18,13 @@ one must:
 
 The correct ordering of these steps is absolutely critical.
 
+Users of `lib.hardware.pci` can rely on steps 6/7 being performed automatically
+in the event unorderly shutdown. However, to ensure that bus mastering for the
+PCI device in use is not disabled due to another worker’s shutdown (see
+`core.worker`) they must keep a `flock(2)` on resource 0. This can be achieved
+either implicitly via `pci.open_pci_resource_locked` or by manual calls to
+`flock(2)`.
+
 
 — Variable **pci.devices**
 


### PR DESCRIPTION
Make sure PCI devices are unbound before attempting to map their memory in intel_mp. This a second take on #1296:

> Since Linux 4.5, devices that are bound to a kernel driver can't have
their memory mapped by userspace under the default configuration of
CONFIG_IO_STRICT_DEVMEM=y.

Why do I think we avoid races this time?  Basically what we have during device initialization is a state machine `FREE -> INIT -> SHARED`.  Master will acquire the exclusive lock, unbind the device, enable bus mastering, and then map device memory and do the init before allowing the lock to be shared (`INIT` state). Other processes will wait for the shared lock and map device memory only after master has finished unbinding and initialization (`SHARED` state).

During looking at this I also stumbled upon the fact that intel_mp bypassed the `lib.hardware.pci` shutdown safety routine, and ended up with https://github.com/snabbco/snabb/commit/af820842ee9618114d8983f42684e7e611a92eeb.

One remaining question that came upon me is if we have a strategy for when two unrelated Snabb process try to grab the same NIC?

Testing, feedback, review would be appreciated @alexandergall @wingo @petebristow 

Resolves: #1286 

Supersedes: #1296 