### PR TITLE
lib.yang.schema: fix refinement of grouping instances

### DIFF
--- a/src/lib/yang/schema.lua
+++ b/src/lib/yang/schema.lua
@@ -968,7 +968,8 @@ function resolve(schema, features)
                local grouping = lookup_lazy(env, 'groupings', v.id)
                for k,v in pairs(grouping.body) do
                   assert(not node.body[k], 'duplicate identifier: '..k)
-                  node.body[k] = v
+                  -- Inline a copy for local refinements
+                  node.body[k] = lib.deepcopy(v)
                end
                for _,refine in ipairs(v.refines) do
                   local target = node.body[refine.node_id]


### PR DESCRIPTION
When a grouping is applied with the "uses" statement, create copies of the grouped elements rather than references to them. This fixes the bug that a "refine" would otherwise modify the grouping itself rather than the instance at the place of insertion.