### PR TITLE
Integrated intel_avf driver

### DIFF
--- a/src/apps/intel_avf/README.md
+++ b/src/apps/intel_avf/README.md
@@ -1,0 +1,42 @@
+# Intel AVF (adaptive virtual function) app (apps.intel_avf.intel_avf)
+
+The `intel_avf.Intel_avf` app provides drivers for the Virtual Functions exported
+by recent generations of Intel network cards.
+
+The links are named `input` and `output`.
+
+    DIAGRAM: Intel_avf
+                 +-----------+
+                 |           |
+      input ---->* Intel_avf *----> output
+                 |           |
+                 +-----------+
+
+## Configuration
+
+— Key **pciaddr**
+
+*Required*. The PCI address of the NIC as a string.
+
+— Key **ring_buffer_size**
+
+*Optional*. Number of DMA descriptors to use i.e. size of the DMA
+transmit and receive queues. Must be a multiple of 128. Default is not
+specified but assumed to be broadly applicable.
+
+## Supported Hardware
+Ethernet controller [0200]: Intel Corporation Ethernet Virtual Function 700 Series [8086:154c] (rev 02)
+
+## Unsupported features
+* Multiple queues per VF. This driver supports a single queue. The spec allows for up to 4 queues.
+* RSS with only 1 queue RSS doesn't make sense.
+* Multiple vlans are unsupported, `ip link` can be used to map all traffic to a single vlan.
+* Multiple MAC addresses are unsupported, `ip link` can be used to set the mac before snabb startup.
+* All of the advanced offload features are unsupported.
+* 16 byte RX descriptors are unsupported.
+
+## Setting up VFs under linux
+echo 2 > /sys/bus/pci/devices/0000\:03\:00.1/sriov_numvfs
+ip link set up dev enp3s0f1
+ip link set enp3s0f1 vf 0 mac 02:00:00:00:00:01
+ip link set enp3s0f1 vf 0 vlan 10

--- a/src/apps/intel_avf/README.md
+++ b/src/apps/intel_avf/README.md
@@ -40,3 +40,5 @@ echo 2 > /sys/bus/pci/devices/0000\:03\:00.1/sriov_numvfs
 ip link set up dev enp3s0f1
 ip link set enp3s0f1 vf 0 mac 02:00:00:00:00:01
 ip link set enp3s0f1 vf 0 vlan 10
+
+A more complete example can be found in apps/intel_avf/tests/setup.sh

--- a/src/apps/intel_avf/intel_avf.lua
+++ b/src/apps/intel_avf/intel_avf.lua
@@ -488,6 +488,9 @@ function Intel_avf:flush_stats ()
    self:mbox_r_stats()
 end
 
+function Intel_avf:rxdrop () return counter.read(self.shm.rxdrop) end
+function Intel_avf:txdrop () return counter.read(self.shm.txdrop) end
+
 function Intel_avf:mbox_setup()
    local dlen = 4096
    self.mbox = {

--- a/src/apps/intel_avf/intel_avf.lua
+++ b/src/apps/intel_avf/intel_avf.lua
@@ -11,7 +11,7 @@ local macaddress  = require("lib.macaddress")
 local pci         = require("lib.hardware.pci")
 local register    = require("lib.hardware.register")
 local tophysical  = core.memory.virtual_to_physical
-local band        = bit.band
+local band, lshift, rshift = bit.band, bit.lshift, bit.rshift
 local transmit, receive, empty = link.transmit, link.receive, link.empty
 local counter     = require("core.counter")
 
@@ -68,7 +68,7 @@ local rxdesc_t = ffi.typeof([[
          uint64_t status_err_type_len;
          uint64_t pad2;
          uint64_t pad3;
-      } __attribute__((packet)) write;
+      } __attribute__((packed)) write;
    }
 ]])
 local rxdesc_ptr_t = ffi.typeof("$ *", rxdesc_t)
@@ -415,7 +415,7 @@ function Intel_avf:pull()
    local pkts = 0
    while band(self.rxdesc[self.rx_tail].write.status_err_type_len, 0x01) == 1 and pkts < engine.pull_npackets do
       local p = self.rxqueue[self.rx_tail]
-      p.length = bit.rshift(self.rxdesc[self.rx_tail].write.status_err_type_len, 38)
+      p.length = rshift(self.rxdesc[self.rx_tail].write.status_err_type_len, 38)
       transmit(lo, p)
 
       local np = packet.allocate()

