### PR TITLE
Fix lwAFTR trace performance issues (for release Alpina)

### DIFF
--- a/src/apps/lwaftr/lwaftr.lua
+++ b/src/apps/lwaftr/lwaftr.lua
@@ -780,16 +780,10 @@ end
 
 function LwAftr:enqueue_encapsulation(pkt, ipv4, port, pkt_src_link)
    if pkt_src_link == PKT_FROM_INET then
-      if self.inet_lookup_queue:enqueue_lookup(pkt, ipv4, port) then
-         -- Flush the queue right away if enough packets are queued up already.
-         self:flush_encapsulation()
-      end
+      self.inet_lookup_queue:enqueue_lookup(pkt, ipv4, port)
    else
       assert(pkt_src_link == PKT_HAIRPINNED)
-      if self.hairpin_lookup_queue:enqueue_lookup(pkt, ipv4, port) then
-         -- Flush the queue right away if enough packets are queued up already.
-         self:flush_hairpin()
-      end
+      self.hairpin_lookup_queue:enqueue_lookup(pkt, ipv4, port)
    end
 end
 
@@ -977,10 +971,7 @@ function LwAftr:flush_decapsulation()
 end
 
 function LwAftr:enqueue_decapsulation(pkt, ipv4, port)
-   if self.inet_lookup_queue:enqueue_lookup(pkt, ipv4, port) then
-      -- Flush the queue right away if enough packets are queued up already.
-      self:flush_decapsulation()
-   end
+   self.inet_lookup_queue:enqueue_lookup(pkt, ipv4, port)
 end
 
 -- FIXME: Verify that the packet length is big enough?

--- a/src/lib/ctable.lua
+++ b/src/lib/ctable.lua
@@ -509,7 +509,6 @@ end
 function LookupStreamer:stream()
    local width = self.width
    local entries = self.entries
-   local keys = self.keys
    local pointers = self.pointers
    local stream_entries = self.stream_entries
    local entries_per_lookup = self.entries_per_lookup

--- a/src/lib/hash/siphash.dasl
+++ b/src/lib/hash/siphash.dasl
@@ -576,8 +576,6 @@ local function make_hash2(opts)
    local hash = make_hash1(opts)
    local stride = opts.stride or opts.size
    return function(ptr, result)
-      ptr = ffi.cast('uint8_t*', ptr)
-      result = ffi.cast('uint32_t*', result)
       result[0] = hash(ptr)
       result[1] = hash(ptr + stride)
    end
@@ -587,8 +585,6 @@ local function make_hash4(opts)
    local hash = make_hash2(opts)
    local stride = opts.stride or opts.size
    return function(ptr, result)
-      ptr = ffi.cast('uint8_t*', ptr)
-      result = ffi.cast('uint32_t*', result)
       hash(ptr, result)
       hash(ptr + stride*2, result + 2)
    end
@@ -612,19 +608,13 @@ function make_multi_hash(opts)
 
    if width % 4 == 0 then
       return function(input, output)
-         input = ffi.cast('uint8_t*', input)
-         output = ffi.cast('uint32_t*', output)
-         for i=1,width,4 do
-            hash4(input, output)
-            input = input + stride*4
-            output = output + 4
+         for i=0,width-1,4 do
+            hash4(input + stride*i, output + i)
          end
       end
    end
 
    return function(input, output)
-      input = ffi.cast('uint8_t*', input)
-      output = ffi.cast('uint32_t*', output)
       for i=1,bit.rshift(width, 2) do
          hash4(input, output)
          input = input + stride*4


### PR DESCRIPTION
Running CI for the Alpina release showed a performance regression in the lwaftr benchmark.

I’ve triaged this to not be due a specific code change, but an existing condition where the previous code generated traces that unnecessarily invoked the GC.

These two commits eliminate some casts that could set off the GC and some side traces to make perf more predictable:

- 5fe89b5ba7ad977ceb338294cb6f87e1f819aa15 don’t flush lookups early, always flush them at the end of `push` (I had increased the queue size for this, but it should be fine with the default `engine.pull_npackets` and there is a new assertion to check the currently hardcoded queue size is sufficient.)
- 4706127a25f175aa90b6be6f4571a2786a7ec1fd optimized the best-case code for siphash’s `make_multi_hash` method to not generate side traces. Also removed casts (caller has to ensure arguments are of the right types, all current callers already do this).