### PR TITLE
lib.ipc.shmem.iftable_mib: add ifIndex to the shmem segment

### DIFF
--- a/src/lib/ipc/shmem/iftable_mib.lua
+++ b/src/lib/ipc/shmem/iftable_mib.lua
@@ -33,6 +33,11 @@ function init_snmp (objs, name, counters, directory, interval, log_date)
    local logger = logger.new({ date = log_date,
                                module = 'iftable_mib' })
    -- ifTable
+   --
+   -- Include a dummy ifIndex to signal to the SNMP agent that it
+   -- needs to instantiate this OID in the table. The value will be
+   -- discarded and replaced by the actual ifIndex by the agent.
+   ifTable:register('ifIndex', 'Integer32')
    ifTable:register('ifDescr', 'OctetStr', objs.ifDescr)
    ifTable:register('ifType', 'Integer32')
    ifTable:set('ifType',


### PR DESCRIPTION
The SNMP agent only generates objects that are included explicitly in the shmem segment. Even though the ifIndex value is created by the agent itself, the OID is not instantiated without ifIndex being present in the shmem segment.

Background: SMIv2 (RFC2578) specifies

   Objects which are both specified in the INDEX clause of a
   conceptual row and also columnar objects of the same conceptual row
   are termed auxiliary objects. The MAX-ACCESS clause for auxiliary
   objects is "not-accessible"

The current implementation assumed that ifIndex was of this type and need not be instantiated by the SNMP agent. However, the ifTable MIB predates this specification and declares MAX-ACCESS as "read-only". Therefore, even though it is rare, an SNMP manager can expect that this object exists.