### PR TITLE
apps.ipfix.maps: re-create map ctable if source file has changed

### DIFF
--- a/src/apps/ipfix/maps.lua
+++ b/src/apps/ipfix/maps.lua
@@ -18,7 +18,7 @@ local S        = require("syscall")
 local mac_to_as_key_t = ffi.typeof("uint8_t[6]")
 local mac_to_as_value_t = ffi.typeof("uint32_t")
 
-local function make_mac_to_as_map(name)
+local function make_mac_to_as_map(name, template_logger)
    local table = ctable.new({ key_type = mac_to_as_key_t,
                               value_type = mac_to_as_value_t,
                               initial_size = 15000,
@@ -27,16 +27,19 @@ local function make_mac_to_as_map(name)
    local value = mac_to_as_value_t()
    for line in assert(io.lines(name)) do
       local as, mac = line:match("^%s*(%d*)-([0-9a-fA-F:]*)")
-      assert(as and mac, "MAC-to-AS map: invalid line: "..line)
-      local key, value = ethernet:pton(mac), tonumber(as)
-      local result = table:lookup_ptr(key)
-      if result then
-         if result.value ~= value then
-            print("MAC-to-AS map: amibguous mapping: "
-                     ..ethernet:ntop(key)..": "..result.value..", "..value)
-         end
+      if not (as and mac) then
+	 template_logger:log("MAC-to-AS map: invalid line: "..line)
+      else
+	 local key, value = ethernet:pton(mac), tonumber(as)
+	 local result = table:lookup_ptr(key)
+	 if result then
+	    if result.value ~= value then
+	       template_logger:log("MAC-to-AS map: amibguous mapping: "
+				   ..ethernet:ntop(key)..": "..result.value..", "..value)
+	    end
+	 end
+	 table:add(key, value, true)
       end
-      table:add(key, value, true)
    end
    return table
 end
@@ -53,16 +56,18 @@ end
 -- elements is relevant, depending on the direction of the flow. File
 -- format:
 --   <TAG>-<ingress>-<egress>
-local function make_vlan_to_ifindex_map(name)
+local function make_vlan_to_ifindex_map(name, template_logger)
    local table = {}
    for line in assert(io.lines(name)) do
       local vlan, ingress, egress = line:match("^(%d+)-(%d+)-(%d+)$")
-      assert(vlan and ingress and egress,
-             "VLAN-to-IFIndex map: invalid line: "..line)
-      table[tonumber(vlan)] = {
-         ingress = tonumber(ingress),
-         egress = tonumber(egress)
-      }
+      if not (vlan and ingress and egress) then
+	 template_logger:log("VLAN-to-IFIndex map: invalid line: "..line)
+      else
+	 table[tonumber(vlan)] = {
+	    ingress = tonumber(ingress),
+	    egress = tonumber(egress)
+	 }
+      end
    end
    return table
 end
@@ -75,17 +80,20 @@ end
 -- authoritative data from the RIRs. This parser supports the format
 -- used by the Geo2Lite database provided by MaxMind:
 -- http://geolite.maxmind.com/download/geoip/database/GeoLite2-ASN-CSV.zip
-local function make_pfx_to_as_map(name, proto)
+local function make_pfx_to_as_map(name, proto, template_logger)
    local table = { pt = poptrie.new{direct_pointing=true,
                                     leaf_t=ffi.typeof("uint32_t")} }
+   local max_plen
    if proto == ipv4 then
       function table:search_bytes (a)
          return self.pt:lookup32(a)
       end
+      max_plen = 32
    elseif proto == ipv6 then
       function table:search_bytes (a)
          return self.pt:lookup128(a)
       end
+      max_plen = 128
    else
       error("Proto must be ipv4 or ipv6")
    end
@@ -93,10 +101,19 @@ local function make_pfx_to_as_map(name, proto)
       if not line:match("^network") then
          local cidr, asn = line:match("([^,]*),(%d+),")
          asn = tonumber(asn)
-         assert(cidr and asn, "Prefix-to-AS map: invalid line: "..line)
-         assert(asn > 0 and asn < 2^32, "Prefix-to-AS map: asn out of range: "..asn)
-         local pfx, len = proto:pton_cidr(cidr)
-         table.pt:add(pfx, len, asn)
+         if not (cidr and asn) then
+	    print(cidr, asn)
+	    template_logger:log("Prefix-to-AS map: invalid line: "..line)
+	 elseif not (asn > 0 and asn < 2^32) then
+	    template_logger:log("Prefix-to-AS map: asn out of range: "..line)
+	 else
+	    local pfx, len = proto:pton_cidr(cidr)
+	    if pfx and len <= max_plen then
+	       table.pt:add(pfx, len, asn)
+	    else
+	       template_logger:log("Prefix-to-AS map: invalid address: "..line)
+	    end
+	 end
       end
    end
    table.pt:build()
@@ -113,27 +130,34 @@ local map_info = {
       logger_module = 'VLAN to ifIndex mapper'
    },
    pfx4_to_as = {
-      create_fn = function (name) return make_pfx_to_as_map(name, ipv4) end,
+      create_fn = function (name, tmpl_logger)
+	 return make_pfx_to_as_map(name, ipv4, tmpl_logger)
+      end,
       logger_module = 'IPv4 prefix to AS mapper'
    },
    pfx6_to_as = {
-      create_fn = function (name) return make_pfx_to_as_map(name, ipv6) end,
+      create_fn = function (name, tmpl_logger)
+	 return make_pfx_to_as_map(name, ipv6, tmpl_logger)
+      end,
       logger_module = 'IPv6 prefix to AS mapper'
    }
 }
 
 local maps = {}
 
-function mk_map(name, file, log_rate, log_fh)
+function mk_map(name, file, log_rate, log_fh, template_logger)
    local info = assert(map_info[name])
    local stat = assert(S.stat(file))
    local map_cache = maps[name]
    if not map_cache or map_cache.ctime ~= stat.ctime then
       map_cache = {
-	 map = info.create_fn(file),
+	 map = info.create_fn(file, template_logger),
 	 ctime = stat.ctime
       }
       maps[name] = map_cache
+      template_logger:log("Created "..name.." map from "..file)
+   else
+      template_logger:log("Using cache for map "..name)
    end
    local map = { map = map_cache.map }
    if log_fh then


### PR DESCRIPTION
If mk_map() is called via ipfix:reconfig() because the name of a map file has changed, the map ctable will still not be re-created due to its presence in the cache used by mk_map(). This commit uses the ctime of the file to detect whether the ctable needs to be re-created.

ipfix:reconfig() is also enhanced to only re-create the mapping tables if the rest of a template's configuration is unchanged.