### PR TITLE
Use MPMC bounded queue for group freelist

### DIFF
--- a/src/apps/interlink/freelist_instrument.lua
+++ b/src/apps/interlink/freelist_instrument.lua
@@ -1,0 +1,26 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
+module(...,package.seeall)
+
+local histogram = require("core.histogram")
+local rdtsc = require("lib.tsc").rdtsc
+
+function instrument_freelist ()
+   local rebalance_latency = histogram.create('engine/rebalance_latency.histogram', 1, 1e9)
+   local allocate_latency = histogram.create('engine/allocate_latency.histogram', 1, 1e9)
+   
+   local rebalance_freelists, allocate = packet.rebalance_freelists, packet.allocate
+   packet.rebalance_freelists = function ()
+      local start = rdtsc()
+      rebalance_freelists()
+      rebalance_latency:add(tonumber(rdtsc()-start))
+   end
+   packet.allocate = function ()
+      local start = rdtsc()
+      local p = allocate()
+      allocate_latency:add(tonumber(rdtsc()-start))
+      return p
+   end
+   
+   return rebalance_latency, allocate_latency
+end

--- a/src/apps/interlink/freelist_instrument.lua
+++ b/src/apps/interlink/freelist_instrument.lua
@@ -10,10 +10,10 @@ function instrument_freelist ()
    local rebalance_latency = histogram.create('engine/rebalance_latency.histogram', 1, 100e6)
    local reclaim_latency = histogram.create('engine/reclaim_latency.histogram', 1, 100e6)
    
-   local rebalance_freelists, reclaim_step = packet.rebalance_freelists, packet.reclaim_step
-   packet.rebalance_freelists = function ()
+   local rebalance_step, reclaim_step = packet.rebalance_step, packet.reclaim_step
+   packet.rebalance_step = function ()
       local start = ts:stamp()
-      rebalance_freelists()
+      rebalance_step()
       rebalance_latency:add(tonumber(ts:to_ns(ts:stamp()-start)))
    end
    packet.reclaim_step = function ()

--- a/src/apps/interlink/test_sink.lua
+++ b/src/apps/interlink/test_sink.lua
@@ -1,0 +1,36 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
+module(...,package.seeall)
+
+local Receiver = require("apps.interlink.receiver")
+local Sink = require("apps.basic.basic_apps").Sink
+local lib = require("core.lib")
+local numa = require("lib.numa")
+
+function configure (c, name)
+   config.app(c, name, Receiver)
+   config.app(c, "sink", Sink)
+   config.link(c, name..".output -> sink.input")
+end
+
+function start (name, duration)
+   local c = config.new()
+   configure(c, name)
+   engine.configure(c)
+   engine.main{duration=duration}
+end
+
+local instr = require("apps.interlink.freelist_instrument")
+
+function start_instrument (name, duration, core)
+   numa.bind_to_cpu(core, 'skip')
+   local rebalance_latency = instr.instrument_freelist()
+   start(name, duration)
+   local min, avg, max = rebalance_latency:summarize()
+   print(("rebalance latency (ns)    min:%16s    avg:%16s    max:%16s")
+      :format(lib.comma_value(math.floor(min)),
+              lib.comma_value(math.floor(avg)),
+              lib.comma_value(math.floor(max))))
+   io.stdout:flush()
+end
+

--- a/src/apps/interlink/test_sink.lua
+++ b/src/apps/interlink/test_sink.lua
@@ -26,11 +26,12 @@ function start_instrument (name, duration, core)
    numa.bind_to_cpu(core, 'skip')
    local rebalance_latency = instr.instrument_freelist()
    start(name, duration)
+   instr.histogram_csv(rebalance_latency, "rebalance")
    local min, avg, max = rebalance_latency:summarize()
