### PR TITLE
apps.rss: remove 59 (no-next-header) from list of IPv6 extension headers

### DIFF
--- a/src/apps/rss/metadata.lua
+++ b/src/apps/rss/metadata.lua
@@ -117,11 +117,6 @@ local ipv6_ext_hdr_fns = {
          local payload_len = ext_hdr.length
          return payload_len * 4 - 2, next_header
       end,
-   [59] =
-      -- No next header
-      function(ptr)
-         return 0, 255
-      end,
    [60] =
       -- Destination
       ipv6_generic_ext_hdr,


### PR DESCRIPTION
The original code had the effect of setting the ULP to 255 in this case, which is wrong.  We simply need to treat 59 like any other ULP.