### PR TITLE
lib.ptree: cleanup obsolete aggregated stats

### DIFF
--- a/src/lib/ptree/ptree.lua
+++ b/src/lib/ptree/ptree.lua
@@ -374,6 +374,14 @@ function Manager:monitor_worker_stats(id)
                counters.archived[0] = counters.archived[0] + val
                counter.delete(qualified_name)
                S.unlink(strip_suffix(qualified_name, ".counter")..".rrd")
+               local last_in_set = true
+               for _ in pairs(counters.active) do
+                  last_in_set = false
+                  break
+               end
+               if last_in_set then
+                  self:cleanup_aggregated_stats(name, 'counter')
+               end
             end
          elseif has_suffix(ev.name, '.gauge') then
             local gauges = self.gauges[name]
@@ -390,6 +398,14 @@ function Manager:monitor_worker_stats(id)
                gauges.active[pid] = nil
                gauges.rrd[pid] = nil
                S.unlink(strip_suffix(qualified_name, ".gauge")..".rrd")
+               local last_in_set = true
+               for _ in pairs(gauges.active) do
+                  last_in_set = false
+                  break
+               end
+               if last_in_set then
+                  self:cleanup_aggregated_stats(name, 'gauge')
+               end
             end
          end
       end
@@ -422,6 +438,20 @@ function Manager:sample_active_stats()
       end
       fiber_sleep(1)
    end
+end
+
+function Manager:cleanup_aggregated_stats(name, typ)
+   shm.unlink(name)
+   shm.unlink(strip_suffix(name, "."..typ)..".rrd")
+   self:cleanup_parent_directories(name)
+end
+
+function Manager:cleanup_parent_directories(name)
+   local parent = name:match("(.*)/[^/]+$")
+   if not parent then return end
+   for _ in pairs(shm.children(parent)) do return end
+   shm.unlink(parent)
+   self:cleanup_parent_directories(parent)
 end
 
 function Manager:start_worker_for_graph(id, graph)


### PR DESCRIPTION
Addresses orphaned counter/gauge aggregates accumulated by lib.ptree. Adds a check whether an aggregate is still backed by any active counter source; if not (i.e., it is orphaned) delete the respective aggregates.

Before this patch, apps with unique names that were started and stopped over the lifetime of the Snabb program using lib.ptree would cause the leader to accumulate past counter aggregates, leading to stale links shown in `snabb top`, and eventually using up all space in `/var/run/snabb`.