### PR TITLE
Configurable interlink queue, freelist, and group freelist sizes

### DIFF
--- a/src/apps/interlink/receiver.lua
+++ b/src/apps/interlink/receiver.lua
@@ -5,11 +5,22 @@ module(...,package.seeall)
 local shm = require("core.shm")
 local interlink = require("lib.interlink")
 
-local Receiver = {name="apps.interlink.Receiver"}
+local Receiver = {
+   name = "apps.interlink.Receiver",
+   config = {
+      queue = {},
+      size = {default=1024}
+   }
+}
 
-function Receiver:new (queue)
+function Receiver:new (conf)
+   local self = {
+      attached = false,
+      queue = conf.queue,
+      size = conf.size
+   }
    packet.enable_group_freelist()
-   return setmetatable({attached=false, queue=queue}, {__index=Receiver})
+   return setmetatable(self, {__index=Receiver})
 end
 
 function Receiver:link ()
@@ -17,7 +28,7 @@ function Receiver:link ()
    if not self.attached then
       self.shm_name = "group/interlink/"..queue..".interlink"
       self.backlink = "interlink/receiver/"..queue..".interlink"
-      self.interlink = interlink.attach_receiver(self.shm_name)
+      self.interlink = interlink.attach_receiver(self.shm_name, self.size)
       shm.alias(self.backlink, self.shm_name)
       self.attached = true
    end

--- a/src/apps/interlink/transmitter.lua
+++ b/src/apps/interlink/transmitter.lua
@@ -5,11 +5,22 @@ module(...,package.seeall)
 local shm = require("core.shm")
 local interlink = require("lib.interlink")
 
-local Transmitter = {name="apps.interlink.Transmitter"}
+local Transmitter = {
+   name = "apps.interlink.Transmitter",
+   config = {
+      queue = {},
+      size = {default=1024}
+   }
+}
 
-function Transmitter:new (queue)
+function Transmitter:new (conf)
+   local self = {
+      attached = false,
+      queue = conf.queue,
+      size = conf.size
+   }
    packet.enable_group_freelist()
-   return setmetatable({attached=false, queue=queue}, {__index=Transmitter})
+   return setmetatable(self, {__index=Transmitter})
 end
 
 function Transmitter:link ()
@@ -17,7 +28,7 @@ function Transmitter:link ()
    if not self.attached then
       self.shm_name = "group/interlink/"..queue..".interlink"
       self.backlink = "interlink/transmitter/"..queue..".interlink"
-      self.interlink = interlink.attach_transmitter(self.shm_name)
+      self.interlink = interlink.attach_transmitter(self.shm_name, self.size)
       shm.alias(self.backlink, self.shm_name)
       self.attached = true
    end

--- a/src/core/group_freelist.lua
+++ b/src/core/group_freelist.lua
@@ -40,8 +40,7 @@ struct group_freelist {
    uint32_t dequeue_pos[1], dequeue_mask;
    uint8_t pad_dequeue_pos[]]..CACHELINE-2*INT..[[];
 
-   uint32_t state[1], size;
-   uint8_t pad_state[]]..CACHELINE-2*INT..[[];
+   uint32_t size, state[1];
 
    struct group_freelist_chunk chunk[?];
 } __attribute__((packed, aligned(]]..CACHELINE..[[)))]])

--- a/src/core/packet.lua
+++ b/src/core/packet.lua
@@ -52,24 +52,28 @@ end
 
 -- Freelist containing empty packets ready for use.
 
-local max_packets = 1e6
+local default_max_packets = 1e6
 
 ffi.cdef([[
 struct freelist {
     int nfree;
     int max;
-    struct packet *list[]]..max_packets..[[];
+    struct packet *list[?];
 };
 ]])
 
-local function freelist_create(name)
-   local fl = shm.create(name, "struct freelist")
+local function freelist_create(name, max_packets)
+   max_packets = max_packets or default_max_packets
+   local fl = shm.create(name, "struct freelist", max_packets)
    fl.max = max_packets
    return fl
 end
 
 local function freelist_open(name, readonly)
-   return shm.open(name, "struct freelist", readonly)
+   local fl = shm.open(name, "struct freelist", 'read-only', 1)
+   local max = fl.max
+   shm.unmap(fl)
+   return shm.open(name, "struct freelist", readonly, max)
 end
 
 local function freelist_full(freelist)
