### PR TITLE
core.app: fix a bug related to getting app zone name

### DIFF
--- a/src/core/app.lua
+++ b/src/core/app.lua
@@ -367,7 +367,7 @@ function apply_config_actions (actions)
          error(("bad return value from app '%s' start() method: %s"):format(
                   name, tostring(app)))
       end
-      local zone = app.zone or getfenv(class.new)._NAME or name
+      local zone = app.zone or rawget(getfenv(class.new), '_NAME') or name
       app.appname = name
       app.output = {}
       app.input = {}


### PR DESCRIPTION
If running an app defined in a script via snabb snsh, getfenv(app.start).__NAME would be undefined and trigger our error handler for undefined variables.

Use rawget to avoid this, and properly fallback to the app name.