### PR TITLE
core.main: open auditlog during initialization

### DIFF
--- a/src/core/main.lua
+++ b/src/core/main.lua
@@ -47,6 +47,7 @@ function main ()
       error("fatal: "..ffi.os.."/"..ffi.arch.." is not a supported platform\n")
    end
    initialize()
+   vmprofile.start()
    if lib.getenv("SNABB_PROGRAM_LUACODE") then
       -- Run the given Lua code instead of the command-line
       local expr = lib.getenv("SNABB_PROGRAM_LUACODE")
@@ -54,8 +55,6 @@ function main ()
       if f == nil then
          error(("Failed to load $SNABB_PROGRAM_LUACODE: %q"):format(expr))
       else
-         engine.setvmprofile("program")
-         vmprofile.start()
          f()
       end
    else
@@ -65,8 +64,6 @@ function main ()
          print("unsupported program: "..program:gsub("_", "-"))
          usage(1)
       else
-         engine.setvmprofile("program")
-         vmprofile.start()
          require(modulename(program)).run(args)
       end
    end
@@ -165,6 +162,9 @@ function initialize ()
    _G.packet = require("core.packet")
    _G.timer  = require("core.timer")
    _G.main   = getfenv()
+   -- Setup audit.log, vmprofile
+   engine.enable_auditlog()
+   engine.setvmprofile("program")
 end
 
 function handler (reason)


### PR DESCRIPTION
Open auditlog during initialization, instead of waiting for engine to start.

Probably we want to open the auditlog even when the engine is never started? Can not hurt to have an auditlog even for non-dataplane processes like e.g. ptree managers? Cc @lukego 

Resolves: https://github.com/snabbco/snabb/issues/1428