### PR TITLE
ipfix probe: cleanup code, optimize operation without software rss

### DIFF
--- a/src/lib/ptree/support/snabb-snabbflow-v1.lua
+++ b/src/lib/ptree/support/snabb-snabbflow-v1.lua
@@ -94,16 +94,13 @@ end
 function collect_rss_states (pid, rss_links)
    local states = {}
    local id
-   for _, app in ipairs(shm.children("/"..pid.."/apps")) do
-      local rss_group = tonumber(app:match("^rss(%d+)$"))
+   for _, link in ipairs(shm.children("/"..pid.."/links")) do
+      local rss_group = tonumber(link:match("^rss(%d+)%."))
       if rss_group then
          id = tonumber(rss_group)
-         break
       end
-   end
-   for _, link in ipairs(shm.children("/"..pid.."/links")) do
       for rss_link, _ in pairs(rss_links) do
-         if (link:match("^"..rss_link) and link:match("^rss%d+.")) -- embedded link
+         if (link:match("^"..rss_link) and link:match("^rss%d+%.")) -- embedded link
          or (link:match("-> *"..rss_link:gsub("%.output$", ".input").."$")) -- interlink
          then
             local stats = shm.open_frame("/"..pid.."/links/"..link)

--- a/src/lib/yang/snabb-snabbflow-v1.yang
+++ b/src/lib/yang/snabb-snabbflow-v1.yang
@@ -25,6 +25,7 @@ module snabb-snabbflow-v1 {
 
     list interface {
       key device;
+      unique "name vlan-tag";
 
       description
         "Interaces serving as IPFIX Observation Points.";
@@ -347,7 +348,7 @@ module snabb-snabbflow-v1 {
       }
 
       leaf mtu {
-        type uint32;
+        type uint32 { range 512..9000; }
         default 1500;
         description
           "MTU for exported UDP packets.";

--- a/src/program/ipfix/lib.lua
+++ b/src/program/ipfix/lib.lua
@@ -1,312 +1,290 @@
 module(..., package.seeall)
 
-local now        = require("core.app").now
-local lib        = require("core.lib")
-local counter    = require("core.counter")
-local app_graph  = require("core.config")
-local link       = require("core.link")
-local pci        = require("lib.hardware.pci")
-local numa       = require("lib.numa")
-local ipv4       = require("lib.protocol.ipv4")
-local ethernet   = require("lib.protocol.ethernet")
-local S          = require("syscall")
-local basic      = require("apps.basic.basic_apps")
-local arp        = require("apps.ipv4.arp")
-local ipfix      = require("apps.ipfix.ipfix")
-local template   = require("apps.ipfix.template")
-local rss        = require("apps.rss.rss")
-local iftable    = require("apps.snmp.iftable")
+local lib         = require("core.lib")
+local app_graph   = require("core.config")
+local pci         = require("lib.hardware.pci")
+local ipv4        = require("lib.protocol.ipv4")
+local ethernet    = require("lib.protocol.ethernet")
+local basic       = require("apps.basic.basic_apps")
+local ipfix       = require("apps.ipfix.ipfix")
+local tap         = require("apps.tap.tap")
+local rss         = require("apps.rss.rss")
+local iftable     = require("apps.snmp.iftable")
+local Receiver    = require("apps.interlink.receiver")
 local Transmitter = require("apps.interlink.transmitter")
-
-
--- apps that can be used as an input or output for the exporter
-local in_apps, out_apps = {}, {}
-
-local function parse_spec (spec, delimiter)
-   local t = {}
-   for s in spec:split(delimiter or ':') do
-      table.insert(t, s)
-   end
-   return t
-end
+local pcap        = require("apps.pcap.pcap")
 
 local function normalize_pci_name (device)
    return pci.qualified(device):gsub("[:%.]", "_")
 end
 
-function in_apps.pcap (path)
-   return { input = "input",
-            output = "output" },
-          { require("apps.pcap.pcap").PcapReader, path }
+local function configure_ipfix_instance (config, in_graph)
+   local graph = in_graph or app_graph.new()
+
+   local ipfix_name = "ipfix_"..assert(config.instance)
+
+   app_graph.app(graph, ipfix_name, ipfix.IPFIX, config)
+
+   return graph, {name=ipfix_name, output='output', input='input'}
 end
 
-function out_apps.pcap (path)
-   return { input = "input",
-            output = "output" },
-          { require("apps.pcap.pcap").PcapWriter, path }
-end
+local function configure_tap_output (config, in_graph)
+   config = lib.parse(config, {
+      instance={required=true},
+      observation_domain={required=true},
+      mtu={required=true},
+      log_date={required=true}
+   })
+   local graph = in_graph or app_graph.new()
 
-function out_apps.tap_routed (device)
-   return { input = "input",
-            output = "output" },
-          { require("apps.tap.tap").Tap, { name = device } }
-end
+   local device = "ipfixexport"..config.observation_domain
 
-function in_apps.raw (device)
-   return { input = "rx",
-            output = "tx" },
-          { require("apps.socket.raw").RawSocket, device }
-end
-out_apps.raw = in_apps.raw
-
-function in_apps.tap (device)
-   return { input = "input",
-            output = "output" },
-          { require("apps.tap.tap").Tap, device }
-end
-out_apps.tap = in_apps.tap
-
-function in_apps.interlink (name)
-   return { input = nil,
-            output = "output" },
-   { require("apps.interlink.receiver"), nil }
-end
-
-function in_apps.pci (input)
-   local device, rxq = input.device, input.rxq or 0
-   local device_info = pci.device_info(device)
-   local conf = { pciaddr = device }
-   if device_info.driver == 'apps.intel_mp.intel_mp' then
-      conf.rxq = rxq
-      conf.rxcounter = rxq
-      conf.ring_buffer_size = input.receive_queue_size
-   elseif device_info.driver == 'apps.mellanox.connectx' then
-      conf = {
-         pciaddress = device,
-         queue = rxq
-      }
-   end
-   return { input = device_info.rx, output = device_info.tx },
-          { require(device_info.driver).driver, conf }
-end
-out_apps.pci = in_apps.pci
-
-probe_config = {
-   -- Probe-specific
-   output_type = {required = true},
-   output = { required = true },
-   input_type = { default = nil },
-   input = { default = nil },
-   exporter_mac = { default = nil },
-   -- Passed on to IPFIX app
-   active_timeout = { default = nil },
-   idle_timeout = { default = nil },
-   flush_timeout = { default = nil },
-   cache_size = { default = nil },
-   max_load_factor = { default = nil },
-   scan_time = { default = nil },
-   observation_domain = { default = nil },
-   template_refresh_interval = { default = nil },
-   ipfix_version = { default = nil },
-   exporter_ip = { required = true },
-   collector_ip = { required = true },
-   collector_port = { required = true },
-   mtu = { default = nil },
-   templates = { required = true },
-   maps = { default = {} },
-   maps_logfile = { default = nil },
-   instance = { default = 1 },
-   add_packet_metadata = { default = true },
-   log_date = { default = false },
-   scan_protection = { default = {} }
-}
-
-local function mk_ipfix_config (config)
-   return { active_timeout = config.active_timeout,
-            idle_timeout = config.idle_timeout,
-            flush_timeout = config.flush_timeout,
-            cache_size = config.cache_size,
-            max_load_factor = config.max_load_factor,
-            scan_time = config.scan_time,
-            observation_domain = config.observation_domain,
-            template_refresh_interval =
-               config.template_refresh_interval,
-            ipfix_version = config.ipfix_version,
-            exporter_ip = config.exporter_ip,
-            collector_ip = config.collector_ip,
-            collector_port = config.collector_port,
-            mtu = config.mtu - 14,
-            templates = config.templates,
-            maps = config.maps,
-            maps_logfile = config.maps_logfile,
-            instance = config.instance,
-            add_packet_metadata = config.add_packet_metadata,
-            log_date = config.log_date,
-            scan_protection = config.scan_protection }
-end
-
-function configure_graph (arg, in_graph)
-   local config = lib.parse(arg, probe_config)
-
-   local in_link, in_app
-   if config.input_type then
-      assert(in_apps[config.input_type],
-             "unknown input type: "..config.input_type)
-      assert(config.input, "Missing input parameter")
-      in_link, in_app = in_apps[config.input_type](config.input)
-   end
-   assert(out_apps[config.output_type],
-          "unknown output type: "..config.output_type)
-   local out_link, out_app = out_apps[config.output_type](config.output)
-
-   if config.output_type == "tap_routed" then
-      local tap_config = out_app[2]
-      tap_config.mtu = config.mtu
-      tap_config.overwrite_dst_mac = true
-      tap_config.forwarding = true
-   end
-
-   local ipfix_config = mk_ipfix_config(config)
-   local ipfix_name = "ipfix_"..config.instance
-   local out_name = "out_"..config.instance
+   local tap_config = {
+      name = device,
+      mtu = config.mtu,
+      overwrite_dst_mac = true,
+      forwarding = true
+   }
+   local tap_name = "out_"..config.instance
    local sink_name = "sink_"..config.instance
 
-   local graph = in_graph or app_graph.new()
-   if config.input then
-      local in_name = "in"
-      if config.input_type == "interlink" then
-         in_name = config.input
-      end
-      app_graph.app(graph, in_name, unpack(in_app))
-      app_graph.link(graph, in_name ..".".. in_link.output .. " -> "
-                        ..ipfix_name..".input")
-   end
-   app_graph.app(graph, ipfix_name, ipfix.IPFIX, ipfix_config)
-   app_graph.app(graph, out_name, unpack(out_app))
+   -- with UDP, ipfix doesn't need to handle packets from the collector
+   -- (hence, discard packets incoming from the tap interface to sink)
+   app_graph.app(graph, tap_name, tap.Tap, tap_config)
+   app_graph.app(graph, sink_name, basic.Sink)   
+   app_graph.link(graph, tap_name..".output -> "..sink_name..".input")
+   app_graph.app(graph, "tap_ifmib_"..config.instance, iftable.MIB, {
+      target_app = tap_name,
+      ifname = device,
+      ifalias = "IPFIX Observation Domain "..config.observation_domain,
+      log_date = config.log_date
+   })
 
-   -- use ARP for link-layer concerns unless the output is connected
-   -- to a pcap writer or a routed tap interface
-   if (config.output_type ~= "pcap" and
-       config.output_type ~= "tap_routed") then
-      local arp_name = "arp_"..config.instance
-      local arp_config    = { self_mac = config.exporter_mac and
-                                 ethernet:pton(config.exporter_mac),
-                              self_ip = ipv4:pton(config.exporter_ip),
-                              next_ip = ipv4:pton(config.collector_ip) }
-      app_graph.app(graph, arp_name, arp.ARP, arp_config)
-      app_graph.app(graph, sink_name, basic.Sink)
-
-      app_graph.link(graph, out_name.."."..out_link.output.." -> "
-                     ..arp_name..".south")
-
-      -- with UDP, ipfix doesn't need to handle packets from the collector
-      app_graph.link(graph, arp_name..".north -> "..sink_name..".input")
-
-      app_graph.link(graph, ipfix_name..".output -> "..arp_name..".north")
-      app_graph.link(graph, arp_name..".south -> "
-                        ..out_name.."."..out_link.input)
-   else
-      app_graph.link(graph, ipfix_name..".output -> "
-                        ..out_name.."."..out_link.input)
-      app_graph.app(graph, sink_name, basic.Sink)
-      app_graph.link(graph, out_name.."."..out_link.output.." -> "
-                     ..sink_name..".input")
-   end
-
-   if config.input_type and config.input_type == "pci" then
-      local pciaddr = unpack(parse_spec(config.input, '/'))
-      app_graph.app(graph, "nic_ifmib", iftable.MIB, {
-         target_app = "in", stats = 'stats',
-         ifname = normalize_pci_name(pciaddr),
-         log_date = config.log_date
-      })
-   end
-   if config.output_type == "tap_routed" then
-      app_graph.app(graph, "tap_ifmib_"..config.instance, iftable.MIB, {
-         target_app = out_name,
-         ifname = config.output,
-         ifalias = "IPFIX Observation Domain "..config.observation_domain,
-         log_date = config.log_date
-      })
-   end
-
-   return graph, config
+   return graph, {name=tap_name, input='input'}
 end
 
-function configure_rss_graph (config, inputs, outputs, log_date, rss_group, input_type)
-   input_type = input_type or 'pci'
-   local graph = app_graph.new()
+local function configure_interlink_input (config, in_graph)
+   config = lib.parse(config, {
+      name={required=true}
+   })
+   local graph = in_graph or app_graph.new()
 
-   local rss_name = "rss"..(rss_group or '')
-   app_graph.app(graph, rss_name, rss.rss, config)
+   local in_name = config.name
 
-   -- An input describes a physical interface
-   local tags, in_app_specs = {}, {}
-   for n, input in ipairs(inputs) do
-      local input_name, link_name, in_link, in_app
-      if input_type == 'pci' then
-         local pci_name = normalize_pci_name(input.device)
-         input_name, link_name = "input_"..pci_name, pci_name
-         in_link, in_app = in_apps.pci(input)
-         table.insert(in_app_specs,
-                      { pciaddr = input.device,
-                        name = input_name,
-                        ifname = input.name or pci_name,
-                        ifalias = input.description })
-      elseif input_type == 'pcap' then
-         input_name, link_name = 'pcap', 'pcap'
-         in_link, in_app = in_apps.pcap(input)
-      else
-         error("Unsupported input_type: "..input_type)
-      end
-      app_graph.app(graph, input_name, unpack(in_app))
-      if input.tag then
-         local tag = input.tag
-         assert(not(tags[tag]), "Tag not unique: "..tag)
-         link_name = "vlan"..tag
-      end
-      app_graph.link(graph, input_name.."."..in_link.output
-                        .." -> "..rss_name.."."..link_name)
+   app_graph.app(graph, in_name, Receiver)
+
+   return graph, {name=in_name, output='output'}
+end
+
+local function configure_interlink_output (config, in_graph)
+   config = lib.parse(config, {
+      name={required=true}
+   })
+   local graph = in_graph or app_graph.new()
+
+   local out_name = config.name
+
+   app_graph.app(graph, out_name, Transmitter)
+
+   return graph, {name=out_name, input='input'}
+end
+
+local function configure_pci_input (config, in_graph)
+   config = lib.parse(config, {
+      device={required=true},
+      rxq={required=true},
+      receive_queue_size={required=true},
+      log_date={required=true},
+      vlan_tag={},
+      name={},
+      description={}
+   })
+   local graph = in_graph or app_graph.new()
+
+   local pci_name = normalize_pci_name(config.device)
+   local in_name = "input_"..pci_name
+   local device_info = pci.device_info(config.device)
+   local driver = require(device_info.driver).driver
+   local conf
+   if device_info.driver == 'apps.intel_mp.intel_mp' then
+      conf = {
+         pciaddr = config.device,
+         rxq = config.rxq,
+         rxcounter = config.rxq,
+         ring_buffer_size = config.receive_queue_size
+      }
+   elseif device_info.driver == 'apps.mellanox.connectx' then
+      conf = {
+         pciaddress = config.device,
+         queue = config.rxq
+      }
    end
 
-   -- An output describes either an interlink or a complete ipfix app
+   app_graph.app(graph, in_name, driver, conf)
+   app_graph.app(graph, "nic_ifmib_"..in_name, iftable.MIB, {
+      target_app = in_name, stats = 'stats',
+      ifname = config.name or pci_name,
+      ifalias = config.description,
+      log_date = config.log_date
+   })
+
+   local nic = {name=in_name, input=device_info.rx, output=device_info.tx}
+   local link_name = nic.name
+   if conf.vlan_tag then
+      link_name = "vlan"..conf.vlan_tag
+   end
+
+   return graph, nic, link_name
+end
+
+local function configure_pcap_input (config, in_graph)
+   config = lib.parse(config, {
+      path={required=true},
+      name={default='pcap'}
+   })
+   local graph = in_graph or app_graph.new()
+
+   local in_name = config.name
+
+   app_graph.app(graph, in_name, pcap.PcapReader, config.path)
+
+   return graph, {name=in_name, output='output'}
+end
+
+local function link (graph, from, to)
+   assert(from.name, "missing name in 'from'")
+   assert(from.output, "missing output in 'from': "..from.name)
+   assert(to.name, "missing name in 'to'")
+   assert(to.input, "missing input in 'to': "..to.name)
+   app_graph.link(
+      graph, from.name.."."..from.output.."->"..to.name.."."..to.input
+   )
+end
+
+local function configure_ipfix_tap_instance (config, in_graph)
+   local graph = in_graph or app_graph.new()
+   local _, ipfix = configure_ipfix_instance(config, graph)
+   local tap_args = {
+      instance = config.instance,
+      observation_domain = config.observation_domain,
+      mtu = config.mtu,
+      log_date = config.log_date
+   }
+   local _, tap = configure_tap_output(tap_args, graph)
+   link(graph, ipfix, tap)
+   return graph, ipfix
+end
+
+function configure_interlink_ipfix_tap_instance (in_name, config)
+   local graph = app_graph.new()
+   local _, receiver = configure_interlink_input({name=in_name}, graph)
+   local _, ipfix = configure_ipfix_tap_instance(config, graph)
+   link(graph, receiver, ipfix)
+
+   return graph
+end
+
+function configure_pci_ipfix_tap_instance (config, inputs, rss_group)
+   local graph = app_graph.new()
+
+   local rss_name = "rss"..assert(rss_group)
+
+   local rss = {name=rss_name, output='output'}
+   app_graph.app(graph, rss_name, basic.Join)
+
+   local links = {}
+   for _, pci in ipairs(inputs) do
+      local _, nic, link_name = configure_pci_input(pci, graph)
+      links[link_name] = assert(not links[link_name],
+         "input link not unique: "..link_name)
+      link(graph, nic, {name=rss.name, input=link_name})
+   end
+   local _, ipfix = configure_ipfix_tap_instance(config, graph)
+   link(graph, rss, ipfix)
+
+   return graph
+end
+
+function configure_pcap_ipfix_tap_instance (config, pcap_path, rss_group)
+   local graph = app_graph.new()
+
+   local rss_name = "rss"..assert(rss_group)
+
+   local _, pcap = configure_pcap_input({name=rss_name, path=pcap_path}, graph)
+   local _, ipfix = configure_ipfix_tap_instance(config, graph)
+   link(graph, pcap, ipfix)
+
+   return graph
+end
+
+local function configure_rss_tap_instances (config, outputs, rss_group, in_graph)
+   local graph = in_graph or app_graph.new()
+
+   local rss_name = "rss"..assert(rss_group)
+   
+   app_graph.app(graph, rss_name, rss.rss, config)
+
    for _, output in ipairs(outputs) do
+      local rss = {name=rss_name, output=output.link_name}
       if output.type == 'interlink' then
          -- Keys
          --   link_name  name of the link
-         app_graph.app(graph, output.link_name, Transmitter)
-         app_graph.link(graph, rss_name.."."..output.link_name.." -> "
-                           ..output.link_name..".input")
+         local _, transmitter = configure_interlink_output(
+            {name=output.link_name}, graph
+         )
+         link(graph, rss, transmitter)
       else
          -- Keys
          --   link_name  name of the link
          --   args       probe configuration
          --   instance   # of embedded instance
          output.args.instance = output.instance or output.args.instance
-         local graph = configure_graph(output.args, graph)
-         app_graph.link(graph, rss_name.."."..output.link_name
-                           .." -> ipfix_"..output.args.instance..".input")
+         local _, ipfix = configure_ipfix_tap_instance(output.args, graph)
+         link(graph, rss, ipfix)
       end
    end
 
-   for _, spec in ipairs(in_app_specs) do
-      app_graph.app(graph, "nic_ifmib_"..spec.name, iftable.MIB, {
-         target_app = spec.name, stats = 'stats',
-         ifname = spec.ifname,
-         ifalias = spec.ifalias,
-         log_date = log_date
-      })
+   return graph, {name=rss_name}
+end
+
+function configure_pci_rss_tap_instances (config, inputs, outputs, rss_group)
+   local graph = app_graph.new()
+
+   local _, rss = configure_rss_tap_instances(config, outputs, rss_group, graph)
+   local links = {}
+   for _, pci in ipairs(inputs) do
+      local _, nic, link_name = configure_pci_input(pci, graph)
+      links[link_name] = assert(not links[link_name],
+         "input link not unique: "..link_name)
+      link(graph, nic, {name=rss.name, input=link_name})
    end
-   
+
    return graph
 end
 
-function configure_mlx_ctrl_graph (mellanox, log_date)
+function configure_pcap_rss_tap_instances(config, pcap_path, outputs, rss_group)
+   local graph = app_graph.new()
+
+   local _, rss = configure_rss_tap_instances(config, outputs, rss_group, graph)
+   local _, pcap = configure_pcap_input({path=pcap_path}, graph)
+   link(graph, pcap, {name=rss.name, input='pcap'})
+
+   return graph
+end
+
+function configure_mlx_controller (devices)
    -- Create a trivial app graph that only contains the control apps
    -- for the Mellanox driver, which sets up the queues and
    -- maintains interface counters.
    local ctrl_graph, need_ctrl = app_graph.new(), false
-   for device, spec in pairs(mellanox) do
+   for device, spec in pairs(devices) do
+      spec = lib.parse(spec, {
+         queues={required=true},
+         recvq_size={required=true},
+         log_date={required=true},
+         name={},
+         alias={}
+      })
       local conf = {
          pciaddress = device,
          queues = spec.queues,
@@ -318,9 +296,9 @@ function configure_mlx_ctrl_graph (mellanox, log_date)
                     require(driver).ConnectX, conf)
       app_graph.app(ctrl_graph, "nic_ifmib_"..pci_name, iftable.MIB, {
          target_app = "ctrl_"..pci_name, stats = 'stats',
-         ifname = spec.ifName or pci_name,
-         ifalias = spec.ifAlias,
-         log_date = log_date
+         ifname = spec.name or pci_name,
+         ifalias = spec.alias,
+         log_date = spec.log_date
       })
       need_ctrl = true
    end

--- a/src/program/ipfix/probe/probe.lua
+++ b/src/program/ipfix/probe/probe.lua
@@ -10,6 +10,7 @@ local pci = require("lib.hardware.pci")
 local lib = require("core.lib")
 local app_graph = require("core.config")
 
+local ipfix = require("apps.ipfix.ipfix")
 local probe = require("program.ipfix.lib")
 
 local probe_schema = 'snabb-snabbflow-v1'
@@ -97,17 +98,13 @@ function start (name, confpath)
    }
 end
 
-local ipfix_default_config = lib.deepcopy(probe.probe_config)
+local ipfix_default_config = lib.deepcopy(ipfix.IPFIX.config)
 for _, key in ipairs({
       "collector_ip",
       "collector_port",
       "observation_domain",
       "exporter_mac",
       "templates",
-      "output_type",
-      "output",
-      "input_type",
-      "input",
       "instance"
 }) do
    ipfix_default_config[key] = nil
@@ -205,15 +202,12 @@ function setup_workers (config)
    for rss_group = 1, rss.hardware_scaling.rss_groups do
       local inputs, outputs = {}, {}
       for device, opt in pairs(interfaces) do
-         if pcap_input then
-            table.insert(inputs, pcap_input)
-            break
-         end
 
          ensure_device_unique(device, interfaces)
          local input = lib.deepcopy(opt)
          input.device = device
          input.rxq = rss_group - 1
+         input.log_date = ipfix.log_date
          table.insert(inputs, input)
 
          -- The mellanox driver requires a master process that sets up
@@ -223,10 +217,11 @@ function setup_workers (config)
          if device_info.driver == 'apps.mellanox.connectx' then
             local spec = mellanox[device]
             if not spec then
-               spec = { ifName = input.name,
-                        ifAlias = input.description,
+               spec = { name = input.name,
+                        alias = input.description,
                         queues = {},
-                        recvq_size = input.receive_queue_size }
+                        recvq_size = input.receive_queue_size,
+                        log_date = ipfix.log_date }
                mellanox[device] = spec
             end
             table.insert(spec.queues, { id = input.rxq })
@@ -247,7 +242,6 @@ function setup_workers (config)
          config.collector_pool = exporter.collector_pool
          config.templates = exporter.template
 
-         config.output_type = "tap_routed"
          config.add_packet_metadata = false
 
          config.maps = {}
@@ -293,11 +287,13 @@ function setup_workers (config)
             iconfig.log_date = ipfix.log_date
             local od = next_observation_domain()
             iconfig.observation_domain = od
-            iconfig.output = "ipfixexport"..od
             if ipfix.maps.log_directory then
                iconfig.maps_logfile =
                   ipfix.maps.log_directory.."/"..od..".log"
             end
+
+            -- Subtract Ethernet and VLAN overhead from MTU
+            iconfig.mtu = iconfig.mtu - 14
 
             -- Scale the scan protection parameters by the number of
             -- ipfix instances in this RSS class
@@ -316,11 +312,10 @@ function setup_workers (config)
                }
             else
                output = { type = "interlink", link_name = rss_link }
-               iconfig.input_type = "interlink"
-               iconfig.input = rss_link
-               
-
-               workers[rss_link] = probe.configure_graph(iconfig)
+               workers[rss_link] =
+                  probe.configure_interlink_ipfix_tap_instance(
+                     rss_link, iconfig
+                  )
                -- Dedicated exporter processes are restartable
                worker_opts[rss_link] = {
                   restart_intensity = software_scaling.restart.intensity,
@@ -348,15 +343,41 @@ function setup_workers (config)
             continue = class.continue
          })
       end
