### PR TITLE
ipfix: add acquire-cpu option to YANG schema

### DIFF
--- a/src/lib/yang/snabb-snabbflow-v1.yang
+++ b/src/lib/yang/snabb-snabbflow-v1.yang
@@ -132,6 +132,15 @@ module snabb-snabbflow-v1 {
               executed in one or more instances, each in its own dedicated
               worker process (using a dedicated CPU core).";
           }
+
+          leaf acquire-cpu {
+            type boolean;
+            default true;
+            description
+              "When 'embed' is false, select whether the worker process should
+               be pinned to a CPU or not. Has no effect when 'embed' is set
+               to true.";
+          }
           
           leaf instances {
             type uint32 { range 1..max; }

--- a/src/program/ipfix/probe/probe.lua
+++ b/src/program/ipfix/probe/probe.lua
@@ -326,7 +326,8 @@ function setup_workers (config)
                -- Dedicated exporter processes are restartable
                worker_opts[rss_link] = {
                   restart_intensity = software_scaling.restart.intensity,
-                  restart_period = software_scaling.restart.period
+                  restart_period = software_scaling.restart.period,
+                  acquire_cpu = software_scaling.acquire_cpu
                }
             end
             table.insert(outputs, output)


### PR DESCRIPTION
By defaut, exporter worker processes are pinned to a CPU from the configured cpu-pool.  The new option allows this to be disabled on a per-exporter basis. It is intended to avoid depletion of the cpu-pool when many non-critical exporter processes are present.