### PR TITLE
Tx->Rx MAC Loopback mode support and minor fixes for intel_mp 82599

### DIFF
--- a/src/apps/intel_mp/README.md
+++ b/src/apps/intel_mp/README.md
@@ -179,6 +179,12 @@ to collect device statistics. The default is true.
 statistics. One per physical NIC (conflicts with `master_stats`). There is a
 small but detectable run time performance hit incurred. The default is false.
 
+— Key **mac_loopback**
+
+*Optional* Boolean indicating if the card should operate in
+“Tx->Rx MAC Loopback mode” for diagnostics or testing purposes. If this is true
+then `wait_for_link` is implicitly false. The default is false.
+
 
 ### RSS hashing methods
 

--- a/src/apps/intel_mp/intel_mp.lua
+++ b/src/apps/intel_mp/intel_mp.lua
@@ -719,7 +719,7 @@ function Intel:push ()
    self.tdh = self.r.TDH()	-- possible race condition, 7.2.2.4, check DD
    --C.full_memory_barrier()
    while cursor ~= self.tdh do
-      if self.txqueue[cursor] then
+      if self.txqueue[cursor] ~= nil then -- Non-null pointer?
          packet.free(self.txqueue[cursor])
          self.txqueue[cursor] = nil
       end

--- a/src/apps/intel_mp/intel_mp.lua
+++ b/src/apps/intel_mp/intel_mp.lua
@@ -649,7 +649,7 @@ function Intel:init_tx_q ()                               -- 4.5.10
       -- enables packet Tx for this VF's pool
       self.r.PFVFTE[math.floor(self.poolnum/32)]:set(bits{VFTE=self.poolnum%32})
       -- enable TX loopback
-      self.r.PFVMTXSW[math.floor(self.poolnum/32)]:clr(bits{LLE=self.poolnum%32})
+      self.r.PFVMTXSW[math.floor(self.poolnum/32)]:set(bits{LLE=self.poolnum%32})
    end
 
    if self.r.DMATXCTL then

--- a/src/apps/intel_mp/test_10g_2q_loopback.snabb
+++ b/src/apps/intel_mp/test_10g_2q_loopback.snabb
@@ -1,0 +1,51 @@
+#!../../snabb snsh
+
+-- Snabb test script for testing Tx->Rx MAC Loopback mode
+
+local basic_apps = require("apps.basic.basic_apps")
+local intel      = require("apps.intel_mp.intel_mp")
+local pcap       = require("apps.pcap.pcap")
+local lib        = require("core.lib")
+
+local pciaddr0 = lib.getenv("SNABB_PCI_INTEL0")
+
+local c = config.new()
+
+config.app(c, "source", pcap.PcapReader, "source.pcap")
+config.app(c, 'sink', basic_apps.Sink)
+
+-- send packets on nic0 txq 0
+config.app(c, "nic0tx", intel.Intel,
+           { pciaddr = pciaddr0,
+             -- disable rxq
+             rxq = false,
+             txq = 0,
+             mac_loopback = true })
+config.app(c, "repeat", basic_apps.Repeater)
+config.link(c, "source.output -> repeat.input")
+config.link(c, "repeat.output -> nic0tx.input")
+
+-- receive packets on nic0 rxq 0/1
+config.app(c, "nic0rx0", intel.Intel,
+           { pciaddr = pciaddr0,
+             rxq = 0,
+             -- disable txq
+             txq = false,
+             mac_loopback = true })
+config.app(c, "nic0rx1", intel.Intel,
+           { pciaddr = pciaddr0,
+             rxq = 1,
+             -- disable txq
+             txq = false,
+             mac_loopback = true })
+config.link(c, "nic0rx0.output -> sink.input0")
+config.link(c, "nic0rx1.output -> sink.input1")
+
+engine.configure(c)
+engine.main({ duration = 1 })
+engine.report_links()
+
+assert(link.stats(engine.app_table.sink.input.input0).rxpackets > 0,
+          "expected packet rx on rxq 0")
+assert(link.stats(engine.app_table.sink.input.input1).rxpackets > 0,
+          "expected packet rx on rxq 1")

--- a/src/apps/intel_mp/test_10g_loopback.snabb
+++ b/src/apps/intel_mp/test_10g_loopback.snabb
@@ -1,0 +1,31 @@
+#!../../snabb snsh
+
+-- Snabb test script for testing Tx->Rx MAC Loopback mode
+
+local basic_apps = require("apps.basic.basic_apps")
+local intel      = require("apps.intel_mp.intel_mp")
+local pcap       = require("apps.pcap.pcap")
+local lib        = require("core.lib")
+
+local pciaddr0 = lib.getenv("SNABB_PCI_INTEL0")
+
+local c = config.new()
+
+config.app(c, "source", pcap.PcapReader, "source.pcap")
+config.app(c, 'sink', basic_apps.Sink)
+
+-- send/receive packets on nic0
+config.app(c, "nic0", intel.Intel,
+           { pciaddr = pciaddr0,
+             mac_loopback = true })
+config.app(c, "repeat", basic_apps.Repeater)
+config.link(c, "source.output -> repeat.input")
+config.link(c, "repeat.output -> nic0.input")
+config.link(c, "nic0.output -> sink.input")
+
+engine.configure(c)
+engine.main({ duration = 1 })
+engine.report_links()
+
+assert(link.stats(engine.app_table.sink.input.input).rxpackets > 0,
+          "expected packet rx")

