### PR TITLE
apps.mellanox.connectx: alloc_pages(): remove assertion

### DIFF
--- a/src/apps/mellanox/connectx.lua
+++ b/src/apps/mellanox/connectx.lua
@@ -848,7 +848,11 @@ end
 
 -- Provide the NIC with freshly allocated memory.
 function HCA:alloc_pages (num_pages)
-   assert(num_pages > 0)
+   -- Assume that num_pages is the result of a call to query_pages(),
+   -- i.e. 0 is a legal value and a negative value indicates that
+   -- pages can be reclaimed. The reclaim is done via notifications on
+   -- the event queue.
+   if num_pages <= 0 then return end
    if debug_info then
       print(("Allocating %d pages to HW"):format(num_pages))
    end


### PR DESCRIPTION
Ignore 0 and negative values in alloc_pages(). This assumes that the function is called with the result of query_pages() for which these values are legal (a negative value indicates that pages can be recalimed by the driver).  In some versions of the firmware on ConnectX7, query_pages() for "regular" pages during initialization returns a negative value that would trigger the assertion.

Allocation of "regular" pages is not part of the card initialization according to the PRM, i.e. this particular problem could also be avoided by removing that call. However, this commit seems more robust.

Note that page reclaims are already handled by the event queue through reclaim notifications.