@@ -104,8 +108,13 @@ local packets_allocated = 0
 local packets_fl, group_fl
 
 -- Call to ensure packet freelist is enabled.
-function initialize ()
-   packets_fl = freelist_create("engine/packets.freelist")
+function initialize (max_packets)
+   if packets_fl then
+      assert(packets_fl.nfree == 0, "freelist is already in use")
+      shm.unmap(packets_fl)
+      shm.unlink("engine/packets.freelist")
+   end
+   packets_fl = freelist_create("engine/packets.freelist", max_packets)
 end
 
 -- Call to ensure group freelist is enabled.
@@ -310,7 +319,7 @@ end
 
 function preallocate_step()
    assert(packets_allocated + packet_allocation_step
-            <= max_packets - group_fl_chunksize,
+            <= packets_fl.max - group_fl_chunksize,
           "packet allocation overflow")
 
    for i=1, packet_allocation_step do
@@ -321,6 +330,12 @@ function preallocate_step()
 end
 
 function selftest ()
+   initialize(10000)
+   assert(packets_fl.max == 10000)
+   allocate()
+   local ok, err = pcall(initialize)
+   assert(not ok and err:match("freelist is already in use"))
+
    assert(is_aligned(0, 1))
    assert(is_aligned(1, 1))
    assert(is_aligned(2, 1))

--- a/src/core/packet.lua
+++ b/src/core/packet.lua
@@ -109,9 +109,11 @@ function initialize ()
 end
 
 -- Call to ensure group freelist is enabled.
-function enable_group_freelist ()
+function enable_group_freelist (nchunks)
    if not group_fl then
-      group_fl = group_freelist.freelist_create("group/packets.freelist")
+      group_fl = group_freelist.freelist_create(
+         "group/packets.freelist", nchunks
+      )
    end
 end
 

--- a/src/core/packet.lua
+++ b/src/core/packet.lua
@@ -121,7 +121,7 @@ end
 function enable_group_freelist (nchunks)
    if not group_fl then
       group_fl = group_freelist.freelist_create(
-         "group/packets.freelist", nchunks
+         "group/packets.group_freelist", nchunks
       )
    end
 end
@@ -158,12 +158,9 @@ function reclaim_step ()
    end
 end
 
--- Register struct freelist as an abstract SHM object type so that the group
+-- Register struct freelist as an abstract SHM object type so that the
 -- freelist can be recognized by shm.open_frame and described with tostring().
-shm.register(
-   'freelist',
-   {open = function (name) return shm.open(name, "struct freelist") end}
-)
+shm.register('freelist', {open=freelist_open})
 ffi.metatype("struct freelist", {__tostring = function (freelist)
    return ("%d/%d"):format(freelist.nfree, freelist.max)
 end})
@@ -187,7 +184,7 @@ end
 -- process termination.
 function shutdown (pid)
    local in_group, group_fl = pcall(
-      group_freelist.freelist_open, "/"..pid.."/group/packets.freelist"
+      group_freelist.freelist_open, "/"..pid.."/group/packets.group_freelist"
    )
    if in_group then
       local packets_fl = freelist_open("/"..pid.."/engine/packets.freelist")

--- a/src/core/shm.lua
+++ b/src/core/shm.lua
@@ -38,7 +38,7 @@ local function map (name, type, readonly, create, ...)
    if create then
       assert(fd:ftruncate(size), "shm: ftruncate failed")
    else
-      assert(fd:fstat().size == size, "shm: unexpected size")
+      assert(fd:fstat().size >= size, "shm: unexpected size")
    end
    local mem, err = S.mmap(nil, size, mapmode, "shared", fd, 0)
    fd:close()

--- a/src/core/shm.lua
+++ b/src/core/shm.lua
@@ -216,8 +216,15 @@ function selftest ()
    assert(not exists(name))
 
    -- Checking parameterized types
+   print("checking parameterized types..")
    local name = "shm/selftest/parameterized"