--- a/src/apps/intel_mp/test_10g_vmdq_loopback.snabb
+++ b/src/apps/intel_mp/test_10g_vmdq_loopback.snabb
@@ -1,0 +1,50 @@
+#!../../snabb snsh
+
+-- Snabb test script for testing Tx->Rx MAC Loopback mode
+
+local basic_apps = require("apps.basic.basic_apps")
+local intel      = require("apps.intel_mp.intel_mp")
+local pcap       = require("apps.pcap.pcap")
+local lib        = require("core.lib")
+
+local pciaddr0 = lib.getenv("SNABB_PCI_INTEL0")
+
+local c = config.new()
+
+config.app(c, "source", pcap.PcapReader, "source2.pcap")
+config.app(c, 'sink', basic_apps.Sink)
+
+-- send/receive packets on nic0 mac0
+config.app(c, "nic0mac0", intel.Intel,
+           { pciaddr = pciaddr0,
+             vmdq = true,
+             macaddr = "50:46:5d:74:1d:f9",
+             mac_loopback = true })
+config.app(c, "repeat", basic_apps.Repeater)
+config.link(c, "source.output -> repeat.input")
+config.link(c, "repeat.output -> nic0mac0.input")
+
+-- receive packets on nic0 mac1/2
+config.app(c, "nic0mac1", intel.Intel,
+           { pciaddr = pciaddr0,
+             vmdq = true,
+             macaddr = "12:34:56:78:9a:bc",
+             mac_loopback = true })
+config.app(c, "nic0mac2", intel.Intel,
+           { pciaddr = pciaddr0,
+             vmdq = true,
+             macaddr = "90:72:82:78:c9:7a",
+             mac_loopback = true })
+
+config.link(c, "nic0mac1.output -> sink.input0")
+config.link(c, "nic0mac2.output -> sink.input1")
+
+engine.configure(c)
+engine.main({ duration = 1 })
+engine.report_links()
+engine.app_table.nic0mac0:debug()
+
+assert(link.stats(engine.app_table.sink.input.input0).rxpackets > 0,
+          "expected packet rx on mac 1")
+assert(link.stats(engine.app_table.sink.input.input1).rxpackets > 0,
+          "expected packet rx on mac 2")

--- a/src/apps/intel_mp/test_10g_vmdq_loopback_self.snabb
+++ b/src/apps/intel_mp/test_10g_vmdq_loopback_self.snabb
@@ -1,0 +1,35 @@
+#!../../snabb snsh
+
+-- Snabb test script for testing Tx->Rx MAC Loopback mode
+
+local basic_apps = require("apps.basic.basic_apps")
+local intel      = require("apps.intel_mp.intel_mp")
+local synth      = require("apps.test.synth")
+local lib        = require("core.lib")
+
+local pciaddr0 = lib.getenv("SNABB_PCI_INTEL0")
+
+local c = config.new()
+
+config.app(c, "source", synth.Synth, {
+              src="50:46:5d:74:1d:f9",
+              dst="50:46:5d:74:1d:f9"
+})
+config.app(c, 'sink', basic_apps.Sink)
+
+-- send/receive packets on nic0
+config.app(c, "nic0", intel.Intel,
+           { pciaddr = pciaddr0,
+             vmdq = true,
+             macaddr = "50:46:5d:74:1d:f9",
+             mac_loopback = true })
+config.link(c, "source.output -> nic0.input")
+config.link(c, "nic0.output -> sink.input")
+
+engine.configure(c)
+engine.main({ duration = 1 })
+engine.report_links()
+engine.app_table.nic0:debug()
+
+assert(link.stats(engine.app_table.sink.input.input).rxpackets > 0,
+          "expected packet rx")


### PR DESCRIPTION
815ac59 Implements Tx->Rx MAC Loopback mode useful for diagnostics/testing purposes

8879ff0 Enables TX loopback in VMDq mode (git history seems to indicate this was intended to be enabled before, but wasn’t)

cd528a6 is a bit interesting in the way that this bug was never triggered in actual use (I was only able to hit it by trying to run two conflicting instances on the driver on the same port). I don’t dare to remove the `if` statement all together though.