### PR TITLE
Picky hexundump

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -816,9 +816,12 @@ end
 
 Returns hexadecimal string for bytes in *string*.
 
-— Function **lib.hexundump** *hexstring*
+— Function **lib.hexundump** *hexstring*, *n*, *error* 
 
-Returns byte string for *hexstring*.
+Returns string of *n* bytes for *hexstring*. Throws an error if less than *n*
+hex-encoded bytes could be parsed unless *error* is `false`.
+
+*Error* is optional and can be the error message to throw.
 
 — Function **lib.comma_value** *n*
 

--- a/src/apps/keyed_ipv6_tunnel/tunnel.lua
+++ b/src/apps/keyed_ipv6_tunnel/tunnel.lua
@@ -137,7 +137,7 @@ function SimpleKeyedTunnel:new (conf)
       )
    local header = header_array_ctype(HEADER_SIZE)
    ffi.copy(header, header_template, HEADER_SIZE)
-   local local_cookie = lib.hexundump(conf.local_cookie, 8)
+   local local_cookie = lib.hexundump(conf.local_cookie, 8, false)
    ffi.copy(
          header + COOKIE_OFFSET,
          local_cookie,
@@ -157,7 +157,9 @@ function SimpleKeyedTunnel:new (conf)
    local remote_address = ffi.cast(paddress_ctype, header + DST_IP_OFFSET)
    local local_address = ffi.cast(paddress_ctype, header + SRC_IP_OFFSET)
 
-   local remote_cookie = ffi.cast(pcookie_ctype, lib.hexundump(conf.remote_cookie, 8))
+   local remote_cookie_s = lib.hexundump(conf.remote_cookie, 8, false)
+   local remote_cookie = ffi.new(cookie_ctype)
+   ffi.copy(remote_cookie, remote_cookie_s, #remote_cookie_s)
 
    if conf.local_session then
       local psession = ffi.cast(psession_id_ctype, header + SESSION_ID_OFFSET)

--- a/src/core/lib.lua
+++ b/src/core/lib.lua
@@ -200,13 +200,16 @@ function hexdump(s)
    return string.format(frm, s:byte(1, #s))
 end
 
-function hexundump(h, n)
+function hexundump(h, n, error)
    local buf = ffi.new('char[?]', n)
    local i = 0
-   for b in h:gmatch('%x%x') do
+   for b in h:gmatch('%s*(%x%x)') do
       buf[i] = tonumber(b, 16)
       i = i+1
       if i >= n then break end
+   end
+   if error ~= false then
+      assert(i == n, error or "Wanted "..n.." bytes, but only got "..i)
    end
    return ffi.string(buf, n)
 end


### PR DESCRIPTION
A few changes to `lib.hexundump`:

 - accept white space between bytes
 - by default, raise an error if less than *n* bytes could be parsed
 - add extra parameter to either supply an error message or force the old behaviour

Rationales:

 - accepting white space makes `hexundump` symmetric with `lib.hexdump`
 - new default behaviour of raising as error less that *n* bytes takes burden to check corner cases off the caller