-   local p1 = create(name, "struct { int x; int xs[?]; }")
+   local p1 = create(name, "struct { int x; int xs[?]; }", 10)
+   local p2 = open(name, "struct { int x; int xs[?]; }", 'read-only', 10)
+   p1.xs[9] = 42
+   assert(p2.xs[9] == 42)
+   unmap(p2)
+   unmap(p1)
+   assert(unlink(name))
 
    -- Test that we can open and cleanup many objects
    print("checking many objects..")

--- a/src/core/shm.lua
+++ b/src/core/shm.lua
@@ -16,13 +16,13 @@ root = os.getenv("SNABB_SHM_ROOT") or "/var/run/snabb"
 mappings = {}
 
 -- Map an object into memory.
-local function map (name, type, readonly, create)
+local function map (name, type, readonly, create, ...)
    local path = resolve(name)
    local mapmode = readonly and 'read' or 'read, write'
    local ctype = ffi.typeof(type)
-   local size = ffi.sizeof(ctype)
+   local size = ffi.sizeof(ctype, ...)
    local stat = S.stat(root..'/'..path)
-   if stat and stat.size ~= size then
+   if stat and stat.size < size then
       print(("shm warning: resizing %s from %d to %d bytes")
             :format(path, stat.size, size))
    end
@@ -47,12 +47,12 @@ local function map (name, type, readonly, create)
    return ffi.cast(ffi.typeof("$&", ctype), mem)
 end
 
-function create (name, type)
-   return map(name, type, false, true)
+function create (name, type, ...)
+   return map(name, type, false, true, ...)
 end
 
-function open (name, type, readonly)
-   return map(name, type, readonly, false)
+function open (name, type, readonly, ...)
+   return map(name, type, readonly, false, ...)
 end
 
 function exists (name)
@@ -214,6 +214,10 @@ function selftest ()
    assert(unlink(name))
    unmap(p1)
    assert(not exists(name))
+
+   -- Checking parameterized types
+   local name = "shm/selftest/parameterized"
+   local p1 = create(name, "struct { int x; int xs[?]; }")
 
    -- Test that we can open and cleanup many objects
    print("checking many objects..")

--- a/src/lib/interlink.lua
+++ b/src/lib/interlink.lua
@@ -71,10 +71,8 @@ local INT = ffi.sizeof("int")
 
 ffi.cdef([[
    struct interlink {
-      int size;
-      char pad0[]]..CACHELINE-1*INT..[[];
-      int read, write, state[1];
-      char pad1[]]..CACHELINE-3*INT..[[];
+      int read, write, state[1], size;
+      char pad1[]]..CACHELINE-4*INT..[[];
       int lwrite, nread;
       char pad2[]]..CACHELINE-2*INT..[[];
       int lread, nwrite;

--- a/src/lib/interlink.lua
+++ b/src/lib/interlink.lua
@@ -71,7 +71,7 @@ local INT = ffi.sizeof("uint32_t")
 
 ffi.cdef([[
    struct interlink {
-      uint32_t read, write, state[1], size;
+      uint32_t read, write, size, state[1];
       char pad1[]]..CACHELINE-4*INT..[[];
       uint32_t lwrite, nread, rmask;
       char pad2[]]..CACHELINE-3*INT..[[];

--- a/src/lib/scheduling.lua
+++ b/src/lib/scheduling.lua
@@ -21,6 +21,7 @@ local scheduling_opts = {
    jit_opt = {default=default_jit_opt}, -- JIT options.
    cpu = {},                  -- CPU index (integer).
    real_time = {},            -- Boolean.
+   max_packets = {},          -- Positive integer.
    ingress_drop_monitor = {}, -- Action string: one of 'flush' or 'warn'.
    profile = {default=true},  -- Boolean.
    busywait = {default=true}, -- Boolean.
@@ -52,6 +53,10 @@ function sched_apply.real_time (real_time)
    if real_time and not S.sched_setscheduler(0, "fifo", 1) then
       fatal('Failed to enable real-time scheduling.  Try running as root.')
    end
+end
+
+function sched_apply.max_packets (max_packets)
+   packet.initialize(max_packets)
 end
 
 function sched_apply.busywait (busywait)


### PR DESCRIPTION
This set of changes allows to adjust interlink queue, freelist, and group freelist sizes at runtime.

This is useful because some applications might choose larger interlink queue sizes (just like an application might select larger NIC driver receive queue buffers) to allow for longer breath latencies before packets are dropped.