### PR TITLE
map_pci_memory: workaround for kernel race condition

### DIFF
--- a/src/lib/hardware/pci.lua
+++ b/src/lib/hardware/pci.lua
@@ -186,17 +186,20 @@ end
 
 function map_pci_memory (f)
    local st = assert(f:stat())
-   local mem
+   local mem, err
+   mem, err = f:mmap(nil, st.size, "read, write", "shared", 0)
    -- mmap() returns EINVAL on Linux >= 4.5 if the device is still
    -- claimed by the kernel driver. We assume that
    -- unbind_device_from_linux() has already been called but it may take
    -- some time for the driver to release the device.
-   lib.waitfor2("mmap of "..filepath,
-                function ()
-                   mem, err = f:mmap(nil, st.size, "read, write", "shared", 0)
-                   assert(not err or err.INVAL)
-                   return mem
-                end, 5, 1000000)
+   if not mem then
+      lib.waitfor2("mmap of "..filepath,
+                   function ()
+                      mem, err = f:mmap(nil, st.size, "read, write", "shared", 0)
+                      assert(not err or err.INVAL)
+                      return mem
+                   end, 5, 1000000)
+   end
    return ffi.cast("uint32_t *", mem)
 end
 

--- a/src/lib/hardware/pci.lua
+++ b/src/lib/hardware/pci.lua
@@ -186,7 +186,17 @@ end
 
 function map_pci_memory (f)
    local st = assert(f:stat())
-   local mem = assert(f:mmap(nil, st.size, "read, write", "shared", 0))
+   local mem
+   -- mmap() returns EINVAL on Linux >= 4.5 if the device is still
+   -- claimed by the kernel driver. We assume that
+   -- unbind_device_from_linux() has already been called but it may take
+   -- some time for the driver to release the device.
+   lib.waitfor2("mmap of "..filepath,
+                function ()
+                   mem, err = f:mmap(nil, st.size, "read, write", "shared", 0)
+                   assert(not err or err.INVAL)
+                   return mem
+                end, 5, 1000000)
    return ffi.cast("uint32_t *", mem)
 end
 


### PR DESCRIPTION
> [map_pci_memory: wait for kernel driver to release the device](https://github.com/snabbco/snabb/commit/7c269fa374421169c5f0df2d7aaa8aa04b037ea3) 

> Starting with 4.5, the kernel returns EINVAL for mmap() if compiled
> with CONFIG_IO_STRICT_DEVMEM=y. Unbinding the device is an
> asynchronous operation. map_pci_memory() waits for EINVAL to disappear
> or gives up after a timeout of 5 seconds.