### PR TITLE
Snabbflow integration (timeline, group freelist and interlink sizes)

### DIFF
--- a/src/core/app.lua
+++ b/src/core/app.lua
@@ -46,6 +46,7 @@ function timeline ()
       timeline_log = timeline_mod.new("events.timeline")
       timeline_mod.rate(timeline_log, 9) -- initially log events with rate >= 9
       events = timeline_mod.load_events(timeline_log, "core.engine")
+      packet.initialize_events()
    end
    return timeline_log
 end
@@ -267,6 +268,8 @@ end
 
 -- Return the configuration actions needed to migrate from old config to new.
 function compute_config_actions (old, new)
+   timeline() -- Ensure timeline is created and initialized
+
    local actions = {}
 
    -- First determine the links that are going away and remove them.
@@ -333,6 +336,8 @@ end
 
 -- Update the active app network by applying the necessary actions.
 function apply_config_actions (actions)
+   timeline() -- Ensure timeline is created and initialized
+
    -- Table of functions that execute config actions
    local ops = {}
    -- As an efficiency hack, some apps rely on the fact that we add

--- a/src/core/packet.lua
+++ b/src/core/packet.lua
@@ -116,7 +116,9 @@ function initialize (max_packets)
       shm.unlink("engine/packets.freelist")
    end
    packets_fl = freelist_create("engine/packets.freelist", max_packets)
-   
+end
+
+function initialize_events ()
    if not events then
       events = timeline.load_events(engine.timeline(), "core.packet")
    end

--- a/src/lib/interlink.lua
+++ b/src/lib/interlink.lua
@@ -298,7 +298,7 @@ local function describe (r)
          [DOWN] = "deallocating"
       })[r.state[0]]
    end
-   return ("%d/%d (%s)"):format(queue_fill(r), size - 1, status(r))
+   return ("%d/%d (%s)"):format(queue_fill(r), r.size, status(r))
 end
 
 ffi.metatype("struct interlink", {__tostring=describe})

--- a/src/lib/ptree/worker.lua
+++ b/src/lib/ptree/worker.lua
@@ -15,7 +15,7 @@ local channel      = require("lib.ptree.channel")
 local action_codec = require("lib.ptree.action_codec")
 local ptree_alarms = require("lib.ptree.alarms")
 local timeline     = require("core.timeline")
-local events       = timeline.load_events(engine.timeline(), "core.engine")
+local events
 
 local Worker = {}
 
@@ -105,7 +105,9 @@ function Worker:main ()
 
    if not engine.auditlog_enabled then engine.enable_auditlog() end
 
-   engine.timeline()
+   if not events then 
+      events = timeline.load_events(engine.timeline(), "core.engine")
+   end
 
    engine.enable_tick()
 

--- a/src/lib/scheduling.lua
+++ b/src/lib/scheduling.lua
@@ -23,6 +23,7 @@ local scheduling_opts = {
    cpu = {},                  -- CPU index (integer).
    real_time = {},            -- Boolean.
    max_packets = {},          -- Positive integer.
+   group_freelist_size = {},
    ingress_drop_monitor = {}, -- Action string: one of 'flush' or 'warn'.
    profile = {default=true},  -- Boolean.
    busywait = {default=true}, -- Boolean.
@@ -59,6 +60,10 @@ end
 
 function sched_apply.max_packets (max_packets)
    packet.initialize(max_packets)
+end
+
+function sched_apply.group_freelist_size (nchunks)
+   packet.enable_group_freelist(nchunks)
 end
 
 function sched_apply.busywait (busywait)

--- a/src/lib/yang/snabb-snabbflow-v1.yang
+++ b/src/lib/yang/snabb-snabbflow-v1.yang
@@ -11,6 +11,11 @@ module snabb-snabbflow-v1 {
   description
    "Configuration for the Snabbflow IPFIX exporter.";
 
+  revision 2023-03-15 {
+    description
+      "Added interlink and group freelist configuration options.";
+  }
+
   revision 2022-04-27 {
     description
       "Initial draft.";
@@ -161,6 +166,22 @@ module snabb-snabbflow-v1 {
             }
           }
         }
+
+        leaf group-freelist-size {
+          type uint32 { range 1024|2048|4096|8192; }
+          default 2048;
+          description
+            "Number of chunks allocated for the group freelist.
+            Each chunk holds up to 2048 packets. Must be a power of two.";
+        }
+
+        leaf interlink-size {
+          type uint32 { range 1024|2048|4096|8192|16384|32768|65536|131072|262144; }
+          default 65536;
+          description
+            "Capacity of inter-process packet queues in number of packets.
+            Must be a power of two.";
+        }       
       }
     }
 

--- a/src/program/ipfix/lib.lua
+++ b/src/program/ipfix/lib.lua
@@ -65,26 +65,28 @@ end
 
 local function configure_interlink_input (config, in_graph)
    config = lib.parse(config, {
-      name={required=true}
+      name={required=true},
+      size={required=true}
    })
    local graph = in_graph or app_graph.new()
 
    local in_name = config.name
 