-      workers["rss"..rss_group] = probe.configure_rss_graph(
-         rss_config, inputs, outputs, ipfix.log_date, rss_group, pcap_input and 'pcap'
-      )
+      if #outputs == 1 and outputs[1].type ~= 'interlink' then
+         -- We have a single output within a single process
+         -- (no flow director classes, and a single embedded exporer instance.)
+         -- This is the simple case: omit creating a software RSS app.
+         -- NB: IPFIX app has to extract metadata as software RSS app is not present.
+         local config = outputs[1].args
+         config.add_packet_metadata = true
+         if pcap_input then
+            workers["rss"..rss_group] = probe.configure_pcap_ipfix_tap_instance(
+               config, pcap_input, rss_group
+            )
+         else
+            workers["rss"..rss_group] = probe.configure_pci_ipfix_tap_instance(
+               config, inputs, rss_group
+            )
+         end
+      else
+         -- Otherwise we have the general case: configure a software RSS app to
+         -- distribute inputs over flow director classes and exporter instances.
+         if pcap_input then
+            workers["rss"..rss_group] = probe.configure_pcap_rss_tap_instances(
+               rss_config, pcap_input, outputs, rss_group
+            )
+         else
+            workers["rss"..rss_group] = probe.configure_pci_rss_tap_instances(
+               rss_config, inputs, outputs, rss_group
+            )
+         end
+      end
    end
 
    -- Create a trivial app graph that only contains the control apps
    -- for the Mellanox driver, which sets up the queues and
    -- maintains interface counters.
