### PR TITLE
apps.rss.metadata: add timestamp

### DIFF
--- a/src/apps/rss/metadata.lua
+++ b/src/apps/rss/metadata.lua
@@ -192,6 +192,8 @@ local magic_number = 0x5ABB
 pkt_meta_data_t = ffi.typeof([[
    struct {
       uint16_t magic;
+      /* Unix timestamp in nanoseconds */
+      uint64_t timestamp;
       /* Actual ethertype for single-tagged frames */
       uint16_t ethertype;
       /* vlan == 0 if untagged frame */
@@ -272,6 +274,7 @@ function add (pkt, rm_ext_headers, vlan_override)
 
    local md = md_ptr(pkt)
    md.magic = magic_number
+   md.timestamp = ffi.C.get_unix_time_ns()
    md.ref = 0
    md.ethertype = ethertype
    md.vlan = vlan_override or vlan

--- a/src/core/lib.c
+++ b/src/core/lib.c
@@ -6,12 +6,20 @@
 #include <sys/time.h>
 #include <unistd.h>
 
-/* Return the current wall-clock time in nanoseconds. */
+/* Return the monotonic time in nanoseconds. */
 uint64_t get_time_ns()
 {
     /* XXX Consider using RDTSC. */
     struct timespec ts;
     clock_gettime(CLOCK_MONOTONIC, &ts);
+    return ts.tv_sec * 1000000000LL + ts.tv_nsec;
+}
+
+/* Return the current wall-clock time in nanoseconds. */
+uint64_t get_unix_time_ns()
+{
+    struct timespec ts;
+    clock_gettime(CLOCK_REALTIME, &ts);
     return ts.tv_sec * 1000000000LL + ts.tv_nsec;
 }
 

--- a/src/core/lib.h
+++ b/src/core/lib.h
@@ -3,6 +3,7 @@
 uint64_t get_time_ns();
 double get_monotonic_time();
 double get_unix_time();
+uint64_t get_unix_time_ns();
 void sleep_ns(int nanoseconds);
 void full_memory_barrier();
 void prefetch_for_read(const void *address);


### PR DESCRIPTION
Add 64-bit Unix wall-clock timestamp in nanoseconds to the packet metadata. This adds a new function get_unix_time_ns() to core/lib.c and fixes the comment for get_time_ns() to refer to monotonic time rather than wall-clock time.