-   print(("rebalance latency (ns)    min:%16s    avg:%16s    max:%16s")
+   io.stderr:write(("rebalance latency (ns)    min:%16s    avg:%16s    max:%16s\n")
       :format(lib.comma_value(math.floor(min)),
               lib.comma_value(math.floor(avg)),
               lib.comma_value(math.floor(max))))
-   io.stdout:flush()
+   io.stderr:flush()
 end
 

--- a/src/apps/interlink/test_sink.lua
+++ b/src/apps/interlink/test_sink.lua
@@ -28,8 +28,9 @@ function start_instrument (name, duration, core)
    start(name, duration)
    instr.histogram_csv(rebalance_latency, "rebalance")
    local min, avg, max = rebalance_latency:summarize()
-   io.stderr:write(("rebalance latency (ns)    min:%16s    avg:%16s    max:%16s\n")
-      :format(lib.comma_value(math.floor(min)),
+   io.stderr:write(("(%d) rebalance latency (ns)    min:%16s    avg:%16s    max:%16s\n")
+      :format(core,
+              lib.comma_value(math.floor(min)),
               lib.comma_value(math.floor(avg)),
               lib.comma_value(math.floor(max))))
    io.stderr:flush()

--- a/src/apps/interlink/test_source.lua
+++ b/src/apps/interlink/test_source.lua
@@ -4,12 +4,52 @@ module(...,package.seeall)
 
 local Transmitter = require("apps.interlink.transmitter")
 local Source = require("apps.basic.basic_apps").Source
+local lib = require("core.lib")
+local numa = require("lib.numa")
 
-function start (name)
-   local c = config.new()
+function configure (c, name)
    config.app(c, name, Transmitter)
    config.app(c, "source", Source)
-   config.link(c, "source.output -> "..name..".input")
+   config.link(c, "source."..name.." -> "..name..".input")
+end
+
+function start (name, duration)
+   local c = config.new()
+   configure(c, name)
    engine.configure(c)
-   engine.main()
+   engine.main{duration=duration}
+end
+
+function startn (name, duration, n)
+   local c = config.new()
+   for i=1,n do
+      configure(c, name..i)
+   end
+   engine.configure(c)
+   engine.main{duration=duration}
+end
+
+function txpackets ()
+   local txpackets = 0
+   for _, output in ipairs(engine.app_table["source"].output) do
+      txpackets = txpackets + link.stats(output).rxpackets
+   end
+   return txpackets
+end
+
+local instr = require("apps.interlink.freelist_instrument")
+
+function startn_instrument (name, duration, n, core)
+   numa.bind_to_cpu(core, 'skip')
+   local _, allocate_latency = instr.instrument_freelist()
+   startn(name, duration, n)
+   local txpackets = txpackets()
+   local min, avg, max = allocate_latency:summarize()
+   engine.main{duration=1, no_report=true}
+   print(("allocate latency (ns)     min:%16s    avg:%16s    max:%16s")
+      :format(lib.comma_value(math.floor(min)),
+              lib.comma_value(math.floor(avg)),
+              lib.comma_value(math.floor(max))))
+   print(txpackets / 1e6 / duration .. " Mpps")
+   io.stdout:flush()
 end

--- a/src/apps/interlink/test_source.lua
+++ b/src/apps/interlink/test_source.lua
@@ -47,8 +47,9 @@ function startn_instrument (name, duration, n, core)
    instr.histogram_csv(reclaim_latency, "reclaim")
    local min, avg, max = reclaim_latency:summarize()
    engine.main{duration=1, no_report=true}
-   io.stderr:write(("reclaim latency (ns)     min:%16s    avg:%16s    max:%16s\n")
-      :format(lib.comma_value(math.floor(min)),
+   io.stderr:write(("(%d) reclaim latency (ns)     min:%16s    avg:%16s    max:%16s\n")
+      :format(core,
+              lib.comma_value(math.floor(min)),
               lib.comma_value(math.floor(avg)),
               lib.comma_value(math.floor(max))))
    io.stderr:write(("%.3f Mpps\n"):format(txpackets / 1e6 / duration))

--- a/src/apps/interlink/wait_test.snabb
+++ b/src/apps/interlink/wait_test.snabb
@@ -14,6 +14,7 @@ local CPUS = numa.parse_cpuset(main.parameters[3] or "")
 local cores = {}
 for core in pairs(CPUS) do
    table.insert(cores, core)
+   table.sort(cores)
 end
 
 require("apps.interlink.freelist_instrument").histogram_csv_header()

--- a/src/apps/interlink/wait_test.snabb
+++ b/src/apps/interlink/wait_test.snabb
@@ -20,12 +20,12 @@ require("apps.interlink.freelist_instrument").histogram_csv_header()
 io.stdout:flush()
 
 for i=1,NCONSUMERS do
-   worker.start("sink", ([[require("apps.interlink.test_sink").start_instrument(%q, %d, %s)]])
-      :format("test"..i, DURATION, cores[i]))
+   worker.start("sink"..i, ([[require("apps.interlink.test_sink").start_instrument(%q, %d, %s)]])
+      :format("test"..i, DURATION, cores[1+i]))
 end
 
 worker.start("source", ([[require("apps.interlink.test_source").startn_instrument(%q, %d, %d, %s)]])
-   :format("test", DURATION, NCONSUMERS, cores[NCONSUMERS+1]))
+   :format("test", DURATION, NCONSUMERS, assert(cores[1])))
 
 engine.main{done = function ()
    for w, s in pairs(worker.status()) do

--- a/src/apps/interlink/wait_test.snabb
+++ b/src/apps/interlink/wait_test.snabb
@@ -1,0 +1,33 @@
+#!snabb snsh
+
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
+local worker = require("core.worker")
+local numa = require("lib.numa")
+
+-- Test wait times caused by group freelist rebalancing
+-- Synopsis: wait_test.snabb [duration] [nconsumers]
+local DURATION = tonumber(main.parameters[1]) or 10
+local NCONSUMERS = tonumber(main.parameters[2]) or 10
+local CPUS = numa.parse_cpuset(main.parameters[3] or "")
+
+local cores = {}
+for core in pairs(CPUS) do
+   table.insert(cores, core)
+end
+
+for i=1,NCONSUMERS do
+   worker.start("sink", ([[require("apps.interlink.test_sink").start_instrument(%q, %d, %s)]])
+      :format("test"..i, DURATION, cores[i]))
+end
+
+worker.start("source", ([[require("apps.interlink.test_source").startn_instrument(%q, %d, %d, %s)]])
+   :format("test", DURATION, NCONSUMERS, cores[NCONSUMERS+1]))
+
+engine.main{done = function ()
+   for w, s in pairs(worker.status()) do
+      if s.alive then return false end
+   end
+   return true
+end}
+engine.main{duration=1, no_report=true}

--- a/src/apps/interlink/wait_test.snabb
+++ b/src/apps/interlink/wait_test.snabb
@@ -33,4 +33,3 @@ engine.main{done = function ()
    end
    return true
 end}
-engine.main{duration=1, no_report=true}

--- a/src/apps/interlink/wait_test.snabb
+++ b/src/apps/interlink/wait_test.snabb
@@ -16,6 +16,9 @@ for core in pairs(CPUS) do
    table.insert(cores, core)
 end
 
+require("apps.interlink.freelist_instrument").histogram_csv_header()
+io.stdout:flush()
+
 for i=1,NCONSUMERS do
    worker.start("sink", ([[require("apps.interlink.test_sink").start_instrument(%q, %d, %s)]])
       :format("test"..i, DURATION, cores[i]))

--- a/src/core/app.lua
+++ b/src/core/app.lua
@@ -604,10 +604,9 @@ function breathe ()
    end
    ::PUSH_EXIT::
    counter.add(breaths)
-   -- Commit counters and rebalance freelists at a reasonable frequency
+   -- Commit counters at a reasonable frequency
    if counter.read(breaths) % 100 == 0 then
       counter.commit()
-      packet.rebalance_freelists()
    end
    running = false
 end

--- a/src/core/group_freelist.lua
+++ b/src/core/group_freelist.lua
@@ -1,0 +1,134 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
+module(...,package.seeall)
+
+local sync = require("core.sync")
+local shm  = require("core.shm")
+local ffi  = require("ffi")
+local band = bit.band
+local min  = math.min
+
+local SIZE = 1048576 -- 2^20, roughly one million
+local MAX = SIZE - 1
+
+local CACHELINE = 64 -- XXX - make dynamic
+local INT = ffi.sizeof("uint32_t")
+
+ffi.cdef([[
+struct group_freelist {
+   uint32_t h_remove[1];
+   uint8_t pad_h_remove[]]..CACHELINE-1*INT..[[];
+
+   uint32_t t_remove[1];
+   uint8_t pad_t_remove[]]..CACHELINE-1*INT..[[];
+
+   uint32_t h_add[1];
+   uint8_t pad_h_add[]]..CACHELINE-1*INT..[[];
+
+   uint32_t t_add[1];
+   uint8_t pad_t_add[]]..CACHELINE-1*INT..[[];
+
+   struct packet *list[]]..SIZE..[[];
+} __attribute__((packed, aligned(]]..CACHELINE..[[)))]])
+
+
+function freelist_create (name)
+   return shm.create(name, "struct group_freelist")
+end
+
+function freelist_open (name, readonly)
+   return shm.open(name, "struct group_freelist", readonly)
+end
+
+local function mask (i)
+   return band(i, MAX)
+end
+
+function start_add (fl, n)
+   while true do
+      local head = fl.h_add[0]
+      assert(MAX-mask(head - fl.t_add[0]) >= n, "group freelist overflow")
+      if sync.cas(fl.h_add, head, mask(head + n)) then
+         return head
+      end
+   end
+end
+
+function add (fl, head, i, p)
+   fl.list[mask(head+i)] = p
+end
+
+local function finish_add1 (fl, head, n)
+   return sync.cas(fl.h_remove, head, mask(head + n))
+end
+function finish_add (fl, head, n)
+   while not finish_add1(fl, head, n) do end
+end
+
+function start_remove (fl, n)
+   while true do
+      local tail = fl.t_remove[0]
+      local n = min(n, mask(fl.h_remove[0] - tail))
+      if n == 0 or sync.cas(fl.t_remove, tail, mask(tail + n)) then
+         return tail, n
+      end
+   end
+end
+
+function remove (fl, tail, i)
+   local p = fl.list[mask(tail+i)]
+   fl.list[mask(tail+i)] = nil
+   return p
+end
+
+local function finish_remove1 (fl, tail, n)
+   return sync.cas(fl.t_add, tail, mask(tail + n))
+end
+function finish_remove (fl, tail, n)
+   while not finish_remove1(fl, tail, n) do end
+end
+
+
+function selftest ()
+   local fl = freelist_create("test_freelist")
+   assert(select(2, start_remove(fl, 1)) == 0) -- empty
+
+   local w1 = start_add(fl, 1000)
+   local w2 = start_add(fl, 3700)
+   assert(select(2, start_remove(fl, 1)) == 0) -- empty
+   assert(not finish_add1(fl, w2, 3700))
+   assert(finish_add1(fl, w1, 1000))
+   assert(finish_add1(fl, w2, 3700))
+   local r1, nr1 = start_remove(fl, 2000)
+   assert(r1 and nr1 == 2000)
+   local r2, nr2 = start_remove(fl, 3000)
+   assert(r2 and nr2 == 2700)
+   assert(not finish_remove1(fl, r2, nr2))
+   assert(finish_remove1(fl, r1, nr1))
+   assert(finish_remove1(fl, r2, nr2))
+   assert(select(2, start_remove(fl, 1)) == 0) -- empty
+
+   local w3 = start_add(fl, 12345)
+   local w4 = start_add(fl, 54321)
+   assert(finish_add1(fl, w3, 12345))
+   local r3, nr3 = start_remove(fl, 10000)
+   assert(r3 and nr3 == 10000)
+   assert(finish_add1(fl, w4, 54321))
+   local r4, nr4 = start_remove(fl, 54321+2345)
+   assert(r4 and nr4 == 54321+2345)
+   assert(not finish_remove1(fl, r4, nr4))
+   assert(finish_remove1(fl, r3, nr3))
+   assert(finish_remove1(fl, r4, nr4))
+   assert(select(2, start_remove(fl, 1)) == 0) -- empty
+
+   local w5 = start_add(fl, MAX)
+   assert(not pcall(start_add, fl, 1)) -- full
+   assert(finish_add1(fl, w5, MAX))
+   local r5, nr5 = start_remove(fl, MAX)
+   assert(r5 and nr5 == MAX)
+   assert(not pcall(start_add, fl, 1)) -- full
+   assert(select(2, start_remove(fl, 1)) == 0) -- empty
+   assert(finish_remove1(fl, r5, nr5))
+   assert(select(2, start_remove(fl, 1)) == 0) -- empty
+   assert(pcall(start_add, fl, 1)) -- not full
+end

--- a/src/core/group_freelist.lua
+++ b/src/core/group_freelist.lua
@@ -20,8 +20,8 @@ local band = bit.band
 -- Group freelist holds up to SIZE chunks of chunksize packets each
 chunksize = 2048
 
--- (SIZE=1024)*(chunksize=2048) == roughly two million packets
-local SIZE = 1024 -- must be a power of two
+-- (SIZE=512)*(chunksize=2048) == roughly one million packets
+local SIZE = 512 -- must be a power of two
 local MAX = SIZE - 1
 
 local CACHELINE = 64 -- XXX - make dynamic

--- a/src/core/group_freelist.lua
+++ b/src/core/group_freelist.lua
@@ -4,218 +4,156 @@ module(...,package.seeall)
 
 local sync = require("core.sync")
 local shm  = require("core.shm")
+local lib  = require("core.lib")
 local ffi  = require("ffi")
 local band = bit.band
-local min  = math.min
 
 -- Group freelist: lock-free multi-producer multi-consumer ring buffer
 -- (mpmc queue)
 --
+-- https://www.1024cores.net/home/lock-free-algorithms/queues/bounded-mpmc-queue
+--
 -- NB: assumes 32-bit wide loads/stores are atomic (as is the fact on x86_64)!
---
--- Logically, the group freelist is a simple ring buffer with
--- 32-bit head and tail cursors, just like core.link (and lib.interlink).
---
--- However, producers and consumers operate in parallel in two phases:
---
---  * start_add and start_remove reserve a "ticket" to produce or consume
---    the next N head or tail positions.
---
---  * finish_add and finish_remove "redeem" a ticket to advance the
---    head or tail cursors accordingly.
---
--- To avoid false sharing, cursors and copies thereof are arranged in
--- distinct cachelines:
---
---  * head_remove is the head cursor visible to consumers.
---    It is updated by finish_add, and copied into head_cache in start_remove.
---
---  * tail_remove is the tail cursor visible to consumers,
---    head_cache is a copy of head_remove intended to avoid invalidation
---    of this cacheline.
---    They are updated in start_remove.
---
---  * tail_add is the tail cursor visible to producers.
---    It is updated by finish_remove, and copied into tail_cache in start_add.
---
---  * head_add is the head cursor visible to producers,
---    tail_cache is a copy of tail_add intended to avoid invalidation
---    of this cacheline.
---    They are updated in start_add.
---
--- Let's walk through what happens in a producer between
--- start_add and finish_add (consumer behavior is symmetric):
---
---  1. We fetch the value head=head_add (this will incur a cache miss if
---     another consumer updated head_add).
---
---  2. We make sure there is enough capacity to add N packets
---     (head < tail_add):
---     fetching tail_cache might be sufficient, otherwise we have to
---     update it by fetching tail_add (this will incur a cache miss if
---     a consumer updated tail_add).
---
---  3. We attempt to CAS head_add = head -> head+N.
---     If this fails we have to start over.
---     If the CAS succeds we obtaine a ticket (head) to add N packets to
---     the freelist (and have invalidated any caches of head_add).
---
---  4. We can now add N packets to list[head..head+N] without
---     synchronizing with other producers or consumers.
---
---  5. We update head_remove, the head cursor visible to consumers,
---     redeeming our ticket.
---     We do this by repeating CAS head_remove = head -> head+N
---     until it succeeds.
---     This will fail for as long as we are waiting for another
---     producer to redeem their earlier ticket by calling finish_add
---     (we incur a cache miss any time another producer updated head_remove).
---
--- The consumer side works in just the same way, the only difference being
--- that in (4.) consumers will incur cache misses when fetching
--- list[tail..tail+N] to remove packets, naturally.
---
--- NB: this design is not crash safe! If a producer or consumer halts
--- in between start_add/start_remove and finish_add/finish_remove other
--- producers or consumers will deadlock in their attempts to
--- redeem their tickets (finish_add/finish_remove).
 
-local SIZE = 1048576 -- 2^20, roughly one million
+-- Group freelist holds up to SIZE chunks of chunksize packets each
+chunksize = 2048
+
+-- (SIZE=1024)*(chunksize=2048) == roughly two million packets
+local SIZE = 1024 -- must be a power of two
 local MAX = SIZE - 1
 
 local CACHELINE = 64 -- XXX - make dynamic
 local INT = ffi.sizeof("uint32_t")
 
 ffi.cdef([[
+struct group_freelist_chunk {
+   uint32_t sequence[1], nfree;
+   struct packet *list[]]..chunksize..[[];
+} __attribute__((packed))]])
+
+ffi.cdef([[
 struct group_freelist {
-   uint32_t head_remove[1];
-   uint8_t pad_head_remove[]]..CACHELINE-1*INT..[[];
+   uint32_t enqueue_pos[1];
+   uint8_t pad_enqueue_pos[]]..CACHELINE-1*INT..[[];
 
-   uint32_t head_cache[1], tail_remove[1];
-   uint8_t pad_tail_remove[]]..CACHELINE-2*INT..[[];
+   uint32_t dequeue_pos[1];
+   uint8_t pad_dequeue_pos[]]..CACHELINE-1*INT..[[];
 
-   uint32_t tail_add[1];
-   uint8_t pad_tail_add[]]..CACHELINE-1*INT..[[];
+   struct group_freelist_chunk chunk[]]..SIZE..[[];
 
-   uint32_t tail_cache[1], head_add[1];
-   uint8_t pad_head_add[]]..CACHELINE-2*INT..[[];
-
-   struct packet *list[]]..SIZE..[[];
+   uint32_t state[1];
 } __attribute__((packed, aligned(]]..CACHELINE..[[)))]])
 
+-- Group freelists states
+local CREATE, INIT, READY = 0, 1, 2
 
 function freelist_create (name)
-   return shm.create(name, "struct group_freelist")
+   local fl = shm.create(name, "struct group_freelist")
+   if sync.cas(fl.state, CREATE, INIT) then
+      for i = 0, MAX do
+         fl.chunk[i].sequence[0] = i
+      end
+      fl.state[0] = READY
+   else
+      lib.waitfor(function () return fl.state[0] == READY end)
+   end
+   return fl
 end
 
 function freelist_open (name, readonly)
-   return shm.open(name, "struct group_freelist", readonly)
+   local fl = shm.open(name, "struct group_freelist", readonly)
+   lib.waitfor(function () return fl.state[0] == READY end)
+   return fl
 end
 
 local function mask (i)
    return band(i, MAX)
 end
 
-local function nfree (head, tail)
-   return mask(head - tail)
-end
-
-local function capacity (head, tail)
-   return MAX - nfree(head, tail)
-end
-
-function start_add (fl, n)
+function start_add (fl)
+   local pos = fl.enqueue_pos[0]
    while true do
-      local head = fl.head_add[0]
-      if capacity(head, fl.tail_cache[0]) < n then
-         fl.tail_cache[0] = fl.tail_add[0]
-         assert(capacity(head, fl.tail_cache[0]) >= n,
-                "group freelist overflow")
-      end
-      if sync.cas(fl.head_add, head, mask(head + n)) then
-         return head
+      local chunk = fl.chunk[mask(pos)]
+      local seq = chunk.sequence[0]
+      local dif = seq - pos
+      if dif == 0 then
+         if sync.cas(fl.enqueue_pos, pos, pos+1) then
+            return chunk, pos+1
+         end
+      elseif dif < 0 then
+         return
+      else
+         pos = fl.enqueue_pos[0]
       end
    end
 end
 
-function add (fl, head, i, p)
-   fl.list[mask(head+i)] = p
-end
-
-local function finish_add1 (fl, head, n)
-   return sync.cas(fl.head_remove, head, mask(head + n))
-end
-function finish_add (fl, head, n)
-   while not finish_add1(fl, head, n) do end
-end
-
-function start_remove (fl, n)
+function start_remove (fl)
+   local pos = fl.dequeue_pos[0]
    while true do
-      local tail = fl.tail_remove[0]
-      if nfree(fl.head_cache[0], tail) < n then
-         fl.head_cache[0] = fl.head_remove[0]
-      end
-      local n = min(n, nfree(fl.head_cache[0], tail))
-      if n == 0 or sync.cas(fl.tail_remove, tail, mask(tail + n)) then
-         return tail, n
+      local chunk = fl.chunk[mask(pos)]
+      local seq = chunk.sequence[0]
+      local dif = seq - (pos+1)
+      if dif == 0 then
+         if sync.cas(fl.dequeue_pos, pos, pos+1) then
+            return chunk, pos+MAX+1
+         end
+      elseif dif < 0 then
+         return
+      else
+         pos = fl.dequeue_pos[0]
       end
    end
 end
 
-function remove (fl, tail, i)
-   local p = fl.list[mask(tail+i)]
-   fl.list[mask(tail+i)] = nil
-   return p
+function finish (chunk, seq)
+   chunk.sequence[0] = seq
 end
-
-local function finish_remove1 (fl, tail, n)
-   return sync.cas(fl.tail_add, tail, mask(tail + n))
-end
-function finish_remove (fl, tail, n)
-   while not finish_remove1(fl, tail, n) do end
-end
-
 
 function selftest ()
    local fl = freelist_create("test_freelist")
-   assert(select(2, start_remove(fl, 1)) == 0) -- empty
+   assert(not start_remove(fl)) -- empty
 
-   local w1 = start_add(fl, 1000)
-   local w2 = start_add(fl, 3700)
-   assert(select(2, start_remove(fl, 1)) == 0) -- empty
-   assert(not finish_add1(fl, w2, 3700))
-   assert(finish_add1(fl, w1, 1000))
-   assert(finish_add1(fl, w2, 3700))
-   local r1, nr1 = start_remove(fl, 2000)
-   assert(r1 and nr1 == 2000)
-   local r2, nr2 = start_remove(fl, 3000)
-   assert(r2 and nr2 == 2700)
-   assert(not finish_remove1(fl, r2, nr2))
-   assert(finish_remove1(fl, r1, nr1))
-   assert(finish_remove1(fl, r2, nr2))
-   assert(select(2, start_remove(fl, 1)) == 0) -- empty
+   local w1, sw1 = start_add(fl)
+   local w2, sw2 = start_add(fl)
+   assert(not start_remove(fl)) -- empty
+   finish(w2, sw2)
+   assert(not start_remove(fl)) -- empty
+   finish(w1, sw1)
+   local r1, sr1 = start_remove(fl)
+   assert(r1 == w1)
+   local r2, sr2 = start_remove(fl)
+   assert(r2 == w2)
+   assert(not start_remove(fl)) -- empty
+   finish(r1, sr1)
+   finish(r2, sr2)
+   assert(not start_remove(fl)) -- empty
 
-   local w3 = start_add(fl, 12345)
-   local w4 = start_add(fl, 54321)
-   assert(finish_add1(fl, w3, 12345))
-   local r3, nr3 = start_remove(fl, 10000)
-   assert(r3 and nr3 == 10000)
-   assert(finish_add1(fl, w4, 54321))
-   local r4, nr4 = start_remove(fl, 54321+2345)
-   assert(r4 and nr4 == 54321+2345)
-   assert(not finish_remove1(fl, r4, nr4))
-   assert(finish_remove1(fl, r3, nr3))
-   assert(finish_remove1(fl, r4, nr4))
-   assert(select(2, start_remove(fl, 1)) == 0) -- empty
+   for i=1,SIZE do
+      local w, sw = start_add(fl)
+      assert(w)
+      finish(w, sw)
+   end
+   assert(not start_add(fl)) -- full
+   for i=1,SIZE do
+      local r, sr = start_remove(fl)
+      assert(r)
+      finish(r, sr)
+   end
+   assert(not start_remove(fl)) -- empty
 
-   local w5 = start_add(fl, MAX)
-   assert(not pcall(start_add, fl, 1)) -- full
-   assert(finish_add1(fl, w5, MAX))
-   local r5, nr5 = start_remove(fl, MAX)
-   assert(r5 and nr5 == MAX)
-   assert(not pcall(start_add, fl, 1)) -- full
-   assert(select(2, start_remove(fl, 1)) == 0) -- empty
-   assert(finish_remove1(fl, r5, nr5))
-   assert(select(2, start_remove(fl, 1)) == 0) -- empty
-   assert(pcall(start_add, fl, 1)) -- not full
+   local w = {}
+   for _=1,10000 do
+      for _=1,math.random(SIZE) do
+         local w1, sw = start_add(fl)
+         if not w1 then break end
+         finish(w1, sw)
+         table.insert(w, w1)
+      end
+      for _=1,math.random(#w) do
+         local r, sr = start_remove(fl)
+         assert(r == table.remove(w, 1))
+         finish(r, sr)
+      end
+   end
 end

--- a/src/core/group_freelist.lua
+++ b/src/core/group_freelist.lua
@@ -20,8 +20,8 @@ local band = bit.band
 -- Group freelist holds up to SIZE chunks of chunksize packets each
 chunksize = 2048
 
--- (SIZE=512)*(chunksize=2048) == roughly one million packets
-local SIZE = 512 -- must be a power of two
+-- (SIZE=1024)*(chunksize=2048) == roughly two million packets
+local SIZE = 1024 -- must be a power of two
 local MAX = SIZE - 1
 
 local CACHELINE = 64 -- XXX - make dynamic

--- a/src/core/packet.lua
+++ b/src/core/packet.lua
@@ -307,7 +307,8 @@ function resize (p, len)
 end
 
 function preallocate_step()
-   assert(packets_allocated + packet_allocation_step <= max_packets,
+   assert(packets_allocated + packet_allocation_step
+            <= max_packets - group_fl_chunksize,
           "packet allocation overflow")
 
    for i=1, packet_allocation_step do


### PR DESCRIPTION
This adresses

- #1468

by employing a smarter data structure for the group freelist (MPMC bounded queue).

It also moves the rebalancing house keeping into `packet.free`, and keeps limits on the upper bound of work performed in any rebalance/reclaim step.

In the density plots below we have `master` in red and this branch in blue (green was an alternative wip branch).

<img width="962" alt="branches-latency" src="https://user-images.githubusercontent.com/4933566/157035768-6a6e93e9-6df1-458d-b9f4-ce25bc9c5f79.png">

This certainly improves latency and thus performance of interlinks, however this does not make interlinks scale without restriction. The benchmarking I did seems to show that sharing memory between cores still turns into a bottleneck, and depending on your CPU architecture you are going to run into that sooner or later. I did compare results between Intel and EPYC machines and they are quite different. But for here and now I’m going to focus only on EPYC as an example.

![nreceivers-latency](https://user-images.githubusercontent.com/4933566/157037050-7173d09f-1e21-4110-abac-aa31b2cce0b3.png)

In the plot above we compare latencies by number of receivers for a single transmitter, and we see a significant blowup of latencies after 1 transmitter + >5 receivers. Now why is that?

If we look at the topology of our CPU as reported by AMDuprof we can get a hint:

```
CPU Topology:
Socket, CCD, Core(s)
0,0, 0 1 2 3 4 5
0,1, 6 7 8 9 10 11
0,2, 12 13 14 15 16 17
0,3, 18 19 20 21 22 23
```

Each CCD spans six CPU cores. So while our workload fits a single CCD we get OK perf (~60Mpps) but as soon as we add a receiver running on a distinct CCD latency and perf tanks (~10Mpps).

<img width="493" alt="Screenshot 2022-02-21 151358" src="https://user-images.githubusercontent.com/4933566/157037922-be3cae01-cda6-4913-b47f-4261c4a5162e.png">

The above diagram of the CPUs architecture/topology gives some hints. So each CCD houses two CCXs, and a cores in a CCX share a L3 cache. I am assuming the CCXs in a CCD also have faster interconnects to each other than to a CCX in a remote CCD?

Anyways if I look at some PMU counters using AMDuprof we can maybe see why a workload distributed across CCDs fares worse (take this with some salt, this is me reading the tea leaves):

- workloads that fit a single CCD can fetch data from shared L3 or other L2 caches in the same CCD or CCX? `DCFillsFromL3orDiffL2` is higher
- they incur less `L2DtlbMiss`es, and have to perform less `DCFillsFromLocalMemory`
- hence they can retire more instructions per cycle

![pmu_ccd](https://user-images.githubusercontent.com/4933566/157038598-c1a70d4d-e288-41c7-96d3-749a5f3914db.png)