-   local ctrl_graph, need_ctrl = probe.configure_mlx_ctrl_graph(mellanox, ipfix.log_date)
+   local ctrl_graph, need_ctrl = probe.configure_mlx_controller(mellanox)
 
    if need_ctrl then
       workers["mlx_ctrl"] = ctrl_graph

--- a/src/program/ipfix/tests/test.lua
+++ b/src/program/ipfix/tests/test.lua
@@ -98,7 +98,7 @@ function selftest ()
       assert(diff <= tolerance, "Flows mismatch!")
    end
 
-   expect(ip4_flows, 30000, 0.1)
+   expect(ip4_flows, 30000, 0.2)
    expect(ip6_flows, 1400, 0.1)
    expect(http4_flows, 200, 0.2)
    expect(dns4_flows, 1300, 0.2)

--- a/src/program/ipfix/tests/test_v4_v6.conf
+++ b/src/program/ipfix/tests/test_v4_v6.conf
@@ -1,0 +1,31 @@
+snabbflow-config {
+    interface {
+        device "00:00.0";
+    }
+    flow-director {
+        default-class {
+            exporter ip;
+        }
+        remove-ipv6-extension-headers true;
+    }
+    ipfix {
+        idle-timeout 2;
+        active-timeout 2;
+        flush-timeout 2;
+        scan-time 0.1;
+        exporter-ip 10.0.0.1;
+        collector-pool { name c1; collector { ip 10.0.0.2; port 4739; } }
+        maps {
+            pfx4-to-as { file "program/ipfix/tests/maps/pfx4_to_as.csv"; }
+            pfx6-to-as { file "program/ipfix/tests/maps/pfx6_to_as.csv"; }
+            vlan-to-ifindex { file "program/ipfix/tests/maps/vlan_to_ifindex"; }
+            mac-to-as { file "program/ipfix/tests/maps/mac_to_as"; }
+        }
+        exporter {
+            name ip;
+            template "v4_extended";
+            template "v6_extended";
+            collector-pool c1;
+        }
+    }
+}


### PR DESCRIPTION
[ipfix probe: cleanup code, optimize operation without software rss](https://github.com/snabbco/snabb/commit/5923add8e3800d3730032b8463dbd3f5b9279119) 

This reorganizes the program.ipfix.lib module and optimizes the case
of a single embedded export instance and no flow director classes.

In this case, we do not create the software rss app and simply Join
the inputs to be then processed directly by the ipfix app.
NB: the ipfix app has to take care of extracting packet metadata.