### PR TITLE
Timed pace breathing

### DIFF
--- a/src/core/app.lua
+++ b/src/core/app.lua
@@ -623,7 +623,7 @@ function pace_breathing ()
       nextbreath = nextbreath or monotonic_now
       local sleep = tonumber(nextbreath - monotonic_now)
       if sleep > 1e-6 then
-         events.sleep_Hz(Hz, math.round(sleep*1e6))
+         events.sleep_Hz(Hz, math.floor(sleep*1e6))
          C.usleep(sleep * 1e6)
          monotonic_now = C.get_monotonic_time()
          events.wakeup_from_sleep()

--- a/src/lib/ptree/ptree.lua
+++ b/src/lib/ptree/ptree.lua
@@ -63,6 +63,7 @@ local manager_config_spec = {
 }
 
 local worker_opt_spec = {
+   scheduling = {},
    acquire_cpu = {default=true}, -- Needs dedicated CPU core?
    restart_intensity = {default=0}, -- How many restarts are permitted...
    restart_period = {default=0} -- ...within period seconds.
@@ -304,6 +305,7 @@ function Manager:compute_workers_aux (worker_app_graphs, worker_opts)
    for id in pairs(worker_app_graphs) do
       local worker_opt = lib.parse(worker_opts[id] or {}, worker_opt_spec)
       local worker_aux = {
+         scheduling = worker_opt.scheduling,
          acquire_cpu = worker_opt.acquire_cpu,
          restart = {
             period = worker_opt.restart_period,
@@ -375,6 +377,9 @@ end
 function Manager:compute_scheduling_for_worker(id, app_graph)
    local ret = {}
    for k, v in pairs(self.worker_default_scheduling) do ret[k] = v end
+   if self.workers_aux[id].scheduling then
+      for k, v in pairs(self.workers_aux[id].scheduling) do ret[k] = v end
+   end
    if self.workers_aux[id].acquire_cpu then
       ret.cpu = self:acquire_cpu_for_worker(id, app_graph)
    end

--- a/src/lib/scheduling.lua
+++ b/src/lib/scheduling.lua
@@ -27,6 +27,7 @@ local scheduling_opts = {
    ingress_drop_monitor = {}, -- Action string: one of 'flush' or 'warn'.
    profile = {default=true},  -- Boolean.
    busywait = {default=true}, -- Boolean.
+   Hz = {},                   -- Positive integer. Enable Hz breathing when set.
    timeline = {},             -- Boolean. Enable timeline logging?
    enable_xdp = {},           -- Enable Snabb XDP mode (see apps.xdp.xdp).
    eval = {}                  -- String.
@@ -68,6 +69,10 @@ end
 
 function sched_apply.busywait (busywait)
    engine.busywait = busywait
+end
+
+function sched_apply.Hz (Hz)
+   engine.Hz = Hz
 end
 
 function sched_apply.timeline (enabled)


### PR DESCRIPTION
Depends on: #1509 

Measure time between *now* and last time a packet was freed during a breath, only sleep in `pace_breathing` when we have been idle for at least 1us.

This is intended to make us more conservative with sleeping when handling bursty real-world traffic. 