### PR TITLE
Tracing JIT stability improvements from lwAFTR

### DIFF
--- a/lib/luajit/src/lj_trace.c
+++ b/lib/luajit/src/lj_trace.c
@@ -371,7 +371,8 @@ static void trace_clearsnapcounts(jit_State *J)
     t = traceref(J, i);
     if (t != NULL)
       for (s = 0; s < t->nsnap; s++)
-        t->snap[s].count = 0;
+        if (t->snap[s].count != SNAPCOUNT_DONE)
+          t->snap[s].count = 0;
   }
 }
 

--- a/lib/luajit/src/lj_trace.c
+++ b/lib/luajit/src/lj_trace.c
@@ -6,6 +6,8 @@
 #define lj_trace_c
 #define LUA_CORE
 
+#include <time.h>
+
 #include "lj_obj.h"
 
 
@@ -46,6 +48,42 @@ void lj_trace_err_info(jit_State *J, TraceError e)
   setintV(J->L->top++, (int32_t)e);
   lj_err_throw(J->L, LUA_ERRRUN);
 }
+
+/* -- Hotcount decay ------------------------------------------------------ */
+
+/* We reset all hotcounts every second. This is a rough way to establish a
+** relation with elapsed time so that hotcounts provide a measure of frequency.
+**
+** The concrete goal is to ensure that the JIT will trace code that becomes hot
+** over a short duration, but not code that becomes hot over, say, the course
+** of an hour.
+**
+** The "one second" constant is certainly tunable.
+** */
+
+static inline uint64_t gettime_ns (void)
+{
+  struct timespec ts;
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+  return ts.tv_sec * 1000000000LL + ts.tv_nsec;
+}
+
+/* Timestamp (ns) of last hotcount reset. */
+static uint64_t hotcount_decay_ts;
+
+/* Decay hotcounts every second. */
+int hotcount_decay (jit_State *J)
+{
+  uint64_t ts = gettime_ns();
+  int decay = (ts - hotcount_decay_ts) > 1000000000LL; /* 1s elapsed? */
+  if (decay) {
+    /* Reset hotcounts. */
+    lj_dispatch_init_hotcount(J2G(J));
+    hotcount_decay_ts = ts;
+  }
+  return decay;
+}
+
 
 /* -- Trace management ---------------------------------------------------- */
 
@@ -277,6 +315,8 @@ int lj_trace_flushall(lua_State *L)
   memset(J->penalty, 0, sizeof(J->penalty));
   /* Reset hotcounts. */
   lj_dispatch_init_hotcount(J2G(J));
+  /* Initialize hotcount decay timestamp. */
+  hotcount_decay_ts = gettime_ns();
   /* Free the whole machine code and invalidate all exit stub groups. */
   lj_mcode_free(J);
   memset(J->exitstubgroup, 0, sizeof(J->exitstubgroup));
@@ -655,6 +695,9 @@ void lj_trace_ins(jit_State *J, const BCIns *pc)
 void lj_trace_hot(jit_State *J, const BCIns *pc)
 {
   /* Note: pc is the interpreter bytecode PC here. It's offset by 1. */
+  if (hotcount_decay(J))
+    /* Check for hotcount decay, do nothing if hotcounts have decayed. */
+    return;
   ERRNO_SAVE
   /* Reset hotcount. */
   hotcount_set(J2GG(J), pc, J->param[JIT_P_hotloop]*HOTCOUNT_LOOP);
@@ -671,6 +714,9 @@ void lj_trace_hot(jit_State *J, const BCIns *pc)
 /* Check for a hot side exit. If yes, start recording a side trace. */
 static void trace_hotside(jit_State *J, const BCIns *pc)
 {
+  if (hotcount_decay(J))
+    /* Check for hotcount decay, do nothing if hotcounts have decayed. */
+    return;
   SnapShot *snap = &traceref(J, J->parent)->snap[J->exitno];
   if (!(J2G(J)->hookmask & HOOK_GC) &&
       isluafunc(curr_func(J->L)) &&

--- a/src/core/app.lua
+++ b/src/core/app.lua
@@ -82,7 +82,7 @@ int vmprofile_get_profile_size();
 void vmprofile_set_profile(void *counters);
 ]]
 
-local vmprofile_t = ffi.new("uint8_t["..C.vmprofile_get_profile_size().."]")
+local vmprofile_t = ffi.typeof("uint8_t["..C.vmprofile_get_profile_size().."]")
 
 local vmprofiles = {}
 local function getvmprofile (name)
@@ -94,6 +94,16 @@ end
 
 function setvmprofile (name)
    C.vmprofile_set_profile(getvmprofile(name))
+end
+
+function clearvmprofiles ()
+   jit.vmprofile.stop()
+   for name, profile in pairs(vmprofiles) do
+      shm.unmap(profile)
+      shm.unlink("vmprofile/"..name..".vmprofile")
+      vmprofiles[name] = nil
+   end
+   jit.vmprofile.start()
 end
 
 -- True when the engine is running the breathe loop.

--- a/src/lib/timers/ingress_drop_monitor.lua
+++ b/src/lib/timers/ingress_drop_monitor.lua
@@ -21,11 +21,13 @@ local IngressDropMonitor = {}
 function new(args)
    local ret = {
       threshold = args.threshold or 100000,
+      threshold_timeout = args.threshold_timeout or 10,
       wait = args.wait or 30,
       grace_period = args.grace_period or 10,
       action = args.action or 'flush',
       tips_url = args.tips_url or default_tips_url,
       last_flush = now(), -- Start in the grace period.
+      last_drop = now(),
       last_value = ffi.new('uint64_t[1]'),
       current_value = ffi.new('uint64_t[1]'),
    }
@@ -70,6 +72,12 @@ function IngressDropMonitor:jit_flush_if_needed ()
    if now() - self.last_flush < self.grace_period then
       self.last_value[0] = self.current_value[0]
       return
+   end
+   if self.last_value[0] < self.current_value[0] then
+      self.last_drop = now()
+   elseif now() - self.last_drop > self.threshold_timeout then
+      -- Reset last_value if no drops occurred within threshold_timeout.
+      self.last_value[0] = self.current_value[0]
    end
    if self.current_value[0] - self.last_value[0] < self.threshold then
       self.ingress_packet_drop_alarm:clear()

--- a/src/lib/timers/ingress_drop_monitor.lua
+++ b/src/lib/timers/ingress_drop_monitor.lua
@@ -88,7 +88,10 @@ function IngressDropMonitor:jit_flush_if_needed ()
    print(msg)
 
    self.ingress_packet_drop_alarm:raise({alarm_text=msg})
-   if self.action == 'flush' then jit.flush() end
+   if self.action == 'flush' then
+      jit.flush()
+      engine.clearvmprofiles()
+   end
 end
 
 function IngressDropMonitor:timer(interval)


### PR DESCRIPTION
This includes some improvements to ingress_drop_monitor as well as an experimental patch[1]  for RaptorJIT that prevents “long-tail trace” generation.

- [1] https://github.com/raptorjit/raptorjit/pull/260

I’ve decided to include this since it has worked well for lwAFTR and I think is ready for broader application in Snabb upstream.