-   app_graph.app(graph, in_name, Receiver)
+   app_graph.app(graph, in_name, Receiver, { size = config.size })
 
    return graph, {name=in_name, output='output'}
 end
 
 local function configure_interlink_output (config, in_graph)
    config = lib.parse(config, {
-      name={required=true}
+      name={required=true},
+      size={required=true}
    })
    local graph = in_graph or app_graph.new()
 
    local out_name = config.name
 
-   app_graph.app(graph, out_name, Transmitter)
+   app_graph.app(graph, out_name, Transmitter, { size = config.size })
 
    return graph, {name=out_name, input='input'}
 end
@@ -175,9 +177,9 @@ local function configure_ipfix_tap_instance (config, in_graph)
    return graph, ipfix
 end
 
-function configure_interlink_ipfix_tap_instance (in_name, config)
+function configure_interlink_ipfix_tap_instance (in_name, link_size, config)
    local graph = app_graph.new()
-   local _, receiver = configure_interlink_input({name=in_name}, graph)
+   local _, receiver = configure_interlink_input({name=in_name, size=link_size}, graph)
    local _, ipfix = configure_ipfix_tap_instance(config, graph)
    link(graph, receiver, ipfix)
 
@@ -230,7 +232,7 @@ local function configure_rss_tap_instances (config, outputs, rss_group, in_graph
          -- Keys
          --   link_name  name of the link
          local _, transmitter = configure_interlink_output(
-            {name=output.link_name}, graph
+            {name=output.link_name, size=output.link_size}, graph
          )
          link(graph, rss, transmitter)
       else

--- a/src/program/ipfix/probe/probe.lua
+++ b/src/program/ipfix/probe/probe.lua
@@ -23,9 +23,10 @@ local long_opts = {
    busywait ="b",
    ["real-time"] = "r",
    ["no-profile"] = "p",
+   ["timeline"] = "t",
    ["test-pcap"] = "T"
 }
-local opt = "hn:brpT:"
+local opt = "hn:brptT:"
 local opt_handler = {}
 local name
 local busywait, real_time, profile = false, false, true
@@ -34,6 +35,8 @@ function opt_handler.n (arg) name = arg end
 function opt_handler.b () busywait = true end
 function opt_handler.r () real_time = true end
 function opt_handler.p () profile = false end
+local timeline = false
+function opt_handler.t () timeline = true end
 local pcap_input
 function opt_handler.T (arg) pcap_input = arg end
 
@@ -86,6 +89,7 @@ function start (name, confpath)
          busywait = busywait,
          real_time = real_time,
          profile = profile,
+         timeline = timeline,
          jit_opt = {
             sizemcode=256,
             maxmcode=8192,

--- a/src/program/ipfix/probe/probe.lua
+++ b/src/program/ipfix/probe/probe.lua
@@ -70,6 +70,17 @@ local function update_cpuset (cpu_pool)
    end
 end
 
+local probe_group_freelist_size
+
+local function update_group_freelist_size (nchunks)
+   if not probe_group_freelist_size then
+      probe_group_freelist_size = nchunks
+   elseif probe_group_freelist_size ~= nchunks then
+      error("Can not change group-freelist-size after probe has started.")
+   end
+   return probe_group_freelist_size
+end
+
 local function warn (msg, ...)
    io.stderr:write("Warning: "..msg:format(...).."\n")
    io.stderr:flush()
@@ -90,6 +101,9 @@ function start (name, confpath)
          real_time = real_time,
          profile = profile,
          timeline = timeline,
+         group_freelist_size = update_group_freelist_size(
+            conf.snabbflow_config.rss.software_scaling.group_freelist_size
+         ),
          jit_opt = {
             sizemcode=256,
             maxmcode=8192,
@@ -125,6 +139,8 @@ function setup_workers (config)
    local rss = config.snabbflow_config.rss
    local flow_director = config.snabbflow_config.flow_director
    local ipfix = config.snabbflow_config.ipfix
+
+   update_group_freelist_size(rss.software_scaling.group_freelist_size)
 
    local collector_pools = {}
    for name, p in pairs(ipfix.collector_pool) do
@@ -302,10 +318,14 @@ function setup_workers (config)
                   args = iconfig
                }
             else
-               output = { type = "interlink", link_name = rss_link }
+               output = {
+                  type = "interlink",
+                  link_name = rss_link,
+                  link_size = rss.software_scaling.interlink_size
+               }
                workers[rss_link] =
                   probe.configure_interlink_ipfix_tap_instance(
-                     rss_link, iconfig
+                     rss_link, output.link_size, iconfig
                   )
                -- Dedicated exporter processes are restartable
                worker_opts[rss_link] = {


### PR DESCRIPTION
- can run `snabb ipfix probe -t/--timeline` to enable timeline event logging

- can configure group freelist and interlink sizes via schema, defaults are:

```
snabbflow-config {
  rss {
    software-scaling {
      group-freelist-size 2048;
      interlink-size 65536;
    }
  }
}
```