--- a/src/apps/intel_avf/intel_avf.lua
+++ b/src/apps/intel_avf/intel_avf.lua
@@ -1,0 +1,692 @@
+-- intel_avf: Device driver that conforms to the Intel Adaptive Virtual
+-- Function specification
+-- https://www.intel.com/content/dam/www/public/us/en/documents/product-specifications/ethernet-adaptive-virtual-function-hardware-spec.pdf
+-- pgXXX in the comments refers to that page in v1.0 of the specification, released Feb 2018
+
+module(..., package.seeall)
+
+local ffi         = require("ffi")
+local lib         = require("core.lib")
+local macaddress  = require("lib.macaddress")
+local pci         = require("lib.hardware.pci")
+local register    = require("lib.hardware.register")
+local tophysical  = core.memory.virtual_to_physical
+local band        = bit.band
+local transmit, receive, empty = link.transmit, link.receive, link.empty
+local counter     = require("core.counter")
+
+local bits        = lib.bits
+local C           = ffi.C
+
+local MAC_ADDR_BYTE_LEN = 6
+
+Intel_avf = {
+   config = {
+      pciaddr = { required=true },
+      ring_buffer_size = {default=2048}
+   }
+}
+
+function Intel_avf:load_registers()
+   local scalar_registers = [[
+      VFGEN_RSTAT       0x00008800 -       RW   VF Reset Status
+      VFINT_DYN_CTL0    0x00005C00 -       RW   VF Interrupt Dynamic Control Zero
+      VF_ATQBAL         0x00007C00 -       RW   VF MailBox Transmit Queu e Base Address Low
+      VF_ATQBAH         0x00007800 -       RW   VF MailBox Transmit Queue Base Address High
+      VF_ATQLEN         0x00006800 -       RW   VF MailBox Transmit Queue Length
+      VF_ATQH           0x00006400 -       RW   VF MailBox Transmit Head
+      VF_ATQT           0x00008400 -       RW   VF MailBox Transmit Tail
+      VF_ARQBAL         0x00006C00 -       RW   VF MailBox Receive Queue Base Address Low
+      VF_ARQBAH         0x00006000 -       RW   VF MailBox Receive Queue Base Address High
+      VF_ARQLEN         0x00008000 -       RW   VF MailBox Receive Queue Length
+      VF_ARQH           0x00007400 -       RW   VF MailBox Receive Head
+      VF_ARQT           0x00007000 -       RW   VF MailBox Receive Tail
+   ]]
+
+   -- VFINT_ITRN[n,m] is not handled well by lib.hardware.register
+   local array_registers = [[
+      VFINT_DYN_CTLN    0x00003800 +0x4*0..63      RW    VF Interrupt Dynamic Control N
+      VFINT_ITR0        0x00004C00 +0x4*0..2       RW    VF Interrupt Throttling Zero
+      QTX_TAIL          0x00000000 +0x4*0..255     RW    Transmit Queue Tail
+      QRX_TAIL          0x00002000 +0x4*0..255     RW    Receive Queue Tail
+   ]]
+   register.define(scalar_registers, self.r, self.base)
+   register.define_array(array_registers, self.r, self.base)
+end
+
+-- Section 2.1.2.1.2 & 2.1.2.2.2 pg12 & pg16
+local rxdesc_t = ffi.typeof([[
+   union {
+      struct {
+         uint64_t address;
+         uint64_t pad1;
+         uint64_t pad2;
+         uint64_t pad3;
+      } __attribute__((packed)) read;
+      struct {
+         uint64_t pad0;
+         uint64_t status_err_type_len;
+         uint64_t pad2;
+         uint64_t pad3;
+      } __attribute__((packet)) write;
+   }
+]])
+local rxdesc_ptr_t = ffi.typeof("$ *", rxdesc_t)
+
+-- section 2.2.2.2 pg22
+local txdesc_t = ffi.typeof([[
+   struct {
+      uint64_t address;
+      uint64_t cmd_type_offset_bsz;
+   } __attribute__((packed))
+]])
+local txdesc_ptr_t = ffi.typeof("$ *", txdesc_t)
+
+local queue_select_t = ffi.typeof([[
+   struct {
+      uint16_t vsi_id;
+      uint16_t pad;
+      uint32_t rx_queues;
+      uint32_t tx_queues;
+   } __attribute__((packed))
+]])
+local queue_select_ptr_t = ffi.typeof("$ *", queue_select_t)
+
+local virtchnl_msg_t = ffi.typeof([[
+   struct {
+      uint64_t pad0;
+      uint32_t opcode;
+      int32_t status;
+      uint32_t vfid;
+   } __attribute__((packed))
+]])
+local virtchnl_msg_ptr_t = ffi.typeof("$ *", virtchnl_msg_t)
+
+local virtchnl_q_pair_t = ffi.typeof([[
+   struct {
+      uint16_t vsi_id;
+      uint16_t num_queue_pairs;
+      uint32_t pad;
+
+      uint16_t tx_vsi_id;
+      uint16_t tx_queue_id;
+      uint16_t tx_ring_len;
+      uint16_t tx_deprecated0;
+      uint64_t tx_dma_ring_addr;
+      uint64_t tx_deprecated1;
+
+      uint16_t rx_vsi_id;
+      uint16_t rx_queue_id;
+      uint32_t rx_ring_len;
+      uint16_t rx_hdr_size;
+      uint16_t rx_deprecated0;
+      uint32_t rx_databuffer_size;
+      uint32_t rx_max_pkt_size;
+      uint32_t rx_pad0;
+      uint64_t rx_dma_ring_addr;
+      uint32_t rx_deprecated1;
+      uint32_t rx_pad1;
+   } __attribute__((packed))
+]])
+local virtchnl_q_pair_ptr_t = ffi.typeof("$ *", virtchnl_q_pair_t)
+
+local virtchnl_ether_addr_t = ffi.typeof([[
+   struct {
+      uint16_t vsi;
+      uint16_t num_elements;
+      uint8_t addr[6]; // MAC_ADDR_BYTE_LEN
+      uint8_t pad[2];
+   } __attribute__((packed))
+]])
+local virtchnl_ether_addr_ptr_t = ffi.typeof("$ *", virtchnl_ether_addr_t)
+
+local eth_stats_t = ffi.typeof([[
+   struct {
+        uint64_t rx_bytes;
+        uint64_t rx_unicast;
+        uint64_t rx_multicast;
+        uint64_t rx_broadcast;
+        uint64_t rx_discards;
+        uint64_t rx_unknown_protocol;
+        uint64_t tx_bytes;
+        uint64_t tx_unicast;
+        uint64_t tx_multicast;
+        uint64_t tx_broadcast;
+        uint64_t tx_discards;
+        uint64_t tx_errors;
+   } __attribute__((packed))
+]])
+local eth_stats_ptr_t = ffi.typeof("$ *", eth_stats_t)
+
+local virtchnl_vf_resources_t = ffi.typeof([[
+   struct {
+      uint16_t num_vsis;
+      uint16_t num_queue_pairs;
+      uint16_t max_vectors;
+      uint16_t max_mtu;
+      uint32_t vf_offload_flag;
+      uint32_t rss_key_size;
+      uint32_t rss_lut_size;
+
+      uint16_t vsi_id;
+      uint16_t vsi_queue_pairs;
+      uint32_t vsi_type;
+      uint16_t qset_handle;
+      uint8_t default_mac_addr[6];
+   } __attribute__((packed))
+]])
+local virtchnl_vf_resources_ptr_t = ffi.typeof('$*', virtchnl_vf_resources_t)
+
+local virtchnl_version_t = ffi.typeof([[
+   struct {
+      uint32_t major;
+      uint32_t minor;
+   } __attribute__((packed))
+]])
+local virtchnl_version_ptr_t = ffi.typeof('$*', virtchnl_version_t)
+
+function Intel_avf:init_tx_q()
+   self.txdesc = ffi.cast(txdesc_ptr_t,
+   memory.dma_alloc(ffi.sizeof(txdesc_t) * self.ring_buffer_size))
+   ffi.fill(self.txdesc, ffi.sizeof(txdesc_t) * self.ring_buffer_size)
+   self.txqueue = ffi.new("struct packet *[?]", self.ring_buffer_size)
+   for i=0, self.ring_buffer_size - 1 do
+      self.txqueue[i] = nil
+      self.txdesc[i].cmd_type_offset_bsz = 0
+   end
+end
+
+function Intel_avf:init_rx_q()
+   self.rxqueue = ffi.new("struct packet *[?]", self.ring_buffer_size)
+   self.rxdesc = ffi.cast(rxdesc_ptr_t,
+   memory.dma_alloc(ffi.sizeof(rxdesc_t) * self.ring_buffer_size), 128)
+
+   for i = 0, self.ring_buffer_size-1 do
+      local p = packet.allocate()
+      self.rxqueue[i] = p
+   self.rxdesc[i].read.address = tophysical(p.data)
+      self.rxdesc[i].write.status_err_type_len = 0
+   end
+end
+
+function Intel_avf:supported_hardware()
+   local vendor = lib.firstline(self.path .. "/vendor")
+   local device = lib.firstline(self.path .. "/device")
+   local devices = {
+      -- Ethernet controller [0200]: Intel Corporation Ethernet Virtual Function 700 Series [8086:154c] (rev 02)
+      "0x154c",
+      -- pg8
+      "0x1889"
+   }
+   assert(vendor == '0x8086', "unsupported nic vendor: " .. vendor)
+
+   for _,v in pairs(devices) do
+      if device == v then return end
+   end
+   assert(devices[device] == true, "unsupported nic version: " .. device)
+end
+
+function Intel_avf:mbox_setup_rxq()
+   self.mbox.rxq =
+      memory.dma_alloc(self.mbox.q_byte_len, self.mbox.q_alignment)
+   ffi.fill(self.mbox.rxq, self.mbox.q_byte_len)
+   self.mbox.rxq = ffi.cast(ffi.typeof("$*", self.mbox.q_t), self.mbox.rxq)
+
+   for i=0,self.mbox.q_len-1 do
+      local ptr = ffi.cast("uint8_t *", memory.dma_alloc(self.mbox.datalen))
+      ffi.fill(ptr, self.mbox.datalen)
+
+      self.mbox.rxq_buffers[i] = ptr
+
+      self.mbox.rxq[i].data_addr_high =
+         tophysical(self.mbox.rxq_buffers[i]) / 2^32
+
+      self.mbox.rxq[i].data_addr_low =
+         tophysical(self.mbox.rxq_buffers[i]) % 2^32
+
+      self.mbox.rxq[i].datalen = self.mbox.datalen
+      self.mbox.rxq[i].flags0 = 0
+      self.mbox.rxq[i].flags1 =
+         bits({LARGE_BUFFER = 1, BUFFER=4, NO_INTERRUPTS=5})
+   end
+   self.r.VF_ARQBAL(tophysical(self.mbox.rxq) % 2^32)
+   self.r.VF_ARQBAH(tophysical(self.mbox.rxq) / 2^32)
+   self.r.VF_ARQH(0)
+   self.r.VF_ARQT(self.mbox.q_len-1)
+   self.mbox.next_recv_idx = 0
+
+   -- set length and enable the queue
+   self.r.VF_ARQLEN(bits({ ENABLE = 31 }) + self.mbox.q_len)
+end
+
+function Intel_avf:mbox_setup_txq()
+   self.mbox.txq = memory.dma_alloc(self.mbox.q_byte_len, self.mbox.q_alignment)
+   ffi.fill(self.mbox.txq, self.mbox.q_byte_len)
+   self.mbox.txq = ffi.cast(ffi.typeof("$*", self.mbox.q_t), self.mbox.txq )
+
+   for i=0,self.mbox.q_len-1 do
+      local ptr = ffi.cast("uint8_t *", memory.dma_alloc(4096))
+
+      self.mbox.txq_buffers[i] = ptr
+
+      self.mbox.txq[i].data_addr_high =
+      tophysical(self.mbox.txq_buffers[i]) / 2^32
+
+      self.mbox.txq[i].data_addr_low =
+      tophysical(self.mbox.txq_buffers[i]) % 2^32
+   end
+   self.r.VF_ATQBAL(tophysical(self.mbox.txq) % 2^32)
+   self.r.VF_ATQBAH(tophysical(self.mbox.txq) / 2^32)
+   self.r.VF_ATQH(0)
+   self.r.VF_ATQT(0)
+   self.mbox.next_send_idx = 0
+
+   -- set length and enable the queue
+   self.r.VF_ATQLEN(bits({ ENABLE = 31 }) + self.mbox.q_len)
+end
+
+function Intel_avf:mbox_sr_q()
+   local tt = self:mbox_send_buf(virtchnl_q_pair_ptr_t)
+
+   tt.vsi_id = self.vsi_id
+   tt.num_queue_pairs = 1
+
+   tt.tx_vsi_id = self.vsi_id
+   tt.tx_queue_id = self.qno
+   tt.tx_ring_len = self.ring_buffer_size
+   tt.tx_dma_ring_addr = tophysical(self.txdesc)
+
+   tt.rx_vsi_id = self.vsi_id
+   tt.rx_queue_id = self.qno
+   tt.rx_ring_len = self.ring_buffer_size
+   -- Only 32 byte rxdescs are supported, at least by the PF driver in
+   -- centos 7 3.10.0-957.1.3.el7.x86_64
+   tt.rx_hdr_size = 32
+   tt.rx_databuffer_size = core.packet.max_payload
+   tt.rx_max_pkt_size = core.packet.max_payload
+   tt.rx_dma_ring_addr = tophysical(self.rxdesc)
+
+   self:mbox_sr('VIRTCHNL_OP_CONFIG_VSI_QUEUES', ffi.sizeof(virtchnl_q_pair_t) + 64)
+
+   -- FIXME why do we sleep?
+   C.usleep(1000*1000)
+   self.r.rx_tail = self.r.QRX_TAIL[self.qno]
+   self.r.tx_tail = self.r.QTX_TAIL[self.qno]
+   self.rx_tail = 0
+   self.r.rx_tail(self.ring_buffer_size - 1)
+end
+
+function Intel_avf:mbox_sr_enable_q ()
+   local tt = self:mbox_send_buf(queue_select_ptr_t)
+
+   tt.vsi_id = self.vsi_id
+   tt.pad = 0
+   tt.rx_queues = bits({ ENABLE = self.qno })
+   tt.tx_queues = bits({ ENABLE = self.qno })
+   self:mbox_sr('VIRTCHNL_OP_ENABLE_QUEUES', ffi.sizeof(queue_select_t))
+end
+
+function Intel_avf:ringnext (index)
+   return band(index+1, self.ring_buffer_size - 1)
+end
+
+function Intel_avf:reclaim_txdesc ()
+   local RS = bits({ RS = 5 })
+   local COMPLETE = 15
+
+   while band(self.txdesc[ self:ringnext(self.tx_cand) ].cmd_type_offset_bsz, COMPLETE) == COMPLETE
+         and self.tx_desc_free < self.ring_buffer_size do
+      local c = self.tx_cand
+      if self.txqueue[c] ~= nil then
+         packet.free(self.txqueue[c])
+         self.txqueue[c] = nil
+      end
+      self.tx_cand = self:ringnext(self.tx_cand)
+      self.tx_desc_free = self.tx_desc_free + 1
+   end
+end
+
+function Intel_avf:push ()
+   local li = self.input.input
+   if li == nil then return end
+
+   local RS_EOP = bits({ EOP = 4, RS = 5 })
+   local SIZE_SHIFT = 34
+
+   self:reclaim_txdesc()
+   while not empty(li) and self.tx_desc_free > 0 do
+      local p = receive(li)
+      self.txdesc[ self.tx_next ].address = tophysical(p.data)
+      self.txqueue[ self.tx_next ] = p
+      self.txdesc[ self.tx_next ].cmd_type_offset_bsz = RS_EOP + p.length * 2^SIZE_SHIFT
+      self.tx_next = self:ringnext(self.tx_next)
+      self.tx_desc_free = self.tx_desc_free - 1
+   end
+   C.full_memory_barrier()
+   self.r.tx_tail(band(self.tx_next-1, self.ring_buffer_size - 1))
+   -- self:mbox_sr_stats()
+end
+
+function Intel_avf:pull()
+   local lo = self.output.output
+   if lo == nil then return end
+
+   local pkts = 0
+   while band(self.rxdesc[self.rx_tail].write.status_err_type_len, 0x01) == 1 and pkts < engine.pull_npackets do
+      local p = self.rxqueue[self.rx_tail]
+      p.length = bit.rshift(self.rxdesc[self.rx_tail].write.status_err_type_len, 38)
+      transmit(lo, p)
+
+      local np = packet.allocate()
+      self.rxqueue[self.rx_tail] = np
+      self.rxdesc[self.rx_tail].read.address = tophysical(np.data)
+      self.rxdesc[self.rx_tail].write.status_err_type_len = 0
+      self.rx_tail = band(self.rx_tail + 1, self.ring_buffer_size-1)
+      pkts = pkts + 1
+   end
+   -- This avoids the queue being full / empty when HEAD=TAIL
+   C.full_memory_barrier()
+   self.r.rx_tail(band(self.rx_tail - 1, self.ring_buffer_size - 1))
+end
+
+function Intel_avf:mbox_setup()
+   local dlen = 4096
+   self.mbox = {
+      q_len = 64,
+      -- FIXME find reference
+      q_alignment = 64,
+      datalen = dlen,
+      txq_buffers = {},
+      rxq_buffers = {},
+      send_buf = memory.dma_alloc(dlen)
+   }
+   self.mbox.q_t = ffi.typeof([[
+      struct {
+         uint8_t flags0;
+         uint8_t flags1;
+         uint16_t opcode;
+         uint16_t datalen;
+         uint16_t return_value;
+         uint32_t cookie_high;
+         uint32_t cookie_low;
+         uint32_t param0;
+         uint32_t param1;
+         uint32_t data_addr_high;
+         uint32_t data_addr_low;
+      } __attribute__((packed))
+   ]])
+   self.mbox.q_byte_len = self.mbox.q_len * ffi.sizeof(self.mbox.q_t)
+
+   self.mbox.hwopcodes = {
+      SEND_TO_PF     = 0x0801,
+      RECV_FROM_PF   = 0x0802,
+      SHUTDOWN_QUEUE = 0x0803
+   }
+   self.mbox.opcodes = {
+      VIRTCHNL_OP_UNKNOWN = 0,
+      VIRTCHNL_OP_VERSION = 1,
+      VIRTCHNL_OP_RESET_VF = 2,
+      VIRTCHNL_OP_GET_VF_RESOURCES = 3,
+      -- 4/5 unsupported by CentOS 7 PF
+      -- VIRTCHNL_OP_CONFIG_TX_QUEUE = 4,
+      -- VIRTCHNL_OP_CONFIG_RX_QUEUE = 5,
+      VIRTCHNL_OP_CONFIG_VSI_QUEUES = 6,
+      -- VIRTCHNL_OP_CONFIG_IRQ_MAP = 7,
+      VIRTCHNL_OP_ENABLE_QUEUES = 8,
+      VIRTCHNL_OP_DISABLE_QUEUES = 9,
+      -- VIRTCHNL_OP_ADD_ETH_ADDR = 10,
+      -- VIRTCHNL_OP_DEL_ETH_ADDR = 11,
+      -- VIRTCHNL_OP_ADD_VLAN = 12,
+      -- VIRTCHNL_OP_DEL_VLAN = 13,
+      -- VIRTCHNL_OP_CONFIG_PROMISCUOUS_MODE = 14,
+      VIRTCHNL_OP_GET_STATS = 15,
+      -- VIRTCHNL_OP_RSVD = 16,
+      VIRTCHNL_OP_EVENT = 17,
+      -- VIRTCHNL_OP_IWARP = 20,
+      -- VIRTCHNL_OP_CONFIG_IWARP_IRQ_MAP = 21,
+      -- VIRTCHNL_OP_RELEASE_IWARP_IRQ_MAP = 22,
+      -- VIRTCHNL_OP_CONFIG_RSS_KEY = 23,
+      -- VIRTCHNL_OP_CONFIG_RSS_LUT = 24,
+      -- VIRTCHNL_OP_GET_RSS_HENA_CAPS = 25,
+      -- VIRTCHNL_OP_SET_RSS_HENA = 26
+   }
+   self:mbox_setup_rxq()
+   self:mbox_setup_txq()
+end
+
+function Intel_avf:mbox_sr(opcode, datalen)
+   opcode = self.mbox.opcodes[opcode]
+   self:mbox_send(opcode, datalen)
+   return self:mbox_recv()
+end
+
+function Intel_avf:mbox_send(opcode, datalen)
+   self:mbox_send_p1(opcode, datalen)
+   self:mbox_send_p2(opcode, datalen)
+end
+-- Splitting mbox_send into 2 parts so that each can be called on a
+-- different breath reducing the per breath latency
+function Intel_avf:mbox_send_p1(opcode, datalen)
+   local idx = self.mbox.next_send_idx
+   self.mbox.tmp_idx = idx
+   self.mbox.next_send_idx = ( idx + 1 ) % self.mbox.q_len
+
+   self.mbox.txq[idx].flags0 = 0
+   self.mbox.txq[idx].flags1 = 0
+
+   self.mbox.txq[idx].opcode = self.mbox.hwopcodes['SEND_TO_PF']
+   if datalen > 512 then
+      self.mbox.txq[idx].flags0 =
+         bit.bor(self.mbox.txq[idx].flags0, bits({ LARGE_BUFFER = 1 }))
+   end
+   self.mbox.txq[idx].flags1
+      = bits({ INDIRECT_BUFFER = 2, BUFFER = 4, NO_INTERRUPTS = 5 })
+   self.mbox.txq[idx].datalen = datalen
+   self.mbox.txq[idx].cookie_high = opcode
+   self.mbox.txq[idx].data_addr_high = tophysical(self.mbox.send_buf) / 2^32
+   self.mbox.txq[idx].data_addr_low = tophysical(self.mbox.send_buf) % 2^32
+
+   self.r.VF_ATQT(self.mbox.next_send_idx)
+   return
+end
+function Intel_avf:mbox_send_p2()
+   -- Wait for the mailbox to process the send
+   -- FIXME Wait with timeout ?
+   -- FIXME assert on timeout ?
+
+   local idx = self.mbox.tmp_idx
+   self.mbox.tmp_idx = nil
+   lib.waitfor(function()
+      return self.r.VF_ATQT() == self.mbox.next_send_idx
+   end)
+   lib.waitfor(function()
+      -- 1 == bits({ DescriptorDone = 0 })
+      -- 2 == bits({ Complete = 1 })
+      return band(self.mbox.txq[idx].flags0, 1) == 1 and
+         band(self.mbox.txq[idx].flags0, 2) == 2
+   end)
+   -- assert error bit is not set
+   assert(band(self.mbox.txq[idx].flags0, 4) == 0)
+   assert(self.mbox.txq[idx].return_value == 0)
+   return
+end
+
+function Intel_avf:mbox_send_buf (t)
+   ffi.fill(self.mbox.send_buf, self.mbox.datalen)
+   return ffi.cast(t, self.mbox.send_buf)
+end
+
+function Intel_avf:mbox_sr_version()
+   local tt = self:mbox_send_buf(virtchnl_version_ptr_t)
+   tt[0].major = 1;
+   tt[0].minor = 1;
+   self:mbox_sr('VIRTCHNL_OP_VERSION', ffi.sizeof(virtchnl_version_t))
+end
+
+function Intel_avf:mbox_sr_caps()
+   -- FIXME use mbox_send_buf
+   -- FIXME move type up top
+   -- avf_get_vf_resource(struct avf_adapter *adapter)
+   -- in
+   -- dpdk/drivers/net/avf/avf_vchnl.c
+   local supported_caps = bits({
+      VIRTCHNL_VF_OFFLOAD_L2 = 0,
+      VIRTCHNL_VF_OFFLOAD_VLAN = 16,
+      VIRTCHNL_VF_OFFLOAD_RX_POLLING = 17
+   })
+   ffi.cast('uint32_t *', self.mbox.send_buf)[0] = supported_caps
+   local rcvd = self:mbox_sr('VIRTCHNL_OP_GET_VF_RESOURCES', ffi.sizeof('uint32_t'))
+
+   local tt = ffi.cast(virtchnl_vf_resources_ptr_t, rcvd)[0]
+
+   assert(tt.num_vsis == 1, "Only 1 vsi supported")
+
+   -- pg76
+   assert(tt.vsi_type == 6, "vsi_type must be VSI_SRIOV (6)")
+
+   assert(bit.band(tt.vf_offload_flag, supported_caps) == supported_caps,
+      "PF driver doesn't support the required capabilities")
+
+   self.vsi_id = tt.vsi_id
+   -- FIXME Is this needed?
+   self.mac = macaddress:from_bytes(tt.default_mac_addr)
+end
+
+function Intel_avf:mbox_recv()
+   local idx = self.mbox.next_recv_idx
+   self.mbox.next_recv_idx = ( idx + 1 ) % self.mbox.q_len
+
+   lib.waitfor(function()
+      return bit.band(self.mbox.rxq[idx].flags0, 1) == 1
+   end)
+
+   assert(bit.band(self.mbox.rxq[idx].flags0, bits({ ERR = 2 })) == 0)
+
+   local msg_status = ffi.cast(virtchnl_msg_ptr_t, self.mbox.rxq + idx)[0].status
+   assert(msg_status == 0, "failure in PF")
+   local opcode = ffi.cast(virtchnl_msg_ptr_t, self.mbox.rxq + idx)[0].opcode
+
+   local bflag = bits({ ExternalBuf = 4 })
+   local ptr
+   if band(self.mbox.rxq[idx].flags1, bflag) == bflag then
+      ptr = ffi.new("uint8_t[?]", self.mbox.rxq[idx].datalen)
+      ffi.copy(ptr, self.mbox.rxq_buffers[idx], self.mbox.rxq[idx].datalen)
+   end
+
+   self.mbox.rxq[idx].datalen = self.mbox.datalen
+   self.mbox.rxq[idx].flags0 = 0
+   self.mbox.rxq[idx].flags1 = bits({LARGE_BUFFER = 1, BUFFER=4, NO_INTERRUPTS=5})
+   ffi.fill(self.mbox.rxq_buffers[idx], self.mbox.datalen)
+
+   self.r.VF_ARQT( idx )
+   if opcode == self.mbox.opcodes['VIRTCHNL_OP_EVENT'] then
+      return self:mbox_recv()
+   end
+   return ptr
+end
+
+function Intel_avf:wait_for_vfgen_rstat()
+   -- Constant names stolen from DPDK drivers/net/avf/base/virtchnl.h
+   -- Section 6.1 on page 51
+   local mask0 = bits( { VIRTCHNL_VFR_COMPLETED = 1 })
+   local mask1 = bits( { VIRTCHNL_VFR_VFACTIVE = 2 })
+   lib.waitfor(function ()
+         local v = self.r.VFGEN_RSTAT()
+         return bit.band(mask0, v) == mask0 or bit.band(mask1, v) == mask1
+   end)
+end
+
+function Intel_avf:new(conf)
+   local self = {
+      pciaddress = conf.pciaddr,
+      path = pci.path(conf.pciaddr),
+      r = {},
+      ring_buffer_size = conf.ring_buffer_size,
+
+      tx_next = 0,
+      tx_cand = 0,
+      tx_desc_free = conf.ring_buffer_size - 1,
+      qno = 0,
+      shm = {
+         rx_bytes       = {counter},
+         rx_unicast     = {counter},
+         rx_multicast   = {counter},
+         rx_broadcast   = {counter},
+         rx_discards    = {counter},
+         rx_unknown_protocol = {counter},
+         tx_bytes       = {counter},
+         tx_unicast     = {counter},
+         tx_multicast   = {counter},
+         tx_broadcast   = {counter},
+         tx_discards    = {counter},
+         tx_errors      = {counter}
+      },
+      throttle = lib.throttle(0.5),
+      stats_pos = 0,
+   }
+
+   -- pg79 /* number of descriptors, multiple of 32 */
+   assert(self.ring_buffer_size % 32 == 0,
+      "ring_buffer_size must be a multiple of 32")
+
+   self = setmetatable(self, { __index = Intel_avf })
+   self:supported_hardware()
+   self.base, self.fd = pci.map_pci_memory_unlocked(self.pciaddress, 0)
+   self:load_registers()
+   pci.unbind_device_from_linux(self.pciaddress)
+   pci.set_bus_master(self.pciaddress, true)
+   pci.disable_bus_master_cleanup(self.pciaddress)
+
+   self:wait_for_vfgen_rstat()
+   self:mbox_setup()
+   self:mbox_sr_version()
+   self:mbox_sr_caps()
+   self:init_tx_q()
+   self:init_rx_q()
+   self:mbox_sr_q()
+   self:mbox_sr_enable_q()
+   return self
+end
+
+function Intel_avf:mbox_sr_add_mac()
+   -- pg81
+   local tt = self:mbox_send_buf(virtchnl_ether_addr_ptr_t)
+   tt.vsi = self.vsi_id
+   tt.num_elements = 1
+   ffi.copy(tt.addr, self.mac, MAC_ADDR_BYTE_LEN)
+   self:mbox_sr('VIRTCHNL_OP_ADD_ETH_ADDR', ffi.sizeof(virtchnl_ether_addr_t) + 8)
+end
+
+function Intel_avf:mbox_sr_stats()
+   if self.throttle() == false then
+      return
+   end
+   if self.stats_pos == 0 then
+      local tt = self:mbox_send_buf(queue_select_ptr_t)
+      tt.vsi_id = self.vsi_id
+      local opcode = self.mbox.opcodes['VIRTCHNL_OP_GET_STATS']
+      self:mbox_send_p1(opcode, ffi.sizeof(queue_select_t))
+      self.stats_pos = 1
+   elseif self.stats_pos == 1 then
+      self:mbox_send_p2()
+      self.stats_pos = 2
+   elseif self.stats_pos == 2 then
+      local stats = ffi.cast(eth_stats_ptr_t, self:mbox_recv())
+      local set = counter.set
+      set(self.shm.rx_bytes,     stats.rx_bytes)
+      set(self.shm.rx_unicast,   stats.rx_unicast)
+      set(self.shm.rx_multicast, stats.rx_multicast)
+      set(self.shm.rx_broadcast, stats.rx_broadcast)
+      set(self.shm.rx_discards,  stats.rx_discards)
+      set(self.shm.rx_unknown_protocol,   stats.rx_unknown_protocol)
+
+      set(self.shm.tx_bytes,     stats.tx_bytes)
+      set(self.shm.tx_unicast,   stats.tx_unicast)
+      set(self.shm.tx_multicast, stats.tx_multicast)
+      set(self.shm.tx_broadcast, stats.tx_broadcast)
+      set(self.shm.tx_discards,  stats.tx_discards)
+      set(self.shm.tx_errors,    stats.tx_errors)
+      self.stats_pos = 0
+   end
+end
+

