### PR TITLE
engine/ptree.worker: stop gc in engine, trigger gc steps proactively

### DIFF
--- a/src/apps/mellanox/connectx.lua
+++ b/src/apps/mellanox/connectx.lua
@@ -848,7 +848,11 @@ end
 
 -- Provide the NIC with freshly allocated memory.
 function HCA:alloc_pages (num_pages)
-   assert(num_pages > 0)
+   -- Assume that num_pages is the result of a call to query_pages(),
+   -- i.e. 0 is a legal value and a negative value indicates that
+   -- pages can be reclaimed. The reclaim is done via notifications on
+   -- the event queue.
+   if num_pages <= 0 then return end
    if debug_info then
       print(("Allocating %d pages to HW"):format(num_pages))
    end

--- a/src/core/app.lua
+++ b/src/core/app.lua
@@ -182,6 +182,7 @@ function configure (new_config)
    local actions = compute_config_actions(configuration, new_config)
    apply_config_actions(actions)
    counter.add(configs)
+   collectgarbage('collect')
 end
 
 
@@ -598,12 +599,17 @@ function main (options)
 
    events.engine_started()
 
+   collectgarbage('stop')
+
    repeat
       breathe()
       if not no_timers then timer.run() events.polled_timers() end
       if not busywait then pace_breathing() end
       randomize_log_rate() -- roll random log rate
    until done and done()
+
+   collectgarbage('restart')
+
    counter.commit()
    if not options.no_report then report(options.report) end
    events.engine_stopped()
@@ -707,6 +713,8 @@ function breathe ()
    if counter.read(breaths) % 100 == 0 then
       counter.commit()
       events.commited_counters()
+      collectgarbage('step', 1)
+      events.gc_step()
    end
    running = false
 end

--- a/src/core/engine.events
+++ b/src/core/engine.events
@@ -41,6 +41,9 @@ can be used to track the rate of traffic.
 The engine commits the latest counter values to externally visible shared
 memory.
 
+1,5|gc_step:
+The engine performs a garbage collection step.
+
 1,4|polled_timers:
 The engine polled its timers and executed any that were expired.
 

--- a/src/core/gc.lua
+++ b/src/core/gc.lua
@@ -1,0 +1,41 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
+module(...,package.seeall)
+
+local S = require("syscall")
+
+local pause
+local steps = 0
+local target = 1000
+local stepsize = 1
+
+function stop ()
+   collectgarbage('stop')
+   pause = collectgarbage('setpause', 100)
+end
+
+function restart ()
+   collectgarbage('setpause', pause)
+   collectgarbage('restart')
+end
+
+function step ()
+   steps = steps + 1
+   if collectgarbage('step', steps) then
+      --print(steps, target, stepsize)
+      if steps > target then
+         stepsize = stepsize * 2
+         print(("GC for pid %d: increased step size to %d")
+            :format(S.getpid(), stepsize))
+      elseif stepsize > 1 and steps < target/2 then
+         stepsize = stepsize / 2
+         print(("GC for pid %d: decreased step size to %d")
+            :format(S.getpid(), stepsize))
+      end
+      steps = 0
+   end
+end
+
+function collect ()
+   collectgarbage('collect')
+end

--- a/src/lib/ptree/worker.lua
+++ b/src/lib/ptree/worker.lua
@@ -82,6 +82,7 @@ function Worker:commit_pending_actions()
    if #to_apply > 0 then engine.apply_config_actions(to_apply) end
    self.pending_actions = {}
    if should_flush then require('jit').flush() end
+   collectgarbage('collect')
 end
 
 function Worker:handle_actions_from_manager()
@@ -110,6 +111,9 @@ function Worker:main ()
    engine.enable_tick()
 
    engine.setvmprofile("engine")
+
+   collectgarbage('stop')
+
    repeat
       self.breathe()
       if next_time < engine.now() then
@@ -123,6 +127,9 @@ function Worker:main ()
       if not engine.busywait then engine.pace_breathing() end
       engine.randomize_log_rate()
    until stop < engine.now()
+
+   collectgarbage('restart')
+
    counter.commit()
    if not self.no_report then engine.report(self.report) end
 end

--- a/src/lib/ptree/worker.lua
+++ b/src/lib/ptree/worker.lua
@@ -15,6 +15,7 @@ local channel      = require("lib.ptree.channel")
 local action_codec = require("lib.ptree.action_codec")
 local ptree_alarms = require("lib.ptree.alarms")
 local timeline     = require("core.timeline")
+local gc           = require("core.gc")
 local events       = timeline.load_events(engine.timeline(), "core.engine")
 
 local Worker = {}
@@ -82,7 +83,7 @@ function Worker:commit_pending_actions()
    if #to_apply > 0 then engine.apply_config_actions(to_apply) end
    self.pending_actions = {}
    if should_flush then require('jit').flush() end
-   collectgarbage('collect')
+   gc.collect()
 end
 
 function Worker:handle_actions_from_manager()
@@ -112,7 +113,7 @@ function Worker:main ()
 
    engine.setvmprofile("engine")
 
-   collectgarbage('stop')
+   gc.stop()
 
    repeat
       self.breathe()
@@ -128,7 +129,7 @@ function Worker:main ()
       engine.randomize_log_rate()
    until stop < engine.now()
 
-   collectgarbage('restart')
+   gc.restart()
 
    counter.commit()
    if not self.no_report then engine.report(self.report) end


### PR DESCRIPTION
This PR changes how we use the GC in order to more tightly control GC pauses:

- perform a full GC cycle after engine (re)configurations
- stop GC during engine breathe loop
- perform a single GC step every 100 breaths
- add a timeline event that measures the latency of GC steps

Before:

![memory_gc_heap_bytes](https://github.com/snabbco/snabb/assets/4933566/1091c42a-ae8b-4f04-9d5a-b2321e7190a0)
(This will devolve into a sawtooth pattern)
![rxdrop](https://github.com/snabbco/snabb/assets/4933566/dfbd1108-ac76-436d-8129-4f030f9faa86)

After:

![memory_gc_heap_bytes](https://github.com/snabbco/snabb/assets/4933566/640d8d88-ec9d-48b8-82da-8c6043cd0334)
(This will end up looking flat)
![rxdrop](https://github.com/snabbco/snabb/assets/4933566/0a1bf662-021f-45ee-92d2-18c57d6c29ab)



Backstory:

We never had any problems with the GC, but recently when testing lwaftr I noticed some instances of packet drops within the first hour of runtime, and correlated them to some larger deltas in heap size. Hypothesis being that as long as the GC works in small steps (as is typical in steady state workloads) all is fine but when a step does too much GC work the pause becomes excessive and leads to drops.

Since these drops/pauses/deltas occurred only relatively shortly after startup I am assuming that the cause is the garbage produced by configuration combined with the GCs inability to split up its work into smaller steps.

I've tried messing around with various GC configuration knobs (`LUAI_GCPAUSE`, `LUAI_GCMUL`, `GCSWEEPCOST`, `GCSWEEPMAX`, `GCSTEPSIZE`) but have not managed to improve things this way.

I've also tried to do a "manual" full GC cycle after engine configuration, and while that does move a lot of "one-time" GC work out of the engine loop it didn't resolve the packet drops.

As for regressions, I've ruled out any changes from the last release (I get the same behaviors with Snabb Davion from earlier this year). So its not due to the luajit changes we recently pulled. Another untested idea is that #1490 changed our GC usage patterns enough to surface these drops.