### PR TITLE
apps.mellanox: use default enable_counters setting

### DIFF
--- a/src/apps/mellanox/connectx.lua
+++ b/src/apps/mellanox/connectx.lua
@@ -315,7 +315,7 @@ function ConnectX:new (conf)
    -- Lists of receive queues by macvlan (used if usemac=true)
    local macvlan_rqlist = {}
 
-   for _, queue in ipairs(conf.queues) do
+   for _, queue in ipairs(queues) do
       -- Create a shared memory object for controlling the queue pair
       local shmpath = "group/pci/"..pciaddress.."/"..queue.id
       local cxq = shm.create(shmpath, cxq_t)


### PR DESCRIPTION
This fixes a bug where per-queue rxdrop counters were not counted.