--- a/src/apps/intel_avf/intel_avf.lua
+++ b/src/apps/intel_avf/intel_avf.lua
@@ -398,9 +398,11 @@ function Intel_avf:push ()
    self:reclaim_txdesc()
    while not empty(li) and self.tx_desc_free > 0 do
       local p = receive(li)
+      -- NB: need to extend size for 4 byte CRC (not clear from the spec.)
+      local size = lshift(4ULL+p.length, SIZE_SHIFT)
       self.txdesc[ self.tx_next ].address = tophysical(p.data)
       self.txqueue[ self.tx_next ] = p
-      self.txdesc[ self.tx_next ].cmd_type_offset_bsz = RS_EOP + p.length * 2^SIZE_SHIFT
+      self.txdesc[ self.tx_next ].cmd_type_offset_bsz = RS_EOP + size
       self.tx_next = self:ringnext(self.tx_next)
       self.tx_desc_free = self.tx_desc_free - 1
    end

--- a/src/apps/intel_avf/intel_avf.lua
+++ b/src/apps/intel_avf/intel_avf.lua
@@ -27,6 +27,10 @@ Intel_avf = {
    }
 }
 
+-- The `driver' variable is used as a reference to the driver class in
+-- order to interchangeably use NIC drivers.
+driver = Intel_avf
+
 function Intel_avf:load_registers()
    local scalar_registers = [[
       VFGEN_RSTAT       0x00008800 -       RW   VF Reset Status

--- a/src/apps/intel_avf/selftest.sh
+++ b/src/apps/intel_avf/selftest.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -e
+
+SKIPPED_CODE=43
+
+if [ -z "$SNABB_AVF_PF0" ]; then
+    echo "SNABB_AVF_PF0 not set, skipping tests."
+    exit $SKIPPED_CODE
+fi
+
+cd "$(dirname $0)/tests"
+
+source <(./setup.sh)
+sleep 1 # FIXME: delay needed for the initial VFs to become usable.
+
+for test in */*; do
+    echo $test
+    (cd "$(dirname $test)"; "./$(basename $test)")
+done

--- a/src/apps/intel_avf/tests/back2back/test.snabb
+++ b/src/apps/intel_avf/tests/back2back/test.snabb
@@ -43,6 +43,12 @@ config.link(c, "nic1.output -> match.rx")
 config.link(c, "tee.output2 -> match.comparator")
 
 engine.configure(c)
+
+local n0 = engine.app_table['nic0']
+local n1 = engine.app_table['nic1']
+n0:flush_stats()
+n1:flush_stats()
+
 engine.main({duration = 1, report = false})
 engine.report_links()
 engine.report_apps()
@@ -60,13 +66,13 @@ local s = rx("tee.output1", "nic0.input")
 local r = rx("nic1.output", "match.rx")
 assert_eq(s, r, "packets_sr_1")
 
-local n0 = engine.app_table['nic0']
-local n1 = engine.app_table['nic1']
-n0:mbox_sr_stats()
-n1:mbox_sr_stats()
+n0:flush_stats()
+n1:flush_stats()
+assert_eq(counter.read(n0.shm.txpackets), counter.read(n1.shm.rxpackets), "mxbox_sr_stats_1")
+assert_eq(counter.read(n0.shm.txpackets), packet_count, "mbox_sr_stats_2")
 
-assert_eq(counter.read(n0.shm.tx_unicast), counter.read(n1.shm.rx_unicast), "mxbox_sr_stats_1")
-assert_eq(counter.read(n0.shm.tx_unicast), packet_count, "mbox_sr_stats_2")
+local m = engine.app_table['match']
+assert(#m:errors() == 0, "Corrupt packets.")
 
 local c = config.new()
 config.app(c, "synth", synth.Synth, {

--- a/src/apps/intel_avf/tests/back2back/test.snabb
+++ b/src/apps/intel_avf/tests/back2back/test.snabb
@@ -1,9 +1,9 @@
 #!../../../../snabb snsh
-local vf0 = os.getenv("SNABB_AVF_VF0")
-local vf1 = os.getenv("SNABB_AVF_VF1")
+local vf0 = os.getenv("SNABB_AVF_PF0_VF0")
+local vf1 = os.getenv("SNABB_AVF_PF1_VF0")
 
-assert(vf0 ~= nil, "SNABB_AVF_VF0 is nil")
-assert(vf1 ~= nil, "SNABB_AVF_VF0 is nil")
+assert(vf0 ~= nil, "SNABB_AVF_PF0_VF0 is nil")
+assert(vf1 ~= nil, "SNABB_AVF_PF1_VF0 is nil")
 
 -- 1001 is an important test case, descriptors are written back in sets of 4
 -- 1001, exercises the interrupt driven write back
@@ -18,7 +18,7 @@ local counter = require("core.counter")
 
 local c = config.new()
 local src="02:00:00:00:00:00"
-local dst="02:00:00:00:00:01"
+local dst="02:00:00:00:00:10"
 config.app(c, "synth", synth.Synth, {
        sizes = {64,128,192,256,384,512,1024},
        src=src,
@@ -44,17 +44,23 @@ engine.main({duration = 3, report = false})
 function rx(l1, l2)
    return counter.read(engine.link_table[l1 .. " -> " .. l2].stats.rxpackets)
 end
-assert(rx("tee.output1", "nic0.input") ==
-	rx("nic1.output", "match.rx"), "packets sent != packets recv")
+function assert_eq(a,b,msg)
+	local an = tonumber(a)
+	local bn = tonumber(b)
+	assert(an == bn, msg .. " " .. an .. " ~= " .. bn)
+end
 
+local s = rx("tee.output1", "nic0.input")
+local r = rx("nic1.output", "match.rx")
+assert_eq(s, r, "packets_sr_1")
 
 local n0 = engine.app_table['nic0']
 local n1 = engine.app_table['nic1']
 n0:mbox_sr_stats()
 n1:mbox_sr_stats()
 
-assert(counter.read(n0.shm.tx_unicast) == counter.read(n1.shm.rx_unicast), "mbox_sr_stats counters dont match")
-assert(counter.read(n0.shm.tx_unicast) == packet_count, "mbox_sr_stats.tx_unicast != packet_count")
+assert_eq(counter.read(n0.shm.tx_unicast), counter.read(n1.shm.rx_unicast), "mxbox_sr_stats_1")
+assert_eq(counter.read(n0.shm.tx_unicast), packet_count, "mbox_sr_stats_2")
 
 local c = config.new()
 config.app(c, "synth", synth.Synth, {
@@ -76,5 +82,5 @@ while true do
 	end
 	engine.main({ duration = 1, no_report = true })
 end
-
+engine.stop()
 main.exit(0)

--- a/src/apps/intel_avf/tests/back2back/test.snabb
+++ b/src/apps/intel_avf/tests/back2back/test.snabb
@@ -5,6 +5,10 @@ local vf1 = os.getenv("SNABB_AVF_VF1")
 assert(vf0 ~= nil, "SNABB_AVF_VF0 is nil")
 assert(vf1 ~= nil, "SNABB_AVF_VF0 is nil")
 
+-- 1001 is an important test case, descriptors are written back in sets of 4
+-- 1001, exercises the interrupt driven write back
+local packet_count = 1001
+
 local basic = require("apps.basic.basic_apps")
 local intel_avf = require("apps.intel_avf.intel_avf")
 local match = require("apps.test.match")
@@ -23,9 +27,7 @@ config.app(c, "synth", synth.Synth, {
 config.app(c, "tee", basic.Tee)
 config.app(c, "match", match.Match)
 
--- 1001 is an important test case, descriptors are written back in sets of 4
--- 1001, exercises the interrupt driven write back
-config.app(c, "npackets", npackets.Npackets, { npackets = 1001 })
+config.app(c, "npackets", npackets.Npackets, { npackets = packet_count })
 config.app(c, "nic0", intel_avf.Intel_avf, { pciaddr = vf0 })
 config.app(c, "nic1", intel_avf.Intel_avf, { pciaddr = vf1 })
 
@@ -36,12 +38,43 @@ config.link(c, "nic1.output -> match.rx")
 config.link(c, "tee.output2 -> match.comparator")
 
 engine.configure(c)
-engine.main({ duration = 0.01 })
-engine.main({duration = 3})
+engine.main({ duration = 0.01, report = false })
+engine.main({duration = 3, report = false})
 
 function rx(l1, l2)
    return counter.read(engine.link_table[l1 .. " -> " .. l2].stats.rxpackets)
 end
 assert(rx("tee.output1", "nic0.input") ==
 	rx("nic1.output", "match.rx"), "packets sent != packets recv")
+
+
+local n0 = engine.app_table['nic0']
+local n1 = engine.app_table['nic1']
+n0:mbox_sr_stats()
+n1:mbox_sr_stats()
+
+assert(counter.read(n0.shm.tx_unicast) == counter.read(n1.shm.rx_unicast), "mbox_sr_stats counters dont match")
+assert(counter.read(n0.shm.tx_unicast) == packet_count, "mbox_sr_stats.tx_unicast != packet_count")
+
+local c = config.new()
+config.app(c, "synth", synth.Synth, {
+       sizes = {64,128,192,256,384,512,1024},
+       src=src,
+       dst=dst
+} )
+config.app(c, "nic0", intel_avf.Intel_avf, { pciaddr = vf0 })
+config.app(c, "nic1", intel_avf.Intel_avf, { pciaddr = vf1 })
+config.app(c, "sink", basic.Sink)
+config.link(c, "synth.output -> nic0.input")
+config.link(c, "nic1.output -> sink.input")
+engine.configure(c)
+
+while true do
+	local v = rx("synth.output", "nic0.input")
+	if v > 100 * 1000 * 1000 then
+		break
+	end
+	engine.main({ duration = 1, no_report = true })
+end
+
 main.exit(0)

--- a/src/apps/intel_avf/tests/back2back/test.snabb
+++ b/src/apps/intel_avf/tests/back2back/test.snabb
@@ -26,7 +26,8 @@ local c = config.new()
 config.app(c, "synth", synth.Synth, {
        sizes = {64,128,192,256,384,512,1024},
        src=src,
-       dst=dst
+       dst=dst,
+       random_payload = true
 } )
 config.app(c, "tee", basic.Tee)
 config.app(c, "match", match.Match)
@@ -42,8 +43,9 @@ config.link(c, "nic1.output -> match.rx")
 config.link(c, "tee.output2 -> match.comparator")
 
 engine.configure(c)
-engine.main({ duration = 0.01, report = false })
-engine.main({duration = 3, report = false})
+engine.main({duration = 1, report = false})
+engine.report_links()
+engine.report_apps()
 
 function rx(l1, l2)
    return counter.read(engine.link_table[l1 .. " -> " .. l2].stats.rxpackets)
@@ -79,12 +81,16 @@ config.link(c, "synth.output -> nic0.input")
 config.link(c, "nic1.output -> sink.input")
 engine.configure(c)
 
+local tosend = 10 * 1000 * 1000
 while true do
 	local v = rx("synth.output", "nic0.input")
-	if v > 100 * 1000 * 1000 then
+	if v > tosend then
 		break
 	end
 	engine.main({ duration = 1, no_report = true })
 end
+engine.report_links()
+assert(rx("nic1.output", "sink.input") >= tosend,
+       "packets received do not match packets sent")
 engine.stop()
 main.exit(0)

--- a/src/apps/intel_avf/tests/back2back/test.snabb
+++ b/src/apps/intel_avf/tests/back2back/test.snabb
@@ -24,7 +24,7 @@ local counter = require("core.counter")
 
 local c = config.new()
 config.app(c, "synth", synth.Synth, {
-       sizes = {64,128,192,256,384,512,1024},
+       sizes = {64,67,128,133,192,256,384,512,777,1024},
        src=src,
        dst=dst,
        random_payload = true

--- a/src/apps/intel_avf/tests/back2back/test.snabb
+++ b/src/apps/intel_avf/tests/back2back/test.snabb
@@ -1,0 +1,47 @@
+#!../../../../snabb snsh
+local vf0 = os.getenv("SNABB_AVF_VF0")
+local vf1 = os.getenv("SNABB_AVF_VF1")
+
+assert(vf0 ~= nil, "SNABB_AVF_VF0 is nil")
+assert(vf1 ~= nil, "SNABB_AVF_VF0 is nil")
+
+local basic = require("apps.basic.basic_apps")
+local intel_avf = require("apps.intel_avf.intel_avf")
+local match = require("apps.test.match")
+local npackets = require("apps.test.npackets")
+local synth = require("apps.test.synth")
+local counter = require("core.counter")
+
+local c = config.new()
+local src="02:00:00:00:00:00"
+local dst="02:00:00:00:00:01"
+config.app(c, "synth", synth.Synth, {
+       sizes = {64,128,192,256,384,512,1024},
+       src=src,
+       dst=dst
+} )
+config.app(c, "tee", basic.Tee)
+config.app(c, "match", match.Match)
+
+-- 1001 is an important test case, descriptors are written back in sets of 4
+-- 1001, exercises the interrupt driven write back
+config.app(c, "npackets", npackets.Npackets, { npackets = 1001 })
+config.app(c, "nic0", intel_avf.Intel_avf, { pciaddr = vf0 })
+config.app(c, "nic1", intel_avf.Intel_avf, { pciaddr = vf1 })
+
+config.link(c, "synth.output -> npackets.input")
+config.link(c, "npackets.output -> tee.input")
+config.link(c, "tee.output1 -> nic0.input")
+config.link(c, "nic1.output -> match.rx")
+config.link(c, "tee.output2 -> match.comparator")
+
+engine.configure(c)
+engine.main({ duration = 0.01 })
+engine.main({duration = 3})
+
+function rx(l1, l2)
+   return counter.read(engine.link_table[l1 .. " -> " .. l2].stats.rxpackets)
+end
+assert(rx("tee.output1", "nic0.input") ==
+	rx("nic1.output", "match.rx"), "packets sent != packets recv")
+main.exit(0)

--- a/src/apps/intel_avf/tests/back2back/test.snabb
+++ b/src/apps/intel_avf/tests/back2back/test.snabb
@@ -1,9 +1,15 @@
 #!../../../../snabb snsh
 local vf0 = os.getenv("SNABB_AVF_PF0_VF0")
-local vf1 = os.getenv("SNABB_AVF_PF1_VF0")
+local vf1 = os.getenv("SNABB_AVF_PF1_VF0") or os.getenv("SNABB_AVF_PF0_VF1")
 
 assert(vf0 ~= nil, "SNABB_AVF_PF0_VF0 is nil")
 assert(vf1 ~= nil, "SNABB_AVF_PF1_VF0 is nil")
+
+local src = os.getenv("SNABB_AVF_PF0_SRC0")
+local dst = os.getenv("SNABB_AVF_PF1_DST0") or os.getenv("SNABB_AVF_PF0_DST1")
+
+assert(src ~= nil, "SNABB_AVF_SRC0 is nil")
+assert(dst ~= nil, "SNABB_AVF_DST1 is nil")
 
 -- 1001 is an important test case, descriptors are written back in sets of 4
 -- 1001, exercises the interrupt driven write back
@@ -17,8 +23,6 @@ local synth = require("apps.test.synth")
 local counter = require("core.counter")
 
 local c = config.new()
-local src="02:00:00:00:00:00"
-local dst="02:00:00:00:00:10"
 config.app(c, "synth", synth.Synth, {
        sizes = {64,128,192,256,384,512,1024},
        src=src,

--- a/src/apps/intel_avf/tests/info/test.snabb
+++ b/src/apps/intel_avf/tests/info/test.snabb
@@ -1,0 +1,11 @@
+#!../../../../snabb snsh
+local vf0 = os.getenv("SNABB_AVF_PF0_VF0")
+
+assert(vf0 ~= nil, "SNABB_AVF_PF0_VF0 is nil")
+
+local pci = require("lib.hardware.pci")
+
+local info = pci.device_info(vf0)
+print(info.pciaddress, info.vendor, info.device, info.model)
+assert(info.driver == 'apps.intel_avf.intel_avf',
+       "Driver should be apps.intel_avf.intel_avf (is "..info.driver..")")

--- a/src/apps/intel_avf/tests/setup.sh
+++ b/src/apps/intel_avf/tests/setup.sh
@@ -1,4 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+set -e
 
 PFIDX=0
 function setup(){
@@ -26,11 +28,10 @@ function setup(){
 	local loop=0
 	for i in ${@:2}; do
 		local vfdir=$( readlink -f $pfdir/virtfn$loop )
-		local vfnic=$( ls $vfdir/net )
 
 		ip link set $nic vf $loop mac $i
 		ip link set $nic vf $loop spoofchk off
-		ip link set $nic vf $loop trust on
+		ip link set $nic vf $loop trust on || true
 
 		local vfid=$( basename $( readlink -f $vfdir ) )
 		echo $vfid > $vfdir/driver/unbind

--- a/src/apps/intel_avf/tests/setup.sh
+++ b/src/apps/intel_avf/tests/setup.sh
@@ -1,38 +1,44 @@
 #!/bin/bash
 
+PFIDX=0
 function setup(){
-       local pciid=$1
-       local mac=$2
-       if [ -z "$pciid" ]; then
-               echo pciid must be defined
-               exit -1
-       fi
-       local pfdir="/sys/bus/pci/devices/$pciid"
-       local drv=$( readlink -f $pfdir/driver)
-       if [ -e "$drv" ]; then
-               echo $pciid > $drv/unbind
-       else
-               drv=/sys/bus/pci/drivers/i40e
-               echo "pciid" unbound trying $drv
-       fi
-       sleep 1
-       echo $pciid > $drv/bind
-       nic=$( ls $pfdir/net )
-       ip link set up dev $nic
-       echo 1 > "$pfdir/sriov_numvfs"
-       sleep 1
+	local pciid=$1
+	local mac=$2
+	if [ -z "$pciid" ]; then
+		echo pciid must be defined
+		exit -1
+	fi
+	local pfdir="/sys/bus/pci/devices/$pciid"
+	local drv=$( readlink -f $pfdir/driver)
+	if [ -e "$drv" ]; then
+		echo $pciid > $drv/unbind
+	else
+		drv=/sys/bus/pci/drivers/i40e
+		echo "pciid" unbound trying $drv
+	fi
+	sleep 1
+	echo $pciid > $drv/bind
+	nic=$( ls $pfdir/net )
+	ip link set up dev $nic
+	echo $(( $# - 1 )) > "$pfdir/sriov_numvfs"
+	sleep 1
 
-       local vfdir=$( readlink -f $pfdir/virtfn0 )
-       local vfnic=$( ls $vfdir/net )
+	local loop=0
+	for i in ${@:2}; do
+		local vfdir=$( readlink -f $pfdir/virtfn$loop )
+		local vfnic=$( ls $vfdir/net )
 
-       ip link set $nic vf 0 mac $mac
-       local vfid=$( basename $( readlink -f $vfdir ) )
-       echo $vfid > $vfdir/driver/unbind
-       echo $vfid
+		ip link set $nic vf $loop mac $i
+		ip link set $nic vf $loop spoofchk off
+		ip link set $nic vf $loop trust on
+
+		local vfid=$( basename $( readlink -f $vfdir ) )
+		echo $vfid > $vfdir/driver/unbind
+		echo "export SNABB_AVF_PF${PFIDX}_VF${loop}=$vfid"
+		loop=$(( loop + 1 ))
+	done
+	PFIDX=$(( VFIDX + 1 ))
 }
 
-SNABB_AVF_VF0=$(setup $SNABB_AVF_PF0 02:00:00:00:00:00)
-SNABB_AVF_VF1=$(setup $SNABB_AVF_PF1 02:00:00:00:00:01)
-sleep 3
-echo export SNABB_AVF_VF0=$SNABB_AVF_VF0
-echo export SNABB_AVF_VF1=$SNABB_AVF_VF1
+setup $SNABB_AVF_PF0 02:00:00:00:00:00 02:00:00:00:00:01 02:00:00:00:00:02 02:00:00:00:00:03
+setup $SNABB_AVF_PF1 02:00:00:00:00:10 02:00:00:00:00:11 02:00:00:00:00:12 02:00:00:00:00:13

--- a/src/apps/intel_avf/tests/setup.sh
+++ b/src/apps/intel_avf/tests/setup.sh
@@ -35,10 +35,14 @@ function setup(){
 		local vfid=$( basename $( readlink -f $vfdir ) )
 		echo $vfid > $vfdir/driver/unbind
 		echo "export SNABB_AVF_PF${PFIDX}_VF${loop}=$vfid"
+                echo "export SNABB_AVF_PF${PFIDX}_SRC${loop}=$i"
+                echo "export SNABB_AVF_PF${PFIDX}_DST${loop}=$i"
 		loop=$(( loop + 1 ))
 	done
-	PFIDX=$(( VFIDX + 1 ))
+	PFIDX=$(( PFIDX + 1 ))
 }
 
-setup $SNABB_AVF_PF0 02:00:00:00:00:00 02:00:00:00:00:01 02:00:00:00:00:02 02:00:00:00:00:03
-setup $SNABB_AVF_PF1 02:00:00:00:00:10 02:00:00:00:00:11 02:00:00:00:00:12 02:00:00:00:00:13
+ADDR_PF0=(02:00:00:00:00:00 02:00:00:00:00:01)
+ADDR_PF1=(02:00:00:00:00:10 02:00:00:00:00:11)
+setup $SNABB_AVF_PF0 ${ADDR_PF0[*]}
+[ -z $SNABB_AVF_PF1 ] || setup $SNABB_AVF_PF1 ${ADDR_PF1[*]}

--- a/src/apps/intel_avf/tests/setup.sh
+++ b/src/apps/intel_avf/tests/setup.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+function setup(){
+       local pciid=$1
+       local mac=$2
+       if [ -z "$pciid" ]; then
+               echo pciid must be defined
+               exit -1
+       fi
+       local pfdir="/sys/bus/pci/devices/$pciid"
+       local drv=$( readlink -f $pfdir/driver)
+       if [ -e "$drv" ]; then
+               echo $pciid > $drv/unbind
+       else
+               drv=/sys/bus/pci/drivers/i40e
+               echo "pciid" unbound trying $drv
+       fi
+       sleep 1
+       echo $pciid > $drv/bind
+       nic=$( ls $pfdir/net )
+       ip link set up dev $nic
+       echo 1 > "$pfdir/sriov_numvfs"
+       sleep 1
+
+       local vfdir=$( readlink -f $pfdir/virtfn0 )
+       local vfnic=$( ls $vfdir/net )
+
+       ip link set $nic vf 0 mac $mac
+       local vfid=$( basename $( readlink -f $vfdir ) )
+       echo $vfid > $vfdir/driver/unbind
+       echo $vfid
+}
+
+SNABB_AVF_VF0=$(setup $SNABB_AVF_PF0 02:00:00:00:00:00)
+SNABB_AVF_VF1=$(setup $SNABB_AVF_PF1 02:00:00:00:00:01)
+echo export SNABB_AVF_VF0=$SNABB_AVF_VF0
+echo export SNABB_AVF_VF1=$SNABB_AVF_VF1

--- a/src/apps/intel_avf/tests/setup.sh
+++ b/src/apps/intel_avf/tests/setup.sh
@@ -33,5 +33,6 @@ function setup(){
 
 SNABB_AVF_VF0=$(setup $SNABB_AVF_PF0 02:00:00:00:00:00)
 SNABB_AVF_VF1=$(setup $SNABB_AVF_PF1 02:00:00:00:00:01)
+sleep 3
 echo export SNABB_AVF_VF0=$SNABB_AVF_VF0
 echo export SNABB_AVF_VF1=$SNABB_AVF_VF1

--- a/src/apps/intel_mp/intel_mp.lua
+++ b/src/apps/intel_mp/intel_mp.lua
@@ -276,7 +276,7 @@ PQMPRC      0x10038 +0x100*0..7     RCR Per Queue Multicast Packets Received
    singleton = [[
 EEMNGCTL  0x01010 -            RW Manageability EEPROM-Mode Control Register
 EEC       0x00010 -            RW EEPROM-Mode Control Register
-FACTPS	  0x05B30 -            Function Active and Power State to MNG
+FACTPS	  0x05B30 -            RO Function Active and Power State to MNG
 ]]
 }
 

--- a/src/apps/test/README.md
+++ b/src/apps/test/README.md
@@ -71,9 +71,11 @@ An array of numbers designating the packet payload sizes. The default is
 `{64}`.
 
 — Key **random_payload**
-Generate a random payload for each packet in `sizes`
+
+Generate a random payload for each packet in `sizes`.
 
 — Key **packet_id**
+
 Insert the packet number (32bit uint) directly after the ethertype. The packet
 number starts at 0 and is sequential on each output link.
 

--- a/src/apps/test/README.md
+++ b/src/apps/test/README.md
@@ -69,3 +69,29 @@ Source and destination MAC addresses in human readable from. The default is
 
 An array of numbers designating the packet payload sizes. The default is
 `{64}`.
+
+— Key **random_payload**
+Generate a random payload for each packet in `sizes`
+
+— Key **packet_id**
+Insert the packet number (32bit uint) directly after the ethertype. The packet
+number starts at 0 and is sequential on each output link.
+
+## Npackets (apps.test.npackets)
+
+The `Npackets` app allows are most N packets to flow through it. Any further
+packets are never dequeued from input.
+
+    DIAGRAM: Npackets
+    		+-----------+
+input ->     	| Npackets  | -> output
+    		+-----------+
+
+### Configuration
+
+The `Npackets` app accepts a table as its configuration argument. The following
+keys are defined:
+
+— Key **npackets**
+The number of packets to forward, further packets are never dequeued from
+input.

--- a/src/apps/test/npackets.lua
+++ b/src/apps/test/npackets.lua
@@ -1,0 +1,41 @@
+module(...,package.seeall)
+
+local ffi = require("ffi")
+local C = ffi.C
+Npackets = {
+   config = {
+      npackets = { default = 1000000 }
+   }
+}
+
+function Npackets:new (conf)
+   return setmetatable({n = conf.npackets}, { __index = Npackets})
+end
+
+function Npackets:push ()
+   while not link.empty(self.input.input) and
+      self.n > 0 do
+      link.transmit(self.output.output, link.receive(self.input.input))
+      self.n = self.n - 1
+   end
+end
+
+function selftest()
+   local synth = require("apps.test.synth")
+   local basic_apps = require("apps.basic.basic_apps")
+   local counter = require("core.counter")
+
+   local c = config.new()
+   config.app(c, "src", synth.Synth)
+   config.app(c, "n", Npackets, { npackets = 100 })
+   config.app(c, "sink", basic_apps.Sink)
+   config.link(c, "src.output -> n.input")
+   config.link(c, "n.output -> sink.input")
+   engine.configure(c)
+   assert(engine.app_table.n.n == 100)
+   engine.main({duration=1})
+   assert(engine.app_table.n.n == 0)
+   assert(counter.read(engine.link_table['src.output -> n.input'].stats.txpackets) > 100)
+   local cnt = counter.read(engine.link_table['n.output -> sink.input'].stats.rxpackets)
+   assert(100 == cnt)
+end

--- a/src/apps/test/synth.lua
+++ b/src/apps/test/synth.lua
@@ -6,6 +6,7 @@ local ffi = require("ffi")
 local ethernet = require("lib.protocol.ethernet")
 local datagram = require("lib.protocol.datagram")
 local transmit, receive = link.transmit, link.receive
+local lib = require("core.lib")
 
 Synth = {
    config = {
@@ -24,15 +25,12 @@ function Synth:new (conf)
       local payload_size = size - ethernet:sizeof()
       assert(payload_size >= 0 and payload_size <= 1536,
              "Invalid payload size: "..payload_size)
-      local data = ffi.new("char[?]", payload_size)
+      local data
       if conf.random_payload then
-         -- dstmac + srcmac + type
-         local off = 6 + 6 + 2
-         ffi.fill(data, payload_size)
-         ffi.copy(data + off,
-            lib.random_bytes(payload_size - off), payload_size - off)
+         data = lib.random_bytes(payload_size)
+      else
+         data = ffi.new("char[?]", payload_size)
       end
-
       local dgram = datagram:new(packet.from_pointer(data, payload_size))
       local ether = ethernet:new({ src = ethernet:pton(conf.src),
 				   dst = ethernet:pton(conf.dst),

--- a/src/lib/hardware/pci.lua
+++ b/src/lib/hardware/pci.lua
@@ -67,6 +67,8 @@ model = {
    ["X520"]      = 'Intel X520',
    ["i350"]      = 'Intel 350',
    ["i210"]      = 'Intel 210',
+   ["XL710_VF"]  = 'Intel XL710/X710 Virtual Function',
+   ["AVF"]       = 'Intel AVF'
 }
 
 -- Supported cards indexed by vendor and device id.
@@ -81,6 +83,8 @@ local cards = {
       ["0x1521"] = {model = model["i350"],      driver = 'apps.intel_mp.intel_mp'},
       ["0x1533"] = {model = model["i210"],      driver = 'apps.intel_mp.intel_mp'},
       ["0x157b"] = {model = model["i210"],      driver = 'apps.intel_mp.intel_mp'},
+      ["0x154c"] = {model = model["XL710_VF"],  driver = 'apps.intel_avf.intel_avf'},
+      ["0x1889"] = {model = model["AVF"],       driver = 'apps.intel_avf.intel_avf'},
    },
    ["0x1924"] =  {
       ["0x0903"] = {model = 'SFN7122F', driver = 'apps.solarflare.solarflare'}
@@ -90,6 +94,7 @@ local cards = {
 local link_names = {
    ['apps.solarflare.solarflare'] = { "rx", "tx" },
    ['apps.intel_mp.intel_mp']     = { "input", "output" },
+   ['apps.intel_avf.intel_avf']   = { "input", "output" },
    ['apps.intel.intel_app']       = { "rx", "tx" }
 }
 

--- a/src/lib/hardware/register.lua
+++ b/src/lib/hardware/register.lua
@@ -218,7 +218,7 @@ end
 --- the optional 'n' argument specifies which register of an array gets
 --- created (default 0)
 function define (description, table, base_ptr, n)
-   local pattern = [[ *(%S+) +(%S+) +(%S+) +(%S+) (.-)
+   local pattern = [[ *(%S+)%s+(%S+)%s+(%S+)%s+(%S+)%s+(.-)
 ]]
    for name,offset,index,perm,longname in description:gmatch(pattern) do
       local offs = in_range(offset, index, n)
@@ -232,7 +232,7 @@ end
 -- an array of registers.
 -- naïve implementation: actually create the whole array
 function define_array (description, table, base_ptr)
-   local pattern = [[ *(%S+) +(%S+) +(%S+) +(%S+) (.-)
+   local pattern = [[ *(%S+)%s+(%S+)%s+(%S+)%s+(%S+)%s+(.-)
 ]]
    for name,offset,index,perm,longname in description:gmatch(pattern) do
       if is_range(index) then

--- a/src/lib/macaddress.lua
+++ b/src/lib/macaddress.lua
@@ -31,6 +31,11 @@ function mac_mt:new (m)
    end
    return macobj
 end
+function mac_mt:from_bytes(b)
+	local macobj = mac_t()
+	ffi.copy(macobj.bytes, b, 6)
+	return macobj
+end
 
 function mac_mt:__tostring ()
    return string.format('%02X:%02X:%02X:%02X:%02X:%02X',


### PR DESCRIPTION
This PR includes @petebristow’s Intel AVF driver in #1411, as well as some minor polish and a bug fix or two. Tested on lugano-1 with both x710 and xl710 cards (rev 01) like so:

```
sudo SNABB_AVF_PF0=0000:03:00.0 apps/intel_avf/selftest.sh
```

(It’s possible to test this with a single unwired port/PF afterall.)

Cc @lukego 

Would be neat to get this into the pending release!